### PR TITLE
hashtable-linear: changed hashtable implementation from cuckoo to

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -178,7 +178,7 @@ import qualified Data.Binary.IEEE754 as IEEE754
 import qualified Data.Bits as Bits
 import           Data.Foldable
 import qualified Data.HashTable.Class as H (toList)
-import qualified Data.HashTable.ST.Cuckoo as H
+import qualified Data.HashTable.ST.Linear as H
 import           Data.Hashable
 import           Data.IORef
 import           Data.Kind

--- a/what4/src/What4/Expr/VarIdentification.hs
+++ b/what4/src/What4/Expr/VarIdentification.hs
@@ -46,7 +46,7 @@ import           Control.Monad.Reader
 import           Control.Monad.ST
 import           Control.Monad.State
 import           Data.Bits
-import qualified Data.HashTable.ST.Cuckoo as H
+import qualified Data.HashTable.ST.Linear as H
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Map.Strict as Map
 import           Data.Parameterized.Nonce


### PR DESCRIPTION
linear due to bugs and lack of support for the former

Same as change for parameterized-utils