### PR TITLE
Bitvector abstract domain enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,6 @@ matrix:
   allow_failures:
   - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG= DO_LINT=True
 
-cache:
-  directories:
-  - $HOME/.cabsnap
-  - $HOME/.cabal/packages
-  - $HOME/.cabal/store
-  - $HOME/.ghc
-  - $TRAVIS_BUILD_DIR/dist-newstyle
 before_install:
 - unset CC
 - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH

--- a/what4/doc/arithdomain.cry
+++ b/what4/doc/arithdomain.cry
@@ -361,6 +361,13 @@ correct_overlap : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
 correct_overlap a b x =
   mem a x ==> mem b x ==> overlap a b
 
+correct_overlap_inv : {n} (fin n) => Dom n -> Dom n -> Bit
+correct_overlap_inv a b =
+  overlap a b ==> (mem a witness /\ mem b witness)
+
+ where
+ witness = if mem a b.lo then b.lo else a.lo
+
 correct_union : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
 correct_union a b x =
   (mem a x \/ mem b x) ==> mem (union a b) x
@@ -470,6 +477,7 @@ property p2 = correct_ubounds`{16}
 property p3 = correct_sbounds`{16}
 property p4 = correct_singleton`{16}
 property p5 = correct_overlap`{16}
+property p5_inv = correct_overlap_inv`{16}
 property p6 = correct_union`{8}
 property p7 = correct_zero_ext`{32, 16}
 property p8 = correct_sign_ext`{32, 16}

--- a/what4/doc/arithdomain.cry
+++ b/what4/doc/arithdomain.cry
@@ -78,14 +78,15 @@ sbounds a = (lo - delta, hi - delta)
     delta = reverse 1
     (lo, hi) = ubounds (interval (a.lo + delta) a.sz)
 
-/** Least and greatest nonzero values in a domain, according to the
-unsigned ordering. */
+/** Nonzero signed values in a domain with the least and greatest
+reciprocals. Note that this coincides with the greatest and least
+nonzero values using the unsigned ordering. */
 rbounds : {n} (fin n, n >= 1) => Dom n -> ([n], [n])
 rbounds a =
-  if a.lo == 0 then (1, a_hi) else
-  if a_hi == 0 then (a.lo, ~0) else
-  if a_hi < a.lo then (1, ~0) else
-  (a.lo, a_hi)
+  if a.lo == 0 then (a_hi, 1) else
+  if a_hi == 0 then (-1, a.lo) else
+  if a_hi < a.lo then (-1, 1) else
+  (a_hi, a.lo)
   where a_hi = a.lo + a.sz
 
 overlap : {n} (fin n) => Dom n -> Dom n -> Bit
@@ -213,14 +214,15 @@ urem a b =
     (ql, rl) = (al / bh', al % bh')
     (qh, rh) = (ah / bl', ah % bl')
 
-// The first argument is a signed interval, but the second argument is
-// an unsigned interval: The arguments should satisfy 'al <=$ ah'
-// (signed) and 'bl <= bh' (unsigned).
+// The first argument is an ordinary signed interval, but the second
+// argument is a reciaprocal interval: The arguments should satisfy 'al
+// <=$ ah' (signed) and '1/bl <= 1/bh' (signed), or equivalently, 'bh
+// <= bl' (unsigned).
 sdivRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> ([1+n], [1+n])
 sdivRange (al, ah) (bl, bh) = (ql, qh)
   where
-    (ql1, qh1) = shrinkRange (al, ah) bl
-    (ql2, qh2) = shrinkRange (al, ah) bh
+    (ql1, qh1) = shrinkRange (al, ah) bh
+    (ql2, qh2) = shrinkRange (al, ah) bl
     ql = smin ql1 ql2
     qh = smax qh1 qh2
 
@@ -409,7 +411,7 @@ correct_urem a b x y =
 
 correct_sdivRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> [n] -> [n] -> Bit
 correct_sdivRange a b x y =
-  smem a x ==> umem b y ==> y != 0 ==> smem (sdivRange a b) (sext x /$ sext y)
+  smem a x ==> umem b y ==> y != 0 ==> smem (sdivRange a (b.1, b.0)) (sext x /$ sext y)
 
 correct_shrinkRange : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> [n] -> Bit
 correct_shrinkRange a x y =
@@ -485,6 +487,7 @@ property a5 = correct_urem`{6}
 property a6 = correct_sdiv`{6}
 property a7 = correct_srem`{6}
 property a8 = correct_bnot`{16}
+property a9 = correct_sdivRange`{6}
 
 property s1 = correct_shl`{8}
 property s2 = correct_lshr`{8}

--- a/what4/doc/arithdomain.cry
+++ b/what4/doc/arithdomain.cry
@@ -1,0 +1,690 @@
+/*
+
+This file contains a Cryptol implementation of the arithmetic
+bitvector abstract domain operations from module What4.Utils.Domain in what4.
+
+In addition to the algorithms themselves, this file also contains
+specifications of correctness for each of the operations. All of the
+correctness properties can be formally proven (each at some specific
+bit width) by loading this file in cryptol and entering ":prove".
+
+*/
+module arithdomain where
+
+////////////////////////////////////////////////////////////
+// Library
+
+bit : {i, n} (fin n, n > i) => [n]
+bit = 1 # (0 : [i])
+
+mask : {i, n} (fin n, n >= i) => [n]
+mask = 0 # (~ 0 : [i])
+
+/** Checked unsigned addition, asserted not to overflow. */
+infixl 80 .+.
+(.+.) : {n} (fin n) => [n] -> [n] -> [n]
+x .+. y = if carry x y then error "overflow" else x + y
+
+/** Checked unsigned subtraction, asserted not to underflow. */
+infixl 80 .-.
+(.-.) : {n} (fin n) => [n] -> [n] -> [n]
+x .-. y = if x < y then error "underflow" else x - y
+
+/** Minimum of two signed values. */
+smin : {a} (SignedCmp a) => a -> a -> a
+smin x y = if x <$ y then x else y
+
+/** Maximum of two signed values. */
+smax : {a} (SignedCmp a) => a -> a -> a
+smax x y = if x >$ y then x else y
+
+////////////////////////////////////////////////////////////
+
+type Dom n = { lo : [n], sz : [n] }
+
+interval : {n} (fin n) => [n] -> [n] -> Dom n
+interval l s = { lo = l, sz = s }
+
+range : {n} (fin n) => [n] -> [n] -> Dom n
+range lo hi = interval lo (hi - lo)
+
+/** Membership predicate that defines the set of concrete values
+represented by an abstract domain element. */
+mem : {n} (fin n) => Dom n -> [n] -> Bit
+mem a x = x - a.lo <= a.sz
+
+umem : {n} (fin n) => ([n], [n]) -> [n] -> Bit
+umem (lo, hi) x = lo <= x /\ x <= hi
+
+smem : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> Bit
+smem (lo, hi) x = lo <=$ x /\ x <=$ hi
+
+top : {n} (fin n) => Dom n
+top = interval 0 (~ 0)
+
+singleton : {n} (fin n) => [n] -> Dom n
+singleton x = interval x 0
+
+isSingleton : {n} (fin n) => Dom n -> Bit
+isSingleton a = a.sz == 0
+
+ubounds : {n} (fin n) => Dom n -> ([n], [n])
+ubounds a =
+  if carry a.lo a.sz then (0, ~0) else (a.lo, a.lo + a.sz)
+
+sbounds : {n} (fin n, n >= 1) => Dom n -> ([n], [n])
+sbounds a = (lo - delta, hi - delta)
+  where
+    delta = reverse 1
+    (lo, hi) = ubounds (interval (a.lo + delta) a.sz)
+
+/** Least and greatest nonzero values in a domain, according to the
+unsigned ordering. */
+rbounds : {n} (fin n, n >= 1) => Dom n -> ([n], [n])
+rbounds a =
+  if a.lo == 0 then (1, a_hi) else
+  if a_hi == 0 then (a.lo, ~0) else
+  if a_hi < a.lo then (1, ~0) else
+  (a.lo, a_hi)
+  where a_hi = a.lo + a.sz
+
+overlap : {n} (fin n) => Dom n -> Dom n -> Bit
+overlap a b = diff <= b.sz \/ carry diff a.sz
+  where diff = a.lo - b.lo
+
+// To compute the union of two intervals, we choose representatives of
+// the endpoints modulo 2^n such that their midpoints are no more than
+// 2^(n-1) apart. In the code below, am and bm are equal to twice the
+// midpoints of intervals a and b, respectively.
+union : {n} (fin n) => Dom n -> Dom n -> Dom n
+union a b =
+  if cw >= size then top else interval (drop`{2} cl) (drop`{2} cw)
+  where
+    size : [n+2]
+    size = bit`{n}
+    am = 2 * zext a.lo .+. zext a.sz
+    bm = 2 * zext b.lo .+. zext b.sz
+    al' = if am .+. size < bm then zext a.lo .+. size else zext a.lo
+    bl' = if bm .+. size < am then zext b.lo .+. size else zext b.lo
+    ah' = al' .+. zext a.sz
+    bh' = bl' .+. zext b.sz
+    cl = min al' bl'
+    ch = max ah' bh'
+    cw = ch .-. cl
+
+////////////////////////////////////////////////////////////
+
+zero_ext : {m, n} (fin m, m >= n) => Dom n -> Dom m
+zero_ext a = interval (zext lo) (zext (hi .-. lo))
+  where (lo, hi) = ubounds a
+
+sign_ext : {m, n} (fin m, m >= n, n >= 1) => Dom n -> Dom m
+sign_ext a = interval (sext lo) (zext (hi - lo))
+  where (lo, hi) = sbounds a
+
+concat : {m, n} (fin m, fin n) => Dom m -> Dom n -> Dom (m + n)
+concat a b = interval (a.lo # lo) (a.sz # sz)
+  where
+    (lo, hi) = ubounds b
+    sz = hi .-. lo
+
+shrink : {m, n} (fin m, fin n) => Dom (m + n) -> Dom m
+shrink a =
+  if b_sz >= size then top
+  else interval (tail b_lo) (tail b_sz)
+  where
+    size : [1 + m]
+    size = bit`{m}
+    b_lo, b_hi, b_sz : [1 + m]
+    b_lo = take`{back=n} (zext a.lo)
+    b_hi = take`{back=n} (zext a.lo .+. zext a.sz)
+    b_sz = b_hi .-. b_lo
+
+trunc : {m, n} (fin m, fin n) => Dom (m + n) -> Dom n
+trunc a =
+  if a.sz > mask`{n} then top
+  else interval (drop`{m} a.lo) (drop`{m} a.sz)
+
+////////////////////////////////////////////////////////////
+// Arithmetic operations
+
+add : {n} (fin n) => Dom n -> Dom n -> Dom n
+add a b =
+  if carry a.sz b.sz then top
+  else interval (a.lo + b.lo) (a.sz .+. b.sz)
+
+neg : {n} (fin n) => Dom n -> Dom n
+neg a = interval (- (a.lo + a.sz)) a.sz
+
+// Turns out, bitwise complement is easy to specify
+// in this domain also
+bnot : {n} (fin n) => Dom n -> Dom n
+bnot a = interval (~ ah) a.sz
+  where ah = a.lo + a.sz
+
+mul : {n} (fin n) => Dom n -> Dom n -> Dom n
+mul a b =
+  if sz >= bit`{n} then top
+  else interval (drop lo) (drop sz)
+  where
+    (lo, hi) = mulRange (zbounds a) (zbounds b)
+    sz = hi - lo
+
+zbounds : {n} (fin n) => Dom n -> ([1 + n], [1 + n])
+zbounds a = (lo', lo' + zext a.sz)
+  where
+    size : [2 + n]
+    size = bit`{n}
+    lo' = if 2 * zext a.lo .+. zext a.sz >= size then 0b1 # a.lo else 0b0 # a.lo
+
+mulRange : {m, n} (fin m, fin n, m >= 1, n >= 1) => ([m], [m]) -> ([n], [n]) -> ([m+n], [m+n])
+mulRange (xl, xh) (yl, yh) = (zl, zh)
+  where
+    (xlyl, xlyh) = scaleRange xl (yl, yh)
+    (xhyl, xhyh) = scaleRange xh (yl, yh)
+    zl = smin xlyl xhyl
+    zh = smax xlyh xhyh
+
+scaleRange : {m, n} (fin m, fin n, m >= 1, n >= 1) => [m] -> ([n], [n]) -> ([m+n], [m+n])
+scaleRange k (lo, hi) = if k <$ 0 then (hi', lo') else (lo', hi')
+  where
+    lo' = sext k * sext lo
+    hi' = sext k * sext hi
+
+udiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+udiv a b = range cl ch
+  where
+    (al, ah) = ubounds a
+    (bl, bh) = ubounds b
+    bl' = max 1 bl // assume that division by 0 does not happen
+    bh' = max 1 bh // assume that division by 0 does not happen
+    cl = al / bh'
+    ch = ah / bl'
+
+urem : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+urem a b =
+  if ql == qh then range rl rh
+  else interval 0 (bh - 1)
+  where
+    (al, ah) = ubounds a
+    (bl, bh) = ubounds b
+    bl' = max 1 bl // assume that division by 0 does not happen
+    bh' = max 1 bh
+    (ql, rl) = (al / bh', al % bh')
+    (qh, rh) = (ah / bl', ah % bl')
+
+// The first argument is a signed interval, but the second argument is
+// an unsigned interval: The arguments should satisfy 'al <=$ ah'
+// (signed) and 'bl <= bh' (unsigned).
+sdivRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> ([1+n], [1+n])
+sdivRange (al, ah) (bl, bh) = (ql, qh)
+  where
+    (ql1, qh1) = shrinkRange (al, ah) bl
+    (ql2, qh2) = shrinkRange (al, ah) bh
+    ql = smin ql1 ql2
+    qh = smax qh1 qh2
+
+// Extra bit of output is to handle the 'INTMIN / -1' overflow case.
+shrinkRange : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> ([1+n], [1+n])
+shrinkRange (lo, hi) k =
+  if k >$ 0 then (lo ./. k, hi ./. k) else
+  if k <$ 0 then (hi ./. k, lo ./. k) else (sext lo, sext hi)
+  where
+    x ./. y = sext x /$ sext y
+
+sdiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+sdiv a b =
+  if sz >= bit`{n} then top
+  else interval (drop lo) (drop sz)
+  where
+    (lo, hi) = sdivRange (sbounds a) (rbounds b)
+    sz = hi - lo
+
+srem : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+srem a b =
+  if ql == qh then
+    (if ql <$ 0
+     then range (al - drop ql * bl) (ah - drop ql * bh)
+     else range (al - drop ql * bh) (ah - drop ql * bl))
+  else range rl rh
+  where
+    (al, ah) = sbounds a
+    (bl, bh) = sbounds b
+    (ql, qh) = sdivRange (al, ah) (rbounds b)
+    rl = if al <$ 0 then smin (bl+1) (-bh+1) else 0
+    rh = if ah >$ 0 then smax (-bl-1) (bh-1) else 0
+
+////////////////////////////////////////////////////////////
+// Shifts
+
+shl : {n} (fin n) => Dom n -> Dom n -> Dom n
+shl a b =
+  if sz > mask`{n} then top
+  else interval (drop lo) (drop sz)
+  where
+    al, ah : [n + 1]
+    (al, ah) = zbounds a
+    bl, bh : [n]
+    (bl, bh) = ubounds b
+    // [n + 2] is enough to avoid signed overflow in shift
+    cl, ch : [n + 2]
+    cl = if bl < `n then 1 << bl else bit`{n}
+    ch = if bh < `n then 1 << bh else bit`{n}
+    (lo, hi) = mulRange (al, ah) (cl, ch)
+    sz = hi - lo
+
+lshr : {n} (fin n) => Dom n -> Dom n -> Dom n
+lshr a b = interval cl (ch - cl)
+  where
+    (al, ah) = ubounds a
+    (bl, bh) = ubounds b
+    cl = al >> bh
+    ch = ah >> bl
+
+ashr : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+ashr a b = interval cl (ch - cl)
+  where
+    (al, ah) = sbounds a
+    (bl, bh) = ubounds b
+    cl = al >>$ (if al <$ 0 then bl else bh)
+    ch = ah >>$ (if ah <$ 0 then bh else bl)
+
+////////////////////////////////////////////////////////////
+// Comparisons
+
+ult : {n} (fin n) => Dom n -> Dom n -> Bit
+ult a b = (ubounds a).1 < (ubounds b).0
+
+ule : {n} (fin n) => Dom n -> Dom n -> Bit
+ule a b = (ubounds a).1 <= (ubounds b).0
+
+slt : {n} (fin n, n >= 1) => Dom n -> Dom n -> Bit
+slt a b = (sbounds a).1 <$ (sbounds b).0
+
+sle : {n} (fin n, n >= 1) => Dom n -> Dom n -> Bit
+sle a b = (sbounds a).1 <=$ (sbounds b).0
+
+// A bitmask indicating which bits cannot be determined
+// given the interval information in the given domain
+unknowns : {n} (fin n, n >= 1) => Dom n -> [n]
+unknowns a = if carry a.lo a.sz then ~0 else bits
+ where
+ bits = fillright diff
+ diff = a.lo ^ (a.lo + a.sz)
+
+fillright : {n} (fin n, n >= 1) => [n] -> [n]
+fillright x = tail (scanl (||) False x)
+
+fillright_alt : {n} (fin n, n >= 1) => [n] -> [n]
+fillright_alt x = x || ((1 << lg2 x) - 1)
+
+property fillright_equiv x = fillright`{16} x == fillright_alt x
+
+////////////////////////////////////////////////////////////
+
+
+///////////////////////////////////////////////////////////
+// Correctness properties
+
+infix 20 =@=
+
+/** Equivalence of bitvector domains. */
+(=@=) : {n} (fin n) => Dom n -> Dom n -> Bit
+a =@= b = (a.sz == ~0 /\ b.sz == ~0) \/ (a == b)
+
+infix 5 <==>
+
+(<==>) : Bit -> Bit -> Bit
+(<==>) = (==)
+
+////////////////////////////////////////////////////////////
+// Soundness properties
+
+correct_top : {n} (fin n) => [n] -> Bit
+correct_top x = mem top x
+
+correct_ubounds : {n} (fin n) => Dom n -> [n] -> Bit
+correct_ubounds a x =
+  mem a x ==> umem (ubounds a) x
+
+correct_sbounds : {n} (fin n, n >= 1) => Dom n -> [n] -> Bit
+correct_sbounds a x =
+  mem a x ==> smem (sbounds a) x
+
+correct_singleton : {n} (fin n) => [n] -> [n] -> Bit
+correct_singleton x y =
+  mem (singleton x) y <==> x == y
+
+correct_overlap : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
+correct_overlap a b x =
+  mem a x ==> mem b x ==> overlap a b
+
+correct_union : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
+correct_union a b x =
+  (mem a x \/ mem b x) ==> mem (union a b) x
+
+correct_zero_ext : {m, n} (fin m, m >= n) => Dom n -> [n] -> Bit
+correct_zero_ext a x =
+  mem a x ==> mem (zero_ext`{m} a) (zext`{m} x)
+
+correct_sign_ext : {m, n} (fin m, m >= n, n >= 1) => Dom n -> [n] -> Bit
+correct_sign_ext a x =
+  mem a x ==> mem (sign_ext`{m} a) (sext`{m} x)
+
+correct_concat : {m, n} (fin m, fin n) => Dom m -> Dom n -> [m] -> [n] -> Bit
+correct_concat a b x y =
+  mem a x ==> mem b y ==> mem (concat a b) (x # y)
+
+correct_shrink : {m, n} (fin m, fin n) => Dom (m + n) -> [m + n] -> Bit
+correct_shrink a x =
+  mem a x ==> mem (shrink`{m} a) (take`{m} x)
+
+correct_trunc : {m, n} (fin m, fin n) => Dom (m + n) -> [m + n] -> Bit
+correct_trunc a x =
+  mem a x ==> mem (trunc`{m} a) (drop`{m} x)
+
+correct_add : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_add a b x y =
+  mem a x ==> mem b y ==> mem (add a b) (x + y)
+
+correct_neg : {n} (fin n) => Dom n -> [n] -> Bit
+correct_neg a x =
+  mem a x <==> mem (neg a) (- x)
+
+correct_mul : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_mul a b x y =
+  mem a x ==> mem b y ==> mem (mul a b) (x * y)
+
+correct_mulRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> [n] -> [n] -> Bit
+correct_mulRange a b x y =
+  smem a x ==> smem b y ==> smem (mulRange a b) (sext x * sext y)
+
+correct_udiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_udiv a b x y =
+  mem a x ==> mem b y ==> y != 0 ==> mem (udiv a b) (x / y)
+
+correct_urem : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_urem a b x y =
+  mem a x ==> mem b y ==> y != 0 ==> mem (urem a b) (x % y)
+
+correct_sdivRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> [n] -> [n] -> Bit
+correct_sdivRange a b x y =
+  smem a x ==> umem b y ==> y != 0 ==> smem (sdivRange a b) (sext x /$ sext y)
+
+correct_shrinkRange : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> [n] -> Bit
+correct_shrinkRange a x y =
+  smem a x ==> y != 0 ==> smem (shrinkRange a y) (sext x /$ sext y)
+
+correct_sdiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_sdiv a b x y =
+  mem a x ==> mem b y ==> y != 0 ==> mem (sdiv a b) (x /$ y)
+
+correct_srem : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_srem a b x y =
+  mem a x ==> mem b y ==> y != 0 ==> mem (srem a b) (x %$ y)
+
+correct_shl : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_shl a b x y =
+  mem a x ==> mem b y ==> mem (shl a b) (x << y)
+
+correct_lshr : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_lshr a b x y =
+  mem a x ==> mem b y ==> mem (lshr a b) (x >> y)
+
+correct_ashr : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_ashr a b x y =
+  mem a x ==> mem b y ==> mem (ashr a b) (x >>$ y)
+
+correct_slt : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_slt a b x y =
+  slt a b ==> mem a x ==> mem b y ==> x <$ y
+
+correct_sle : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_sle a b x y =
+  sle a b ==> mem a x ==> mem b y ==> x <=$ y
+
+correct_ult : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_ult a b x y =
+  ult a b ==> mem a x ==> mem b y ==> x < y
+
+correct_ule : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_ule a b x y =
+  ule a b ==> mem a x ==> mem b y ==> x <= y
+
+correct_bnot : {n} (fin n) => Dom n -> [n] -> Bit
+correct_bnot a x =
+  mem a x <==> mem (bnot a) (~ x)
+
+correct_isSingleton : {n} (fin n) => Dom n -> Bit
+correct_isSingleton a =
+  isSingleton a ==> a == singleton a.lo
+
+correct_unknowns : {n} (fin n, n >= 1) => Dom n -> [n] -> [n] -> Bit
+correct_unknowns a x y =
+  mem a x ==> mem a y ==> (x || unknowns a) == (y || unknowns a)
+
+property p1 = correct_top`{16}
+property p2 = correct_ubounds`{16}
+property p3 = correct_sbounds`{16}
+property p4 = correct_singleton`{16}
+property p5 = correct_overlap`{16}
+property p6 = correct_union`{8}
+property p7 = correct_zero_ext`{32, 16}
+property p8 = correct_sign_ext`{32, 16}
+property p9 = correct_concat`{16, 16}
+property p10 = correct_shrink`{8, 8}
+property p11 = correct_trunc`{8, 8}
+property p12 = correct_unknowns`{16}
+property p13 = correct_isSingleton`{16}
+
+property a1 = correct_add`{8}
+property a2 = correct_neg`{16}
+property a3 = correct_mul`{4}
+property a4 = correct_udiv`{8}
+property a5 = correct_urem`{6}
+property a6 = correct_sdiv`{6}
+property a7 = correct_srem`{6}
+property a8 = correct_bnot`{16}
+
+property s1 = correct_shl`{8}
+property s2 = correct_lshr`{8}
+property s3 = correct_ashr`{8}
+
+property o1 = correct_slt`{16}
+property o2 = correct_sle`{16}
+property o3 = correct_ult`{16}
+property o4 = correct_ule`{16}
+
+////////////////////////////////////////////////////////////
+// Operations preserve singletons
+
+singleton_overlap : {n} (fin n) => [n] -> [n] -> Bit
+singleton_overlap x y =
+  overlap (singleton x) (singleton y) == (x == y)
+
+singleton_zero_ext : {m, n} (fin m, m >= n) => [n] -> Bit
+singleton_zero_ext x =
+  zero_ext`{m} (singleton x) == singleton (zext`{m} x)
+
+singleton_sign_ext : {m, n} (fin m, m >= n, n >= 1) => [n] -> Bit
+singleton_sign_ext x =
+  sign_ext`{m} (singleton x) == singleton (sext`{m} x)
+
+singleton_concat : {m, n} (fin m, fin n) => [m] -> [n] -> Bit
+singleton_concat x y =
+  concat (singleton x) (singleton y) == singleton (x # y)
+
+singleton_shrink : {m, n} (fin m, fin n) => [m + n] -> Bit
+singleton_shrink x =
+  shrink`{m} (singleton x) == singleton (take`{m} x)
+
+singleton_trunc : {m, n} (fin m, fin n) => [m + n] -> Bit
+singleton_trunc x =
+  trunc`{m} (singleton x) == singleton (drop`{m} x)
+
+singleton_add : {n} (fin n) => [n] -> [n] -> Bit
+singleton_add x y =
+  add (singleton x) (singleton y) == singleton (x + y)
+
+singleton_neg : {n} (fin n) => [n] -> Bit
+singleton_neg x =
+  neg (singleton x) == singleton (- x)
+
+singleton_mul : {n} (fin n) => [n] -> [n] -> Bit
+singleton_mul x y =
+  mul (singleton x) (singleton y) == singleton (x * y)
+
+singleton_mulRange : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_mulRange x y =
+  mulRange (x, x) (y, y) == (sext x * sext y, sext x * sext y)
+
+singleton_udiv : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_udiv x y =
+  y != 0 ==> udiv (singleton x) (singleton y) == singleton (x / y)
+
+singleton_urem : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_urem x y =
+  y != 0 ==> urem (singleton x) (singleton y) == singleton (x % y)
+
+singleton_sdiv : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_sdiv x y =
+  y != 0 ==> sdiv (singleton x) (singleton y) == singleton (x /$ y)
+
+singleton_srem : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_srem x y =
+  y != 0 ==> srem (singleton x) (singleton y) == singleton (x %$ y)
+
+singleton_shl : {n} (fin n) => [n] -> [n] -> Bit
+singleton_shl x y =
+  shl (singleton x) (singleton y) == singleton (x << y)
+
+singleton_lshr : {n} (fin n) => [n] -> [n] -> Bit
+singleton_lshr x y =
+  lshr (singleton x) (singleton y) == singleton (x >> y)
+
+singleton_ashr : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_ashr x y =
+  ashr (singleton x) (singleton y) == singleton (x >>$ y)
+
+singleton_slt : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_slt x y =
+  slt (singleton x) (singleton y) == (x <$ y)
+
+singleton_sle : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_sle x y =
+  sle (singleton x) (singleton y) == (x <=$ y)
+
+singleton_ult : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_ult x y =
+  ult (singleton x) (singleton y) == (x < y)
+
+singleton_ule : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_ule x y =
+  ule (singleton x) (singleton y) == (x <= y)
+
+property i01 = singleton_overlap`{16}
+property i02 = singleton_zero_ext`{32, 16}
+property i03 = singleton_sign_ext`{32, 16}
+property i04 = singleton_concat`{16, 16}
+property i05 = singleton_shrink`{8, 8}
+property i06 = singleton_trunc`{8, 8}
+property i07 = singleton_add`{8}
+property i08 = singleton_neg`{16}
+property i09 = singleton_mul`{4}
+property i10 = singleton_udiv`{8}
+property i11 = singleton_urem`{8}
+property i12 = singleton_sdiv`{8}
+property i13 = singleton_srem`{8}
+property i14 = singleton_shl`{8}
+property i15 = singleton_lshr`{8}
+property i16 = singleton_ashr`{8}
+property i17 = singleton_slt`{16}
+property i18 = singleton_sle`{16}
+property i19 = singleton_ult`{16}
+property i20 = singleton_ule`{16}
+
+////////////////////////////////////////////////////////////
+// Associativity/commutativity properties
+
+comm_overlap : {n} (fin n) => Dom n -> Dom n -> Bit
+comm_overlap a b = overlap a b <==> overlap b a
+
+comm_add : {n} (fin n) => Dom n -> Dom n -> Bit
+comm_add a b = add a b == add b a
+
+assoc_add : {n} (fin n) => Dom n -> Dom n -> Dom n -> Bit
+assoc_add a b c = add a (add b c) =@= add (add a b) c
+
+comm_mul : {n} (fin n) => Dom n -> Dom n -> Bit
+comm_mul a b = mul a b == mul b a
+
+/* mul is not associative! */
+assoc_mul : {n} (fin n) => Dom n -> Dom n -> Dom n -> Bit
+assoc_mul a b c = mul a (mul b c) =@= mul (mul a b) c
+
+comm_mulRange :
+  {i, j} (fin i, fin j, i >= 1, j >= 1) => ([i], [i]) -> ([j], [j]) -> Bit
+comm_mulRange a b =
+  a.0 <=$ a.1 ==> b.0 <=$ b.1 ==> mulRange a b == mulRange b a
+
+assoc_mulRange :
+  {i, j, k} (fin i, fin j, fin k, i >= 1, j >= 1, k >= 1) =>
+  ([i], [i]) -> ([j], [j]) -> ([k], [k]) -> Bit
+assoc_mulRange a b c =
+  a.0 <=$ a.1 ==>
+  b.0 <=$ b.1 ==>
+  c.0 <=$ c.1 ==>
+  mulRange a (mulRange b c) == mulRange (mulRange a b) c
+
+property c1 = comm_overlap`{16}
+property c2 = comm_add`{16}
+property c3 = assoc_add`{16}
+property c4 = comm_mul`{4}
+property c5 = comm_mulRange`{4,4}
+property c6 = assoc_mulRange`{3,3,3}
+
+////////////////////////////////////////////////////////////
+// Additional properties about union
+
+comm_union : {n} (fin n) => Dom n -> Dom n -> Bit
+comm_union a b = union a b == union b a
+
+/* union is actually not associative! */
+assoc_union : {n} (fin n) => Dom n -> Dom n -> Dom n -> Bit
+assoc_union a b c = union a (union b c) == union (union a b) c
+
+/* union always has a lower bound equal to one of the input lower bounds */
+lo_union : {n} (fin n) => Dom n -> Dom n -> Bit
+lo_union a b =
+  union a b == top \/ (union a b).lo == a.lo \/ (union a b).lo == b.lo
+
+/* union always has an upper bound equal to one of the input upper bounds */
+hi_union : {n} (fin n) => Dom n -> Dom n -> Bit
+hi_union a b = c == top \/ c_hi == a_hi \/ c_hi == b_hi
+  where
+    c = union a b
+    a_hi = a.lo + a.sz
+    b_hi = b.lo + b.sz
+    c_hi = c.lo + c.sz
+
+/* union doesn't return top unless necessary */
+nontriv_union : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
+nontriv_union a b x =
+  union a b =@= top ==> mem a x \/ mem b x
+
+/* union of opposite intervals prefers to exclude zero */
+nonzero_union : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+nonzero_union lo sz =
+  mem (union a b) half /\
+  (~ mem a 0 ==> ~ mem b 0 ==> ~ mem (union a b) 0)
+  where
+    half : [n]
+    half = reverse 1
+    a = interval lo sz
+    b = interval (lo + half) sz
+
+property u1 = comm_union`{16}
+property u2 = lo_union`{16}
+property u3 = hi_union`{16}
+property u4 = nontriv_union`{8}
+property u5 = nonzero_union`{16}

--- a/what4/doc/bitsdomain.cry
+++ b/what4/doc/bitsdomain.cry
@@ -1,0 +1,268 @@
+/*
+
+This file contains a Cryptol implementation of the bitwise
+bitvector abstract domain operations from What4.Utils.BVDomain
+
+In addition to the algorithms themselves, this file also contains
+specifications of correctness for each of the operations. All of the
+correctness properties can be formally proven (each at some specific
+bit width) by loading this file in cryptol and entering ":prove".
+
+*/
+module bitsdomain where
+
+// This type represents _bitwise_ bounds as opposed to the
+// arithmetic bounds described by BVDom.  Note that
+// this representation allows the empty set if
+// lomask is not bitwise below himask.  However, all
+// the operations (other than intersection) preserve the property
+// of being nonempty (implied by their various soundness properties).
+type Dom n = { lomask : [n] , himask : [n] }
+
+/** Membership predicate that defines the set of concrete values
+represented by a bitwise abstract domain element. */
+mem : {n} (fin n) => Dom n -> [n] -> Bit
+mem a x = bitle a.lomask x /\ bitle x a.himask
+
+bitle : {n} (fin n) => [n] -> [n] -> Bit
+bitle x y = x || y == y
+
+nonempty : {n} (fin n) => Dom n -> Bit
+nonempty b = bitle b.lomask b.himask
+
+singleton : {n} (fin n) => [n] -> Dom n
+singleton x = { lomask = x, himask = x }
+
+isSingleton : {n} (fin n) => Dom n -> Bit
+isSingleton a = a.lomask == a.himask
+
+top : {n} (fin n) => Dom n
+top = { lomask = 0, himask = ~0 }
+
+overlap : {n} (fin n) => Dom n -> Dom n -> Bit
+overlap a b = nonempty (intersection a b)
+
+intersection : {n} (fin n) => Dom n -> Dom n -> Dom n
+intersection a b = { lomask = a.lomask || b.lomask, himask = a.himask && b.himask }
+
+union : {n} (fin n) => Dom n -> Dom n -> Dom n
+union a b = { lomask = a.lomask && b.lomask, himask = a.himask || b.himask }
+
+zero_ext : {m, n} (fin m, m >= n) => Dom n -> Dom m
+zero_ext a = { lomask = zext a.lomask, himask = zext a.himask }
+
+sign_ext : {m, n} (fin m, m >= n, n >= 1) => Dom n -> Dom m
+sign_ext a = { lomask = sext a.lomask, himask = sext a.himask }
+
+concat : {m, n} (fin m, fin n) => Dom m -> Dom n -> Dom (m + n)
+concat a b = { lomask = a.lomask # b.lomask, himask = a.himask # b.himask }
+
+shrink : {m, n} (fin m, fin n) => Dom (m + n) -> Dom m
+shrink a = { lomask = take`{m} a.lomask, himask = take`{m} a.himask }
+
+trunc : {m, n} (fin m, fin n) => Dom (m + n) -> Dom n
+trunc a = { lomask = drop`{m} a.lomask, himask = drop`{m} a.himask }
+
+bnot : {n} (fin n) => Dom n -> Dom n
+bnot b = { lomask = ~b.himask, himask = ~b.lomask }
+
+band : {n} (fin n) => Dom n -> Dom n -> Dom n
+band a b = { lomask = a.lomask && b.lomask, himask = a.himask && b.himask }
+
+bor : {n} (fin n) => Dom n -> Dom n -> Dom n
+bor a b = { lomask = a.lomask || b.lomask, himask = a.himask || b.himask }
+
+// Note, this requires quite a few more operations than AND and OR.
+// See "xordomain.cry" for a domain optimized for XOR and AND operations.
+bxor : {n} (fin n) => Dom n -> Dom n -> Dom n
+bxor a b = { lomask = lo, himask = hi }
+  where
+  ua = a.lomask ^ a.himask
+  ub = b.lomask ^ b.himask
+  c  = a.lomask ^ b.lomask
+  u  = ua || ub
+  hi = c || u
+  lo = hi ^ u
+
+// Note: shift operations in this domain only apply when the
+// shift amount is known
+shl : {n} (fin n) => Dom n -> [n] -> Dom n
+shl a x = { lomask = a.lomask << x', himask = a.himask << x' }
+  where x' = if x < `n then x else `n
+
+lshr : {n} (fin n) => Dom n -> [n] -> Dom n
+lshr a x = { lomask = a.lomask >> x', himask = a.himask >> x' }
+  where x' = if x < `n then x else `n
+
+ashr : {n} (fin n, n >= 1) => Dom n -> [n] -> Dom n
+ashr a x = { lomask = a.lomask >>$ x', himask = a.himask >>$ x' }
+  where x' = if x < `n then x else `n
+
+////////////////////////////////////////////////////////////
+// Soundness properties
+
+correct_top : {n} (fin n) => [n] -> Bit
+correct_top x = mem top x
+
+correct_singleton : {n} (fin n) => [n] -> [n] -> Bit
+correct_singleton x y = mem (singleton x) y == (x == y)
+
+correct_overlap : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
+correct_overlap a b x =
+  mem a x ==> mem b x ==> overlap a b
+
+correct_overlap_inv : {n} (fin n) => Dom n -> Dom n -> Bit
+correct_overlap_inv a b =
+  overlap a b ==> (mem a (a.lomask || b.lomask) /\ mem b (a.lomask || b.lomask))
+
+correct_union : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
+correct_union a b x =
+  (mem a x \/ mem b x) ==> mem (union a b) x
+
+correct_intersection : {n} (fin n) => Dom n -> Dom n -> [n] -> Bit
+correct_intersection a b x =
+  (mem a x /\ mem b x) == mem (intersection a b) x
+
+correct_zero_ext : {m, n} (fin m, m >= n) => Dom n -> [n] -> Bit
+correct_zero_ext a x =
+  mem a x ==> mem (zero_ext`{m} a) (zext`{m} x)
+
+correct_sign_ext : {m, n} (fin m, m >= n, n >= 1) => Dom n -> [n] -> Bit
+correct_sign_ext a x =
+  mem a x ==> mem (sign_ext`{m} a) (sext`{m} x)
+
+correct_concat : {m, n} (fin m, fin n) => Dom m -> Dom n -> [m] -> [n] -> Bit
+correct_concat a b x y =
+  mem a x ==> mem b y ==> mem (concat a b) (x # y)
+
+correct_shrink : {m, n} (fin m, fin n) => Dom (m + n) -> [m+n] -> Bit
+correct_shrink a x =
+  mem a x ==> mem (shrink`{m} a) (take`{m} x)
+
+correct_trunc : {m, n} (fin m, fin n) => Dom (m + n) -> [m+n] -> Bit
+correct_trunc a x =
+  mem a x ==> mem (trunc`{m} a) (drop`{m} x)
+
+correct_isSingleton : {n} (fin n) => Dom n -> Bit
+correct_isSingleton a =
+  isSingleton a ==> a == singleton a.lomask
+
+correct_bnot : {n} (fin n) => Dom n -> [n] -> Bit
+correct_bnot a x =
+  mem a x == mem (bnot a) (~ x)
+
+correct_band : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_band a b x y =
+  mem a x ==> mem b y ==> mem (band a b) (x && y)
+
+correct_bor : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_bor a b x y =
+  mem a x ==> mem b y ==> mem (bor a b) (x || y)
+
+correct_bxor : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_bxor a b x y =
+  mem a x ==> mem b y ==> mem (bxor a b) (x ^ y)
+
+correct_shl : {n} (fin n) => Dom n -> [n] -> [n] -> Bit
+correct_shl a x y =
+  mem a x ==> mem (shl a y) (x << y)
+
+correct_lshr : {n} (fin n) => Dom n -> [n] -> [n] -> Bit
+correct_lshr a x y =
+  mem a x ==> mem (lshr a y) (x >> y)
+
+correct_ashr : {n} (fin n, n >= 1) => Dom n -> [n] -> [n] -> Bit
+correct_ashr a x y =
+  mem a x ==> mem (ashr a y) (x >>$ y)
+
+property b1 = correct_top`{16}
+property b2 = correct_singleton`{16}
+property b3 = correct_overlap`{16}
+property b4 = correct_overlap_inv`{16}
+property b5 = correct_union`{8}
+property b6 = correct_intersection`{8}
+property b7 = correct_zero_ext`{32, 16}
+property b8 = correct_sign_ext`{32, 16}
+property b9 = correct_concat`{16, 16}
+property b10 = correct_shrink`{8, 8}
+property b11 = correct_trunc`{8, 8}
+property b12 = correct_isSingleton`{16}
+
+property l1 = correct_bnot`{16}
+property l2 = correct_band`{16}
+property l3 = correct_bor`{16}
+property l4 = correct_bxor`{16}
+
+property s1 = correct_shl`{8}
+property s2 = correct_lshr`{8}
+property s3 = correct_ashr`{8}
+
+
+////////////////////////////////////////////////////////////
+// Operations preserve singletons
+
+singleton_overlap : {n} (fin n) => [n] -> [n] -> Bit
+singleton_overlap x y =
+  overlap (singleton x) (singleton y) == (x == y)
+
+singleton_zero_ext : {m, n} (fin m, m >= n) => [n] -> Bit
+singleton_zero_ext x =
+  zero_ext`{m} (singleton x) == singleton (zext`{m} x)
+
+singleton_sign_ext : {m, n} (fin m, m >= n, n >= 1) => [n] -> Bit
+singleton_sign_ext x =
+  sign_ext`{m} (singleton x) == singleton (sext`{m} x)
+
+singleton_concat : {m, n} (fin m, fin n) => [m] -> [n] -> Bit
+singleton_concat x y =
+  concat (singleton x) (singleton y) == singleton (x # y)
+
+singleton_shrink : {m, n} (fin m, fin n) => [m + n] -> Bit
+singleton_shrink x =
+  shrink`{m} (singleton x) == singleton (take`{m} x)
+
+singleton_trunc : {m, n} (fin m, fin n) => [m + n] -> Bit
+singleton_trunc x =
+  trunc`{m} (singleton x) == singleton (drop`{m} x)
+
+singleton_bnot : {n} (fin n) => [n] -> Bit
+singleton_bnot x =
+  bnot (singleton x) == singleton (~ x)
+
+singleton_band : {n} (fin n) => [n] -> [n] -> Bit
+singleton_band x y =
+  band (singleton x) (singleton y) == singleton (x && y)
+
+singleton_bor : {n} (fin n) => [n] -> [n] -> Bit
+singleton_bor x y =
+  bor (singleton x) (singleton y) == singleton (x || y)
+
+singleton_bxor : {n} (fin n) => [n] -> [n] -> Bit
+singleton_bxor x y =
+  bxor (singleton x) (singleton y) == singleton (x ^ y)
+
+singleton_shl : {n} (fin n) => [n] -> [n] -> Bit
+singleton_shl x y =
+  shl (singleton x) y == singleton (x << y)
+
+singleton_lshr : {n} (fin n) => [n] -> [n] -> Bit
+singleton_lshr x y =
+  lshr (singleton x) y == singleton (x >> y)
+
+singleton_ashr : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+singleton_ashr x y =
+  ashr (singleton x) y == singleton (x >>$ y)
+
+property i01 = singleton_overlap`{16}
+property i02 = singleton_zero_ext`{32, 16}
+property i03 = singleton_sign_ext`{32, 16}
+property i04 = singleton_concat`{16, 16}
+property i05 = singleton_shrink`{8, 8}
+property i06 = singleton_trunc`{8, 8}
+property i07 = singleton_band`{16}
+property i08 = singleton_bor`{16}
+property i09 = singleton_bxor`{16}
+property i10 = singleton_bnot`{16}
+property i11 = singleton_shl`{8}
+property i12 = singleton_lshr`{8}
+property i13 = singleton_ashr`{8}

--- a/what4/doc/bitsdomain.cry
+++ b/what4/doc/bitsdomain.cry
@@ -84,8 +84,8 @@ bxor a b = { lomask = lo, himask = hi }
   hi = c || u
   lo = hi ^ u
 
-// Note: shift operations in this domain only apply when the
-// shift amount is known
+// Note: shift and rotate operations in this domain only apply
+// when the shift amount is known
 shl : {n} (fin n) => Dom n -> [n] -> Dom n
 shl a x = { lomask = a.lomask << x', himask = a.himask << x' }
   where x' = if x < `n then x else `n
@@ -97,6 +97,12 @@ lshr a x = { lomask = a.lomask >> x', himask = a.himask >> x' }
 ashr : {n} (fin n, n >= 1) => Dom n -> [n] -> Dom n
 ashr a x = { lomask = a.lomask >>$ x', himask = a.himask >>$ x' }
   where x' = if x < `n then x else `n
+
+rol : {n} (fin n) => Dom n -> [n] -> Dom n
+rol a x = { lomask = a.lomask <<< x, himask = a.himask <<< x }
+
+ror : {n} (fin n) => Dom n -> [n] -> Dom n
+ror a x = { lomask = a.lomask >>> x, himask = a.himask >>> x }
 
 ////////////////////////////////////////////////////////////
 // Soundness properties
@@ -175,6 +181,14 @@ correct_ashr : {n} (fin n, n >= 1) => Dom n -> [n] -> [n] -> Bit
 correct_ashr a x y =
   mem a x ==> mem (ashr a y) (x >>$ y)
 
+correct_rol : {n} (fin n) => Dom n -> [n] -> [n] -> Bit
+correct_rol a x y =
+  mem a x ==> mem (rol a y) (x <<< y)
+
+correct_ror : {n} (fin n) => Dom n -> [n] -> [n] -> Bit
+correct_ror a x y =
+  mem a x ==> mem (ror a y) (x >>> y)
+
 property b1 = correct_top`{16}
 property b2 = correct_singleton`{16}
 property b3 = correct_overlap`{16}
@@ -193,9 +207,11 @@ property l2 = correct_band`{16}
 property l3 = correct_bor`{16}
 property l4 = correct_bxor`{16}
 
-property s1 = correct_shl`{8}
-property s2 = correct_lshr`{8}
-property s3 = correct_ashr`{8}
+property s1 = correct_shl`{16}
+property s2 = correct_lshr`{16}
+property s3 = correct_ashr`{16}
+property s4 = correct_rol`{16}
+property s5 = correct_ror`{16}
 
 
 ////////////////////////////////////////////////////////////

--- a/what4/doc/bvdomain.cry
+++ b/what4/doc/bvdomain.cry
@@ -12,6 +12,149 @@ import bitsdomain as B
 import xordomain as X
 
 
+// Precondition `x <= mask`.  Find the (arithmetically) smallest
+//  `z` above `x` which is bitwise above `mask`.  In other words
+// find the smallest `z` such that `x <= z` and `mask || z == z`.
+
+bitwise_round_above : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+bitwise_round_above x mask = (x && ~q) ^ (mask && q)
+  where
+  q = A::fillright_alt ((x || mask) ^ x)
+
+bra_correct1 : {n} (fin n, n>=1) => [n] -> [n] -> Bit
+bra_correct1 x mask = mask <= x ==> (x <= q /\ B::bitle mask q)
+  where
+  q = bitwise_round_above x mask
+
+bra_correct2 : {n} (fin n, n>=1) => [n] -> [n] -> [n] -> Bit
+bra_correct2 x mask q' = (x <= q' /\ B::bitle mask q') ==> q <= q'
+  where
+  q = bitwise_round_above x mask
+
+property bra1 = bra_correct1`{64}
+property bra2 = bra_correct2`{64}
+
+
+// Precondition `lomask <= x <= himask` and `lomask || himask == himask`.
+// Find the (arithmetically) smallest `z` above `x` which is bitwise between
+// `lomask` and `himask`.  In otherwords, find the smallest `z` such that
+//  `x <= z` and `lomask || z = z` and `z || himask == himask`.
+bitwise_round_between : {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n]
+bitwise_round_between x lomask himask = if r == 0 then loup else final
+  // Read these steps from the bottom up...
+  where
+
+  // Finally mask out the low bits and only set those requried by the lomask
+  final = (upper && ~lowbits) || lomask
+
+  // add the correcting bit and mask out any extraneous bits set in
+  // the previous step
+  upper = (z + highbit) && himask
+
+  // set ourselves up so that when we add the high bit to correct,
+  // the carry will ripple until it finds a bit position that we
+  // are allowed to set.
+  z = loup || ~himask
+
+  // isolate just the highest incorrect bit
+  highbit = rmask ^ lowbits
+
+  // A mask for all the bits lower than the high bit of r
+  lowbits = rmask >> 1
+
+  // set all the bits to the right of the highest incorrect bit
+  rmask = A::fillright_alt r
+
+  // now compute all the bits that are set that are not allowed
+  // to be set according to the himask
+  r = loup && ~himask
+
+  // first, round up to the lomask
+  loup = bitwise_round_above x lomask
+
+
+brb_correct1 : {n} (fin n, n>=1) => [n] -> [n] -> [n] -> Bit
+brb_correct1 x lomask himask =
+    (B::bitle lomask himask /\ lomask <= x /\ x <= himask) ==>
+    (x <= q /\ B::bitle lomask q /\ B::bitle q himask)
+
+  where
+  q = bitwise_round_between x lomask himask
+
+brb_correct2 : {n} (fin n, n>=1) => [n] -> [n] -> [n] -> [n] -> Bit
+brb_correct2 x lomask himask q' = (x <= q' /\ B::bitle lomask q' /\ B::bitle q' himask) ==> q <= q'
+  where
+  q = bitwise_round_between x lomask himask
+
+property brb1 = brb_correct1`{64}
+property brb2 = brb_correct2`{64}
+
+// Interesting fact about arithmetic domains: the low values of the two domains
+// represent overlap candidates.  If neither low value is contained in the other domain,
+// then they do not overlap.
+arith_overlap_candidates : {n} (fin n, n >= 1) => A::Dom n -> A::Dom n -> [n] -> Bit
+arith_overlap_candidates a b x =
+  A::mem a x ==>
+  A::mem b x ==>
+  ((A::mem a b.lo /\ A::mem b b.lo) \/
+   (A::mem a a.lo /\ A::mem b a.lo))
+
+// Bitwise domains, if they overlap, must overlap in some specific points.  The bitwise
+// union of the low bounds is one.
+bitwise_overlap_candidates : {n} (fin n, n >= 1) => B::Dom n -> B::Dom n -> [n] -> Bit
+bitwise_overlap_candidates a b x =
+  B::mem a x ==>
+  B::mem b x ==>
+  (B::mem a witness /\ B::mem b witness)
+
+ where
+ witness = a.lomask || b.lomask
+
+// If mixed domains have some common value, then they must definintely overlap at one
+// of the following three listed candidate points.
+mixed_overlap_candidates : {n} (fin n, n >= 1) => A::Dom n -> B::Dom n -> [n] -> Bit
+mixed_overlap_candidates a b x =
+  A::mem a x ==>
+  B::mem b x ==>
+  (A::mem a b.lomask /\ B::mem b b.lomask) \/
+  (A::mem a b.himask /\ B::mem b b.himask) \/
+  (A::mem a next     /\ B::mem b next)
+
+ where
+ next = bitwise_round_between a.lo b.lomask b.himask
+
+
+// A mixed domain overlap test.  It relies on testing special candidate overlap values.
+//
+// If none of the overlap candidates are found in both domains, then the domains do not overlap.
+// On the other hand, if any canadiate is in both domains, it is a constructive witness of
+// overlap.
+mixed_domain_overlap : {n} (fin n, n >= 1) => A::Dom n -> B::Dom n -> Bit
+mixed_domain_overlap a b =
+  A::mem a b.lomask \/ A::mem a b.himask \/ A::mem a (bitwise_round_between a.lo b.lomask b.himask)
+
+// If mixed domains have a common element, the overlap test will be true.
+correct_mixed_domain_overlap : {n} (fin n, n >= 1) => A::Dom n -> B::Dom n -> [n] -> Bit
+correct_mixed_domain_overlap a b x =
+  A::mem a x ==>
+  B::mem b x ==>
+  mixed_domain_overlap a b
+
+// If the overlap test is true, then we can find some element they share in common,
+// provided the bitwise domain is nonempty.
+correct_mixed_domain_overlap_inv : {n} (fin n, n >= 1) => A::Dom n -> B::Dom n -> Bit
+correct_mixed_domain_overlap_inv a b =
+  B::nonempty b ==> mixed_domain_overlap a b ==> (A::mem a witness /\ B::mem b witness)
+
+ where
+ witness = if A::mem a b.lomask then b.lomask else
+           if A::mem a b.himask then b.himask else
+           bitwise_round_between a.lo b.lomask b.himask
+
+property mx = correct_mixed_domain_overlap`{64}
+property mx_inv = correct_mixed_domain_overlap_inv`{64}
+
+
 // Operations that transfer between the domains
 
 arithToBitDom : {n} (fin n, n >= 1) => A::Dom n -> B::Dom n

--- a/what4/doc/bvdomain.cry
+++ b/what4/doc/bvdomain.cry
@@ -1,738 +1,144 @@
 /*
 
-This file contains a Cryptol implementation of the bitvector abstract
-domain operations from module What4.Utils.BVDomain in what4.
-
-In addition to the algorithms themselves, this file also contains
-specifications of correctness for each of the operations. All of the
-correctness properties can be formally proven (each at some specific
-bit width) by loading this file in cryptol and entering ":prove".
-
+This file gives Cryptol implementations for transferring between
+the various bitvector domain representations and proofs of the
+correctness of these operations.
 */
 
-////////////////////////////////////////////////////////////
-// Library
+module bvdomain where
 
-bit : {i, n} (fin n, n > i) => [n]
-bit = 1 # (0 : [i])
+import arithdomain as A
+import bitsdomain as B
+import xordomain as X
 
-mask : {i, n} (fin n, n >= i) => [n]
-mask = 0 # (~ 0 : [i])
 
-/** Checked unsigned addition, asserted not to overflow. */
-infixl 80 .+.
-(.+.) : {n} (fin n) => [n] -> [n] -> [n]
-x .+. y = if carry x y then error "overflow" else x + y
+// Operations that transfer between the domains
 
-/** Checked unsigned subtraction, asserted not to underflow. */
-infixl 80 .-.
-(.-.) : {n} (fin n) => [n] -> [n] -> [n]
-x .-. y = if x < y then error "underflow" else x - y
-
-/** Minimum of two signed values. */
-smin : {a} (SignedCmp a) => a -> a -> a
-smin x y = if x <$ y then x else y
-
-/** Maximum of two signed values. */
-smax : {a} (SignedCmp a) => a -> a -> a
-smax x y = if x >$ y then x else y
-
-////////////////////////////////////////////////////////////
-
-type BVDom n = { lo : [n], sz : [n] }
-
-interval : {n} (fin n) => [n] -> [n] -> BVDom n
-interval l s = { lo = l, sz = s }
-
-range : {n} (fin n) => [n] -> [n] -> BVDom n
-range lo hi = interval lo (hi - lo)
-
-/** Membership predicate that defines the set of concrete values
-represented by an abstract domain element. */
-mem : {n} (fin n) => BVDom n -> [n] -> Bit
-mem a x = x - a.lo <= a.sz
-
-umem : {n} (fin n) => ([n], [n]) -> [n] -> Bit
-umem (lo, hi) x = lo <= x /\ x <= hi
-
-smem : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> Bit
-smem (lo, hi) x = lo <=$ x /\ x <=$ hi
-
-top : {n} (fin n) => BVDom n
-top = interval 0 (~ 0)
-
-singleton : {n} (fin n) => [n] -> BVDom n
-singleton x = interval x 0
-
-ubounds : {n} (fin n) => BVDom n -> ([n], [n])
-ubounds a =
-  if carry a.lo a.sz then (0, ~0) else (a.lo, a.lo + a.sz)
-
-sbounds : {n} (fin n, n >= 1) => BVDom n -> ([n], [n])
-sbounds a = (lo - delta, hi - delta)
+arithToBitDom : {n} (fin n, n >= 1) => A::Dom n -> B::Dom n
+arithToBitDom a = { lomask = lo, himask = hi }
   where
-    delta = reverse 1
-    (lo, hi) = ubounds (interval (a.lo + delta) a.sz)
+  u  = A::unknowns a
+  hi = a.lo || u
+  lo = hi ^ u
 
-/** Nonzero signed values in a domain with the least and greatest
-reciprocals. Note that this coincides with the greatest and least
-nonzero values using the unsigned ordering. */
-rbounds : {n} (fin n, n >= 1) => BVDom n -> ([n], [n])
-rbounds a =
-  if a.lo == 0 then (a_hi, 1) else
-  if a_hi == 0 then (-1, a.lo) else
-  if a_hi < a.lo then (-1, 1) else
-  (a_hi, a.lo)
-  where a_hi = a.lo + a.sz
+bitToArithDom : {n} (fin n) => B::Dom n -> A::Dom n
+bitToArithDom b = A::range b.lomask b.himask
 
-overlap : {n} (fin n) => BVDom n -> BVDom n -> Bit
-overlap a b = diff <= b.sz \/ carry diff a.sz
-  where diff = a.lo - b.lo
+bitToXorDom : {n} (fin n) => B::Dom n -> X::Dom n
+bitToXorDom b = { val = b.himask, unknown = b.lomask ^ b.himask }
 
-// To compute the union of two intervals, we choose representatives of
-// the endpoints modulo 2^n such that their midpoints are no more than
-// 2^(n-1) apart. In the code below, am and bm are equal to twice the
-// midpoints of intervals a and b, respectively.
-union : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-union a b =
-  if cw >= size then top else interval (drop`{2} cl) (drop`{2} cw)
+xorToBitDom : {n} (fin n) => X::Dom n -> B::Dom n
+xorToBitDom x = { lomask = x.val ^ x.unknown, himask = x.val }
+
+arithToXorDom : {n} (fin n, n >= 1) => A::Dom n -> X::Dom n
+arithToXorDom a = { val = a.lo || u, unknown = u }
   where
-    size : [n+2]
-    size = bit`{n}
-    am = 2 * zext a.lo .+. zext a.sz
-    bm = 2 * zext b.lo .+. zext b.sz
-    al' = if am .+. size < bm then zext a.lo .+. size else zext a.lo
-    bl' = if bm .+. size < am then zext b.lo .+. size else zext b.lo
-    ah' = al' .+. zext a.sz
-    bh' = bl' .+. zext b.sz
-    cl = min al' bl'
-    ch = max ah' bh'
-    cw = ch .-. cl
+  u = A::unknowns a
 
-////////////////////////////////////////////////////////////
+// A small collection of operations that start in one
+// domain and end in the other
 
-zero_ext : {m, n} (fin m, m >= n) => BVDom n -> BVDom m
-zero_ext a = interval (zext lo) (zext (hi .-. lo))
-  where (lo, hi) = ubounds a
+popcount : {n} (fin n, n>=1) => [n] -> [n]
+popcount bs = sum [ zero#[b] | b <- bs ]
 
-sign_ext : {m, n} (fin m, m >= n, n >= 1) => BVDom n -> BVDom m
-sign_ext a = interval (sext lo) (zext (hi - lo))
-  where (lo, hi) = sbounds a
+countLeadingZeros : {n} (fin n, n>=1) => [n] -> [n]
+countLeadingZeros x = loop 0
+ where
+ loop n =
+   if n >= length x then
+     length x
+   else
+     if x@n then n else loop (n+1)
 
-concat : {m, n} (fin m, fin n) => BVDom m -> BVDom n -> BVDom (m + n)
-concat a b = interval (a.lo # lo) (a.sz # sz)
+countTrailingZeros : {n} (fin n, n>=1) => [n] -> [n]
+countTrailingZeros xs = countLeadingZeros (reverse xs)
+
+
+
+popcnt : {n} (fin n, n>=1) => B::Dom n -> A::Dom n
+popcnt b = A::range lo hi
   where
-    (lo, hi) = ubounds b
-    sz = hi .-. lo
-
-shrink : {m, n} (fin m, fin n) => BVDom (m + n) -> BVDom m
-shrink a =
-  if b_sz >= size then top
-  else interval (tail b_lo) (tail b_sz)
-  where
-    size : [1 + m]
-    size = bit`{m}
-    b_lo, b_hi, b_sz : [1 + m]
-    b_lo = take`{back=n} (zext a.lo)
-    b_hi = take`{back=n} (zext a.lo .+. zext a.sz)
-    b_sz = b_hi .-. b_lo
-
-trunc : {m, n} (fin m, fin n) => BVDom (m + n) -> BVDom n
-trunc a =
-  if a.sz > mask`{n} then top
-  else interval (drop`{m} a.lo) (drop`{m} a.sz)
-
-////////////////////////////////////////////////////////////
-// Arithmetic operations
-
-add : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-add a b =
-  if carry a.sz b.sz then top
-  else interval (a.lo + b.lo) (a.sz .+. b.sz)
-
-neg : {n} (fin n) => BVDom n -> BVDom n
-neg a = interval (- (a.lo + a.sz)) a.sz
-
-mul : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-mul a b =
-  if sz >= bit`{n} then top
-  else interval (drop lo) (drop sz)
-  where
-    (lo, hi) = mulRange (zbounds a) (zbounds b)
-    sz = hi - lo
-
-zbounds : {n} (fin n) => BVDom n -> ([1 + n], [1 + n])
-zbounds a = (lo', lo' + zext a.sz)
-  where
-    size : [2 + n]
-    size = bit`{n}
-    lo' = if 2 * zext a.lo .+. zext a.sz >= size then 0b1 # a.lo else 0b0 # a.lo
-
-mulRange : {m, n} (fin m, fin n, m >= 1, n >= 1) => ([m], [m]) -> ([n], [n]) -> ([m+n], [m+n])
-mulRange (xl, xh) (yl, yh) = (zl, zh)
-  where
-    (xlyl, xlyh) = scaleRange xl (yl, yh)
-    (xhyl, xhyh) = scaleRange xh (yl, yh)
-    zl = smin xlyl xhyl
-    zh = smax xlyh xhyh
-
-scaleRange : {m, n} (fin m, fin n, m >= 1, n >= 1) => [m] -> ([n], [n]) -> ([m+n], [m+n])
-scaleRange k (lo, hi) = if k <$ 0 then (hi', lo') else (lo', hi')
-  where
-    lo' = sext k * sext lo
-    hi' = sext k * sext hi
-
-udiv : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> BVDom n
-udiv a b = range cl ch
-  where
-    (al, ah) = ubounds a
-    (bl, bh) = ubounds b
-    bl' = max 1 bl // assume that division by 0 does not happen
-    bh' = max 1 bh // assume that division by 0 does not happen
-    cl = al / bh'
-    ch = ah / bl'
-
-urem : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> BVDom n
-urem a b =
-  if ql == qh then range rl rh
-  else interval 0 (bh - 1)
-  where
-    (al, ah) = ubounds a
-    (bl, bh) = ubounds b
-    bl' = max 1 bl // assume that division by 0 does not happen
-    bh' = max 1 bh
-    (ql, rl) = (al / bh', al % bh')
-    (qh, rh) = (ah / bl', ah % bl')
-
-// The first argument is an ordinary signed interval, but the second
-// argument is a reciprocal interval: The arguments should satisfy 'al
-// <=$ ah' (signed) and '1/bl <= 1/bh' (signed), or equivalently, 'bh
-// <= bl' (unsigned).
-sdivRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> ([1+n], [1+n])
-sdivRange (al, ah) (bl, bh) = (ql, qh)
-  where
-    (ql1, qh1) = shrinkRange (al, ah) bh
-    (ql2, qh2) = shrinkRange (al, ah) bl
-    ql = smin ql1 ql2
-    qh = smax qh1 qh2
-
-// Extra bit of output is to handle the 'INTMIN / -1' overflow case.
-shrinkRange : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> ([1+n], [1+n])
-shrinkRange (lo, hi) k =
-  if k >$ 0 then (lo ./. k, hi ./. k) else
-  if k <$ 0 then (hi ./. k, lo ./. k) else (sext lo, sext hi)
-  where
-    x ./. y = sext x /$ sext y
-
-sdiv : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> BVDom n
-sdiv a b =
-  if sz >= bit`{n} then top
-  else interval (drop lo) (drop sz)
-  where
-    (lo, hi) = sdivRange (sbounds a) (rbounds b)
-    sz = hi - lo
-
-srem : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> BVDom n
-srem a b =
-  if ql == qh then
-    (if ql <$ 0
-     then range (al - drop ql * bl) (ah - drop ql * bh)
-     else range (al - drop ql * bh) (ah - drop ql * bl))
-  else range rl rh
-  where
-    (al, ah) = sbounds a
-    (bl, bh) = sbounds b
-    (ql, qh) = sdivRange (al, ah) (rbounds b)
-    rl = if al <$ 0 then smin (bl+1) (-bh+1) else 0
-    rh = if ah >$ 0 then smax (-bl-1) (bh-1) else 0
-
-////////////////////////////////////////////////////////////
-// Shifts
-
-shl : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-shl a b =
-  if sz > mask`{n} then top
-  else interval (drop lo) (drop sz)
-  where
-    al, ah : [n + 1]
-    (al, ah) = zbounds a
-    bl, bh : [n]
-    (bl, bh) = ubounds b
-    // [n + 2] is enough to avoid signed overflow in shift
-    cl, ch : [n + 2]
-    cl = if bl < `n then 1 << bl else bit`{n}
-    ch = if bh < `n then 1 << bh else bit`{n}
-    (lo, hi) = mulRange (al, ah) (cl, ch)
-    sz = hi - lo
-
-lshr : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-lshr a b = interval cl (ch - cl)
-  where
-    (al, ah) = ubounds a
-    (bl, bh) = ubounds b
-    cl = al >> bh
-    ch = ah >> bl
-
-ashr : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> BVDom n
-ashr a b = interval cl (ch - cl)
-  where
-    (al, ah) = sbounds a
-    (bl, bh) = ubounds b
-    cl = al >>$ (if al <$ 0 then bl else bh)
-    ch = ah >>$ (if ah <$ 0 then bh else bl)
-
-////////////////////////////////////////////////////////////
-// Comparisons
-
-ult : {n} (fin n) => BVDom n -> BVDom n -> Bit
-ult a b = (ubounds a).1 < (ubounds b).0
-
-ule : {n} (fin n) => BVDom n -> BVDom n -> Bit
-ule a b = (ubounds a).1 <= (ubounds b).0
-
-slt : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> Bit
-slt a b = (sbounds a).1 <$ (sbounds b).0
-
-sle : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> Bit
-sle a b = (sbounds a).1 <=$ (sbounds b).0
-
-////////////////////////////////////////////////////////////
-// Bitwise operations
-
-bnot : {n} (fin n) => BVDom n -> BVDom n
-bnot a = interval (~ ah) a.sz
-  where ah = a.lo + a.sz
-
-unknowns : {n} (fin n) => BVDom n -> [n]
-unknowns a =
-  if carry a.lo a.sz then ~0 else bits
-  where bits = tail (scanl (||) False (a.lo ^ (a.lo + a.sz)))
-
-bitbounds : {n} (fin n) => BVDom n -> ([n], [n])
-bitbounds a = (a.lo && ~ u, a.lo || u)
-  where u = unknowns a
-
-bitle : {n} (fin n) => [n] -> [n] -> Bit
-bitle x y = x || y == y
-
-bitmem : {n} (fin n) => ([n], [n]) -> [n] -> Bit
-bitmem (lo, hi) x = bitle lo x /\ bitle x hi
-
-band : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-band a b = interval cl (ch - cl)
-  where
-    (al, ah) = bitbounds a
-    (bl, bh) = bitbounds b
-    (cl, ch) = (al && bl, ah && bh)
-
-bor : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-bor a b = interval cl (ch - cl)
-  where
-    (al, ah) = bitbounds a
-    (bl, bh) = bitbounds b
-    (cl, ch) = (al || bl, ah || bh)
-
-bxor : {n} (fin n) => BVDom n -> BVDom n -> BVDom n
-bxor a b = interval cl cu
-  where
-    au = unknowns a
-    bu = unknowns b
-    cu = au || bu
-    cl = (a.lo ^ b.lo) && ~ cu
-
-///////////////////////////////////////////////////////////
-// Syntax for stating properties
-
-infix 20 =@=
-
-/** Equivalence of bitvector domains. */
-(=@=) : {n} (fin n) => BVDom n -> BVDom n -> Bit
-a =@= b = (a.sz == ~0 /\ b.sz == ~0) \/ (a == b)
-
-infix 5 <==>
-
-(<==>) : Bit -> Bit -> Bit
-(<==>) = (==)
-
-////////////////////////////////////////////////////////////
-// Soundness properties
-
-correct_top : {n} (fin n) => [n] -> Bit
-correct_top x = mem top x
-
-correct_ubounds : {n} (fin n) => BVDom n -> [n] -> Bit
-correct_ubounds a x =
-  mem a x ==> umem (ubounds a) x
-
-correct_sbounds : {n} (fin n, n >= 1) => BVDom n -> [n] -> Bit
-correct_sbounds a x =
-  mem a x ==> smem (sbounds a) x
-
-correct_singleton : {n} (fin n) => [n] -> [n] -> Bit
-correct_singleton x y =
-  mem (singleton x) y <==> x == y
-
-correct_overlap : {n} (fin n) => BVDom n -> BVDom n -> [n] -> Bit
-correct_overlap a b x =
-  mem a x ==> mem b x ==> overlap a b
-
-correct_union : {n} (fin n) => BVDom n -> BVDom n -> [n] -> Bit
-correct_union a b x =
-  (mem a x \/ mem b x) ==> mem (union a b) x
-
-correct_zero_ext : {m, n} (fin m, m >= n) => BVDom n -> [n] -> Bit
-correct_zero_ext a x =
-  mem a x ==> mem (zero_ext`{m} a) (zext`{m} x)
-
-correct_sign_ext : {m, n} (fin m, m >= n, n >= 1) => BVDom n -> [n] -> Bit
-correct_sign_ext a x =
-  mem a x ==> mem (sign_ext`{m} a) (sext`{m} x)
-
-correct_concat : {m, n} (fin m, fin n) => BVDom m -> BVDom n -> [m] -> [n] -> Bit
-correct_concat a b x y =
-  mem a x ==> mem b y ==> mem (concat a b) (x # y)
-
-correct_shrink : {m, n} (fin m, fin n) => BVDom (m + n) -> [m + n] -> Bit
-correct_shrink a x =
-  mem a x ==> mem (shrink`{m} a) (take`{m} x)
-
-correct_trunc : {m, n} (fin m, fin n) => BVDom (m + n) -> [m + n] -> Bit
-correct_trunc a x =
-  mem a x ==> mem (trunc`{m} a) (drop`{m} x)
-
-correct_add : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_add a b x y =
-  mem a x ==> mem b y ==> mem (add a b) (x + y)
-
-correct_neg : {n} (fin n) => BVDom n -> [n] -> Bit
-correct_neg a x =
-  mem a x <==> mem (neg a) (- x)
-
-correct_mul : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_mul a b x y =
-  mem a x ==> mem b y ==> mem (mul a b) (x * y)
-
-correct_mulRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> [n] -> [n] -> Bit
-correct_mulRange a b x y =
-  smem a x ==> smem b y ==> smem (mulRange a b) (sext x * sext y)
-
-correct_udiv : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_udiv a b x y =
-  mem a x ==> mem b y ==> y != 0 ==> mem (udiv a b) (x / y)
-
-correct_urem : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_urem a b x y =
-  mem a x ==> mem b y ==> y != 0 ==> mem (urem a b) (x % y)
-
-correct_sdivRange : {n} (fin n, n >= 1) => ([n], [n]) -> ([n], [n]) -> [n] -> [n] -> Bit
-correct_sdivRange a b x y =
-  smem a x ==> umem b y ==> y != 0 ==> smem (sdivRange a b) (sext x /$ sext y)
-
-correct_shrinkRange : {n} (fin n, n >= 1) => ([n], [n]) -> [n] -> [n] -> Bit
-correct_shrinkRange a x y =
-  smem a x ==> y != 0 ==> smem (shrinkRange a y) (sext x /$ sext y)
-
-correct_sdiv : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_sdiv a b x y =
-  mem a x ==> mem b y ==> y != 0 ==> mem (sdiv a b) (x /$ y)
-
-correct_srem : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_srem a b x y =
-  mem a x ==> mem b y ==> y != 0 ==> mem (srem a b) (x %$ y)
-
-correct_shl : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_shl a b x y =
-  mem a x ==> mem b y ==> mem (shl a b) (x << y)
-
-correct_lshr : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_lshr a b x y =
-  mem a x ==> mem b y ==> mem (lshr a b) (x >> y)
-
-correct_ashr : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_ashr a b x y =
-  mem a x ==> mem b y ==> mem (ashr a b) (x >>$ y)
-
-correct_slt : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_slt a b x y =
-  slt a b ==> mem a x ==> mem b y ==> x <$ y
-
-correct_sle : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_sle a b x y =
-  sle a b ==> mem a x ==> mem b y ==> x <=$ y
-
-correct_ult : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_ult a b x y =
-  ult a b ==> mem a x ==> mem b y ==> x < y
-
-correct_ule : {n} (fin n, n >= 1) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_ule a b x y =
-  ule a b ==> mem a x ==> mem b y ==> x <= y
-
-correct_bitbounds : {n} (fin n) => BVDom n -> [n] -> Bit
-correct_bitbounds a x =
-  mem a x ==> bitmem (bitbounds a) x
-
-correct_bnot : {n} (fin n) => BVDom n -> [n] -> Bit
-correct_bnot a x =
-  mem a x ==> mem (bnot a) (~ x)
-
-correct_band : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_band a b x y =
-  mem a x ==> mem b y ==> mem (band a b) (x && y)
-
-correct_bor : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_bor a b x y =
-  mem a x ==> mem b y ==> mem (bor a b) (x || y)
-
-correct_bxor : {n} (fin n) => BVDom n -> BVDom n -> [n] -> [n] -> Bit
-correct_bxor a b x y =
-  mem a x ==> mem b y ==> mem (bxor a b) (x ^ y)
-
-property p1 = correct_top`{16}
-property p2 = correct_ubounds`{16}
-property p3 = correct_sbounds`{16}
-property p4 = correct_singleton`{16}
-property p5 = correct_overlap`{16}
-property p6 = correct_union`{8}
-property p7 = correct_zero_ext`{32, 16}
-property p8 = correct_sign_ext`{32, 16}
-property p9 = correct_concat`{16, 16}
-property p10 = correct_shrink`{8, 8}
-property p11 = correct_trunc`{8, 8}
-
-property a1 = correct_add`{8}
-property a2 = correct_neg`{16}
-property a3 = correct_mul`{4}
-property a4 = correct_udiv`{8}
-property a5 = correct_urem`{6}
-property a6 = correct_sdiv`{6}
-property a7 = correct_srem`{6}
-
-property s1 = correct_shl`{8}
-property s2 = correct_lshr`{8}
-property s3 = correct_ashr`{8}
-
-property o1 = correct_slt`{16}
-property o2 = correct_sle`{16}
-property o3 = correct_ult`{16}
-property o4 = correct_ule`{16}
-
-property l1 = correct_bitbounds`{16}
-property l2 = correct_bnot`{16}
-property l3 = correct_band`{16}
-property l4 = correct_bor`{16}
-property l5 = correct_bxor`{16}
-
-////////////////////////////////////////////////////////////
-// Operations preserve singletons
-
-singleton_overlap : {n} (fin n) => [n] -> [n] -> Bit
-singleton_overlap x y =
-  overlap (singleton x) (singleton y) == (x == y)
-
-singleton_zero_ext : {m, n} (fin m, m >= n) => [n] -> Bit
-singleton_zero_ext x =
-  zero_ext`{m} (singleton x) == singleton (zext`{m} x)
-
-singleton_sign_ext : {m, n} (fin m, m >= n, n >= 1) => [n] -> Bit
-singleton_sign_ext x =
-  sign_ext`{m} (singleton x) == singleton (sext`{m} x)
-
-singleton_concat : {m, n} (fin m, fin n) => [m] -> [n] -> Bit
-singleton_concat x y =
-  concat (singleton x) (singleton y) == singleton (x # y)
-
-singleton_shrink : {m, n} (fin m, fin n) => [m + n] -> Bit
-singleton_shrink x =
-  shrink`{m} (singleton x) == singleton (take`{m} x)
-
-singleton_trunc : {m, n} (fin m, fin n) => [m + n] -> Bit
-singleton_trunc x =
-  trunc`{m} (singleton x) == singleton (drop`{m} x)
-
-singleton_add : {n} (fin n) => [n] -> [n] -> Bit
-singleton_add x y =
-  add (singleton x) (singleton y) == singleton (x + y)
-
-singleton_neg : {n} (fin n) => [n] -> Bit
-singleton_neg x =
-  neg (singleton x) == singleton (- x)
-
-singleton_mul : {n} (fin n) => [n] -> [n] -> Bit
-singleton_mul x y =
-  mul (singleton x) (singleton y) == singleton (x * y)
-
-singleton_mulRange : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_mulRange x y =
-  mulRange (x, x) (y, y) == (sext x * sext y, sext x * sext y)
-
-singleton_udiv : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_udiv x y =
-  y != 0 ==> udiv (singleton x) (singleton y) == singleton (x / y)
-
-singleton_urem : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_urem x y =
-  y != 0 ==> urem (singleton x) (singleton y) == singleton (x % y)
-
-singleton_sdiv : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_sdiv x y =
-  y != 0 ==> sdiv (singleton x) (singleton y) == singleton (x /$ y)
-
-singleton_srem : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_srem x y =
-  y != 0 ==> srem (singleton x) (singleton y) == singleton (x %$ y)
-
-singleton_shl : {n} (fin n) => [n] -> [n] -> Bit
-singleton_shl x y =
-  shl (singleton x) (singleton y) == singleton (x << y)
-
-singleton_lshr : {n} (fin n) => [n] -> [n] -> Bit
-singleton_lshr x y =
-  lshr (singleton x) (singleton y) == singleton (x >> y)
-
-singleton_ashr : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_ashr x y =
-  ashr (singleton x) (singleton y) == singleton (x >>$ y)
-
-singleton_slt : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_slt x y =
-  slt (singleton x) (singleton y) == (x <$ y)
-
-singleton_sle : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_sle x y =
-  sle (singleton x) (singleton y) == (x <=$ y)
-
-singleton_ult : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_ult x y =
-  ult (singleton x) (singleton y) == (x < y)
-
-singleton_ule : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-singleton_ule x y =
-  ule (singleton x) (singleton y) == (x <= y)
-
-singleton_bnot : {n} (fin n) => [n] -> Bit
-singleton_bnot x =
-  bnot (singleton x) == singleton (~ x)
-
-singleton_band : {n} (fin n) => [n] -> [n] -> Bit
-singleton_band x y =
-  band (singleton x) (singleton y) == singleton (x && y)
-
-singleton_bor : {n} (fin n) => [n] -> [n] -> Bit
-singleton_bor x y =
-  bor (singleton x) (singleton y) == singleton (x || y)
-
-singleton_bxor : {n} (fin n) => [n] -> [n] -> Bit
-singleton_bxor x y =
-  bxor (singleton x) (singleton y) == singleton (x ^ y)
-
-property i01 = singleton_overlap`{16}
-property i02 = singleton_zero_ext`{32, 16}
-property i03 = singleton_sign_ext`{32, 16}
-property i04 = singleton_concat`{16, 16}
-property i05 = singleton_shrink`{8, 8}
-property i06 = singleton_trunc`{8, 8}
-property i07 = singleton_add`{8}
-property i08 = singleton_neg`{16}
-property i09 = singleton_mul`{4}
-property i10 = singleton_udiv`{8}
-property i11 = singleton_urem`{8}
-property i12 = singleton_sdiv`{8}
-property i13 = singleton_srem`{8}
-property i14 = singleton_shl`{8}
-property i15 = singleton_lshr`{8}
-property i16 = singleton_ashr`{8}
-property i17 = singleton_slt`{16}
-property i18 = singleton_sle`{16}
-property i19 = singleton_ult`{16}
-property i20 = singleton_ule`{16}
-property i21 = singleton_bnot`{16}
-property i22 = singleton_band`{16}
-property i23 = singleton_bor`{16}
-property i24 = singleton_bxor`{16}
-
-////////////////////////////////////////////////////////////
-// Associativity/commutativity properties
-
-comm_overlap : {n} (fin n) => BVDom n -> BVDom n -> Bit
-comm_overlap a b = overlap a b <==> overlap b a
-
-comm_add : {n} (fin n) => BVDom n -> BVDom n -> Bit
-comm_add a b = add a b == add b a
-
-assoc_add : {n} (fin n) => BVDom n -> BVDom n -> BVDom n -> Bit
-assoc_add a b c = add a (add b c) =@= add (add a b) c
-
-comm_mul : {n} (fin n) => BVDom n -> BVDom n -> Bit
-comm_mul a b = mul a b == mul b a
-
-/* mul is not associative! */
-assoc_mul : {n} (fin n) => BVDom n -> BVDom n -> BVDom n -> Bit
-assoc_mul a b c = mul a (mul b c) =@= mul (mul a b) c
-
-comm_mulRange :
-  {i, j} (fin i, fin j, i >= 1, j >= 1) => ([i], [i]) -> ([j], [j]) -> Bit
-comm_mulRange a b =
-  a.0 <=$ a.1 ==> b.0 <=$ b.1 ==> mulRange a b == mulRange b a
-
-assoc_mulRange :
-  {i, j, k} (fin i, fin j, fin k, i >= 1, j >= 1, k >= 1) =>
-  ([i], [i]) -> ([j], [j]) -> ([k], [k]) -> Bit
-assoc_mulRange a b c =
-  a.0 <=$ a.1 ==>
-  b.0 <=$ b.1 ==>
-  c.0 <=$ c.1 ==>
-  mulRange a (mulRange b c) == mulRange (mulRange a b) c
-
-property c1 = comm_overlap`{16}
-property c2 = comm_add`{16}
-property c3 = assoc_add`{16}
-property c4 = comm_mul`{4}
-property c5 = comm_mulRange`{4,4}
-property c6 = assoc_mulRange`{3,3,3}
-
-////////////////////////////////////////////////////////////
-// Additional properties about union
-
-comm_union : {n} (fin n) => BVDom n -> BVDom n -> Bit
-comm_union a b = union a b == union b a
-
-/* union is actually not associative! */
-assoc_union : {n} (fin n) => BVDom n -> BVDom n -> BVDom n -> Bit
-assoc_union a b c = union a (union b c) == union (union a b) c
-
-/* union always has a lower bound equal to one of the input lower bounds */
-lo_union : {n} (fin n) => BVDom n -> BVDom n -> Bit
-lo_union a b =
-  union a b == top \/ (union a b).lo == a.lo \/ (union a b).lo == b.lo
-
-/* union always has an upper bound equal to one of the input upper bounds */
-hi_union : {n} (fin n) => BVDom n -> BVDom n -> Bit
-hi_union a b = c == top \/ c_hi == a_hi \/ c_hi == b_hi
-  where
-    c = union a b
-    a_hi = a.lo + a.sz
-    b_hi = b.lo + b.sz
-    c_hi = c.lo + c.sz
-
-/* union doesn't return top unless necessary */
-nontriv_union : {n} (fin n) => BVDom n -> BVDom n -> [n] -> Bit
-nontriv_union a b x =
-  union a b =@= top ==> mem a x \/ mem b x
-
-/* union of opposite intervals prefers to exclude zero */
-nonzero_union : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
-nonzero_union lo sz =
-  mem (union a b) half /\
-  (~ mem a 0 ==> ~ mem b 0 ==> ~ mem (union a b) 0)
-  where
-    half : [n]
-    half = reverse 1
-    a = interval lo sz
-    b = interval (lo + half) sz
-
-property u1 = comm_union`{16}
-property u2 = lo_union`{16}
-property u3 = hi_union`{16}
-property u4 = nontriv_union`{8}
-property u5 = nonzero_union`{16}
+  lo = popcount b.lomask
+  hi = popcount b.himask
+
+clz : {n} (fin n, n>=1) => B::Dom n -> A::Dom n
+clz b = A::range lo hi
+ where
+ lo = countLeadingZeros b.himask
+ hi = countLeadingZeros b.lomask
+
+ctz : {n} (fin n, n>=1) => B::Dom n -> A::Dom n
+ctz b = A::range lo hi
+ where
+ lo = countTrailingZeros b.himask
+ hi = countTrailingZeros b.lomask
+
+
+//////////////////////////////////////////////////////////////
+// Correctness properties
+
+correct_arithToBitDom : {n} (fin n, n >= 1) => A::Dom n -> [n] -> Bit
+correct_arithToBitDom a x =
+  A::mem a x ==> B::mem (arithToBitDom a) x
+
+correct_bitToArithDom : {n} (fin n) => B::Dom n -> [n] -> Bit
+correct_bitToArithDom b x =
+  B::mem b x ==> A::mem (bitToArithDom b) x
+
+correct_bitToXorDom : {n} (fin n) => B::Dom n -> [n] -> Bit
+correct_bitToXorDom b x =
+  B::mem b x == X::mem (bitToXorDom b) x
+
+correct_xorToBitDom : {n} (fin n) => X::Dom n -> [n] -> Bit
+correct_xorToBitDom b x =
+  X::mem b x == B::mem (xorToBitDom b) x
+
+correct_arithToXorDom : {n} (fin n, n >= 1) => A::Dom n -> [n] -> Bit
+correct_arithToXorDom a x =
+  A::mem a x ==> X::mem (arithToXorDom a) x
+
+property t1 = correct_arithToBitDom`{16}
+property t2 = correct_bitToArithDom`{16}
+property t3 = correct_bitToXorDom`{16}
+property t4 = correct_xorToBitDom`{16}
+property t5 = correct_arithToXorDom`{16}
+
+correct_popcnt : {n} (fin n, n>=1) => B::Dom n -> [n] -> Bit
+correct_popcnt a x =
+  B::mem a x ==> A::mem (popcnt a) (popcount x)
+
+correct_clz : {n} (fin n, n>=1) => B::Dom n -> [n] -> Bit
+correct_clz a x =
+  B::mem a x ==> A::mem (clz a) (countLeadingZeros x)
+
+correct_ctz : {n} (fin n, n>=1) => B::Dom n -> [n] -> Bit
+correct_ctz a x =
+  B::mem a x ==> A::mem (ctz a) (countTrailingZeros x)
+
+property w1 = correct_popcnt`{16}
+property w2 = correct_clz`{16}
+property w3 = correct_ctz`{16}
+
+////////////////////////////////////////////////////////////////
+// Proofs that the XOR domain is really just an alternate way
+// to compute the same thing as the bitsdomain operations.
+// For "band" this requires the input domains to be nonempty,
+// which should be the case for all actual values of interest.
+
+equiv_bxor : {n} (fin n) => B::Dom n -> B::Dom n -> Bit
+equiv_bxor a b =
+  B::bxor a b == xorToBitDom (X::bxor (bitToXorDom a) (bitToXorDom b))
+
+equiv_band : {n} (fin n) => B::Dom n -> B::Dom n -> Bit
+equiv_band a b =
+  B::nonempty a /\ B::nonempty b ==>
+  B::band a b == xorToBitDom (X::band (bitToXorDom a) (bitToXorDom b))
+
+equiv_band_scalar : {n} (fin n) => B::Dom n -> [n] -> Bit
+equiv_band_scalar a x =
+  B::band a (B::singleton x) == xorToBitDom (X::band_scalar (bitToXorDom a) x)
+
+
+property e1 = equiv_bxor`{16}
+property e2 = equiv_band`{16}
+property e3 = equiv_band_scalar`{16}

--- a/what4/doc/xordomain.cry
+++ b/what4/doc/xordomain.cry
@@ -1,0 +1,53 @@
+/*
+This file contains a Cryptol implementation of a specialzed bitwise
+abstract domain that is optimized for the XOR/AND semiring representation.
+The standard bitwise domain from "bitsdomain.cry" requires 6 bitwise
+operations to compute XOR, whereas AND and OR only requre 2.
+In this domain, XOR and AND both can be computed in 3 bitwise operations,
+and scalar AND can be computed in 2.
+*/
+
+module xordomain where
+
+// In this presentation "val" is a bitwise upper bound on
+// the values in the set, and "unknown" represents all the
+// bits whose values are not concretely known
+type Dom n = { val : [n], unknown : [n] }
+
+// Membership predicate for the XOR bitwise domain
+mem : {n} (fin n) => Dom n -> [n] -> Bit
+mem a x = a.val == x || a.unknown
+
+bxor : {n} (fin n) => Dom n -> Dom n -> Dom n
+bxor a b = { val = v || u, unknown = u }
+  where
+  v = a.val ^ b.val
+  u = a.unknown || b.unknown
+
+band : {n} (fin n) => Dom n -> Dom n -> Dom n
+band a b = { val = v, unknown = u && v }
+  where
+  v   = a.val && b.val
+  u   = a.unknown || b.unknown
+
+band_scalar : {n} (fin n) => Dom n -> [n] -> Dom n
+band_scalar a x = { val = a.val && x, unknown = a.unknown && x }
+
+////////////////////////////////////////////////////////////
+// Soundness properties
+
+correct_bxor : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_bxor a b x y =
+  mem a x ==> mem b y ==> mem (bxor a b) (x ^ y)
+
+correct_band : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_band a b x y =
+  mem a x ==> mem b y ==> mem (band a b) (x && y)
+
+correct_band_scalar : {n} (fin n) => Dom n -> [n] -> [n] -> Bit
+correct_band_scalar a x y =
+  mem a x ==> mem (band_scalar a y) (x && y)
+
+property x1 = correct_bxor`{16}
+property x2 = correct_band`{16}
+property x3 = correct_band_scalar`{16}

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -1591,16 +1591,15 @@ abstractEval f a0 = do
     BVShl  w x y -> BVD.shl w (f x) (f y)
     BVLshr w x y -> BVD.lshr w (f x) (f y)
     BVAshr w x y -> BVD.ashr w (f x) (f y)
-    BVRol  w _ _ -> BVD.any w -- TODO?
-    BVRor  w _ _ -> BVD.any w -- TODO?
+    BVRol  w x y -> BVD.rol w (f x) (f y)
+    BVRor  w x y -> BVD.ror w (f x) (f y)
     BVZext w x   -> BVD.zext (f x) w
     BVSext w x   -> BVD.sext (bvWidth x) (f x) w
     BVFill w _   -> BVD.range w (-1) 0
 
-    -- TODO: pretty sure we can do better for popcount, ctz and clz
-    BVPopcount w _ -> BVD.range w 0 (intValue w)
-    BVCountLeadingZeros w _ -> BVD.range w 0 (intValue w)
-    BVCountTrailingZeros w _ -> BVD.range w 0 (intValue w)
+    BVPopcount w x -> BVD.popcnt w (f x)
+    BVCountLeadingZeros w x -> BVD.clz w (f x)
+    BVCountTrailingZeros w x -> BVD.ctz w (f x)
 
     FloatPZero{} -> ()
     FloatNZero{} -> ()

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -1585,8 +1585,8 @@ abstractEval f a0 = do
     BVSdiv w x y -> BVD.sdiv w (f x) (f y)
     BVSrem w x y -> BVD.srem w (f x) (f y)
 
-    BVShl  _ x y -> BVD.shl (f x) (f y)
-    BVLshr _ x y -> BVD.lshr (f x) (f y)
+    BVShl  w x y -> BVD.shl w (f x) (f y)
+    BVLshr w x y -> BVD.lshr w (f x) (f y)
     BVAshr w x y -> BVD.ashr w (f x) (f y)
     BVRol  w _ _ -> BVD.any w -- TODO?
     BVRor  w _ _ -> BVD.any w -- TODO?

--- a/what4/src/What4/Utils/Arithmetic.hs
+++ b/what4/src/What4/Utils/Arithmetic.hs
@@ -43,7 +43,9 @@ lg i0 | i0 > 0 = go 0 (i0 `shiftR` 1)
         go r n = go (r+1) (n `shiftR` 1)
 
 -- | Returns ceil of log base 2.
+--   We define @lgCeil 0 = 0@
 lgCeil :: (Bits a, Num a, Ord a) => a -> Int
+lgCeil 0 = 0
 lgCeil 1 = 0
 lgCeil i | i > 1 = 1 + lg (i-1)
          | otherwise = error "lgCeil given number that is not positive."

--- a/what4/src/What4/Utils/BVDomain.hs
+++ b/what4/src/What4/Utils/BVDomain.hs
@@ -13,19 +13,24 @@ domains.
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module What4.Utils.BVDomain
-  ( BVDomain
+  ( BVDomain(..)
+  , asArithDomain
+  , asBitwiseDomain
+  , member
     -- * Projection functions
   , asSingleton
-  , ubounds
-  , sbounds
   , eq
   , slt
   , ult
   , testBit
   , domainsOverlap
-  , ranges
+  , ubounds
+  , sbounds
+  , A.arithDomainData
+  , B.bitbounds
     -- * Operations
   , any
   , singleton
@@ -54,6 +59,42 @@ module What4.Utils.BVDomain
   , and
   , or
   , xor
+
+    -- * Correctness properties
+  , genDomain
+  , genElement
+  , genPair
+
+  , correct_arithToBitwise
+  , correct_bitwiseToArith
+  , correct_any
+  , correct_ubounds
+  , correct_sbounds
+  , correct_singleton
+  , correct_overlap
+  , correct_union
+  , correct_zero_ext
+  , correct_sign_ext
+  , correct_concat
+  , correct_select
+  , correct_add
+  , correct_neg
+  , correct_mul
+  , correct_udiv
+  , correct_urem
+  , correct_sdiv
+  , correct_srem
+  , correct_shl
+  , correct_lshr
+  , correct_ashr
+  , correct_eq
+  , correct_ult
+  , correct_slt
+  , correct_and
+  , correct_or
+  , correct_not
+  , correct_xor
+  , correct_testBit
   ) where
 
 import qualified Data.Bits as Bits
@@ -63,99 +104,92 @@ import           Numeric.Natural
 import           GHC.TypeNats
 import           GHC.Stack
 
-import           Prelude hiding (any, concat, negate, and, or)
+import qualified Prelude
+import           Prelude hiding (any, concat, negate, and, or, not)
+
+import qualified What4.Utils.BVDomain.Arith as A
+import qualified What4.Utils.BVDomain.Bitwise as B
+
+import           Test.QuickCheck (Property, property, (==>), Gen, counterexample, arbitrary)
+
+
+arithToBitwiseDomain :: A.Domain w -> B.Domain w
+arithToBitwiseDomain a =
+  let mask = A.bvdMask a in
+  case A.arithDomainData a of
+    Nothing -> B.interval mask 0 mask
+    Just (alo,_) -> B.interval mask lo hi
+      where
+        u = A.unknowns a
+        hi = alo .|. u
+        lo = hi `Bits.xor` u
+
+bitwiseToArithDomain :: B.Domain w -> A.Domain w
+bitwiseToArithDomain b = A.interval mask lo ((hi - lo) .&. mask)
+  where
+  mask = B.bvdMask b
+  (lo,hi) = B.bitbounds b
 
 --------------------------------------------------------------------------------
 -- BVDomain definition
 
 -- | A value of type @'BVDomain' w@ represents a set of bitvectors of
--- width @w@. Each 'BVDomain' can represent a single contiguous
--- interval of bitvectors that may wrap around from -1 to 0.
+-- width @w@. A BVDomain represents either an arithmetic interval, or
+-- a bitwise interval.
+
 data BVDomain (w :: Nat)
-  = BVDAny !Integer
-  -- ^ The set of all bitvectors of width @w@. Argument caches @2^w-1@.
-  | BVDInterval !Integer !Integer !Integer
-  -- ^ Intervals are represented by a starting value and a size.
-  -- @BVDInterval mask l d@ represents the set of values of the form
-  -- @x mod 2^w@ for @x@ such that @l <= x <= l + d@. It should
-  -- satisfy the invariants @0 <= l < 2^w@ and @0 <= d < 2^w@. The
-  -- first argument caches the value @2^w-1@.
+  = BVDArith !(A.Domain w)
+  | BVDBitwise !(B.Domain w)
   deriving Show
 
 bvdMask :: BVDomain w -> Integer
 bvdMask x =
   case x of
-    BVDAny mask -> mask
-    BVDInterval mask _ _ -> mask
+    BVDArith a   -> A.bvdMask a
+    BVDBitwise b -> B.bvdMask b
 
---------------------------------------------------------------------------------
+member :: BVDomain w -> Integer -> Bool
+member (BVDArith a) x = A.member a x
+member (BVDBitwise a) x = B.member a x
 
--- | @halfRange n@ returns @2^(n-1)@.
-halfRange :: (1 <= w) => NatRepr w -> Integer
-halfRange w = bit (widthVal w - 1)
+asArithDomain :: BVDomain w -> A.Domain w
+asArithDomain (BVDArith a)   = a
+asArithDomain (BVDBitwise b) = bitwiseToArithDomain b
+
+asBitwiseDomain :: BVDomain w -> B.Domain w
+asBitwiseDomain (BVDArith a)   = arithToBitwiseDomain a
+asBitwiseDomain (BVDBitwise b) = b
+
+genDomain :: NatRepr w -> Gen (BVDomain w)
+genDomain w =
+  do b <- arbitrary
+     if b then
+       BVDArith <$> A.genDomain w
+     else
+       BVDBitwise <$> B.genDomain w
+
+genElement :: BVDomain w -> Gen Integer
+genElement (BVDArith a) = A.genElement a
+genElement (BVDBitwise b) = B.genElement b
+
+genPair :: NatRepr w -> Gen (BVDomain w, Integer)
+genPair w =
+  do a <- genDomain w
+     x <- genElement a
+     return (a,x)
 
 --------------------------------------------------------------------------------
 -- Projection functions
 
--- | Convert domain to list of ranges.
-ranges :: NatRepr w -> BVDomain w -> [(Integer, Integer)]
-ranges _w x =
-  case x of
-    BVDAny mask -> [(0, mask)]
-    BVDInterval mask xl xd
-      | xh > mask -> [(0, xh .&. mask), (xl, mask)]
-      | otherwise -> [(xl, xh)]
-      where xh = xl + xd
-
 -- | Return value if this is a singleton.
 asSingleton :: BVDomain w -> Maybe Integer
-asSingleton x =
-  case x of
-    BVDAny _ -> Nothing
-    BVDInterval _ xl xd
-      | xd == 0 -> Just xl
-      | otherwise -> Nothing
-
-isSingletonZero :: BVDomain w -> Bool
-isSingletonZero x =
-  case x of
-    BVDInterval _ 0 0 -> True
-    _ -> False
-
-isBVDAny :: BVDomain w -> Bool
-isBVDAny x =
-  case x of
-    BVDAny {} -> True
-    BVDInterval {} -> False
-
--- | Return unsigned bounds for domain.
-ubounds :: BVDomain w -> (Integer, Integer)
-ubounds a =
-  case a of
-    BVDAny mask -> (0, mask)
-    BVDInterval mask al aw
-      | ah > mask -> (0, mask)
-      | otherwise -> (al, ah)
-      where ah = al + aw
-
--- | Return signed bounds for domain.
-sbounds :: (1 <= w) => NatRepr w -> BVDomain w -> (Integer, Integer)
-sbounds w a = (lo - delta, hi - delta)
-  where
-    delta = halfRange w
-    (lo, hi) = ubounds (add a (BVDInterval (bvdMask a) delta 0))
+asSingleton (BVDArith a)   = A.asSingleton a
+asSingleton (BVDBitwise b) = B.asSingleton b
 
 -- | Return true if domains contain a common element.
 domainsOverlap :: BVDomain w -> BVDomain w -> Bool
-domainsOverlap a b =
-  case a of
-    BVDAny _ -> True
-    BVDInterval _ al aw ->
-      case b of
-        BVDAny _ -> True
-        BVDInterval mask bl bw ->
-          diff <= bw || diff + aw > mask
-          where diff = (al - bl) .&. mask
+domainsOverlap (BVDBitwise a) (BVDBitwise b) = B.domainsOverlap a b
+domainsOverlap (asArithDomain -> a) (asArithDomain -> b) = A.domainsOverlap a b
 
 eq :: BVDomain w -> BVDomain w -> Maybe Bool
 eq a b
@@ -166,23 +200,11 @@ eq a b
 
 -- | Check if all elements in one domain are less than all elements in other.
 slt :: (1 <= w) => NatRepr w -> BVDomain w -> BVDomain w -> Maybe Bool
-slt w a b
-  | a_max < b_min = Just True
-  | a_min >= b_max = Just False
-  | otherwise = Nothing
-  where
-    (a_min, a_max) = sbounds w a
-    (b_min, b_max) = sbounds w b
+slt w a b = A.slt w (asArithDomain a) (asArithDomain b)
 
 -- | Check if all elements in one domain are less than all elements in other.
 ult :: (1 <= w) => BVDomain w -> BVDomain w -> Maybe Bool
-ult a b
-  | a_max < b_min = Just True
-  | a_min >= b_max = Just False
-  | otherwise = Nothing
-  where
-    (a_min, a_max) = ubounds a
-    (b_min, b_max) = ubounds b
+ult a b = A.ult (asArithDomain a) (asArithDomain b)
 
 -- | Return @Just@ if every bitvector in the domain has the same bit
 -- at the given index.
@@ -191,121 +213,47 @@ testBit ::
   BVDomain w ->
   Natural {- ^ Index of bit (least-significant bit has index 0) -} ->
   Maybe Bool
-testBit w a i =
-  if i >= natValue w then Nothing else
-  case a of
-    BVDAny _ -> Nothing
-    BVDInterval _ al aw
-      | (al `shiftR` j) == (ah `shiftR` j) ->
-        Just (al `Bits.testBit` j)
-      | otherwise ->
-        Nothing
-      where
-        j = fromIntegral i
-        ah = al + aw
+testBit _w a i = B.testBit (asBitwiseDomain a) i
+
+ubounds :: BVDomain w -> (Integer, Integer)
+ubounds a = A.ubounds (asArithDomain a)
+
+sbounds :: (1 <= w) => NatRepr w -> BVDomain w -> (Integer, Integer)
+sbounds w a = A.sbounds w (asArithDomain a)
 
 --------------------------------------------------------------------------------
 -- Operations
 
 -- | Represents all values
 any :: (1 <= w) => NatRepr w -> BVDomain w
-any w = BVDAny (maxUnsigned w)
+any w = BVDBitwise (B.any w)
 
 -- | Create a bitvector domain representing the integer.
 singleton :: (HasCallStack, 1 <= w) => NatRepr w -> Integer -> BVDomain w
-singleton w x = BVDInterval mask (x .&. mask) 0
-  where mask = maxUnsigned w
+singleton w x = BVDBitwise (B.singleton w x)
 
 -- | @range w l u@ returns domain containing all bitvectors formed
 -- from the @w@ low order bits of some @i@ in @[l,u]@.  Note that per
 -- @testBit@, the least significant bit has index @0@.
 range :: NatRepr w -> Integer -> Integer -> BVDomain w
-range w al ah = interval mask al ((ah - al) .&. mask)
-  where mask = maxUnsigned w
-
--- | Unsafe constructor for internal use only. Caller must ensure that
--- @mask = maxUnsigned w@, and that @aw@ is non-negative.
-interval :: Integer -> Integer -> Integer -> BVDomain w
-interval mask al aw =
-  if aw >= mask then BVDAny mask else BVDInterval mask (al .&. mask) aw
+range w al ah = BVDArith (A.range w al ah)
 
 -- | Create an abstract domain from an ascending list of elements.
 -- The elements are assumed to be distinct.
 fromAscEltList :: (1 <= w) => NatRepr w -> [Integer] -> BVDomain w
-fromAscEltList w [] = singleton w 0
-fromAscEltList w [x] = singleton w x
-fromAscEltList w (x0 : x1 : xs) = go (x0, x0) (x1, x1) xs
-  where
-    -- Invariant: the gap between @b@ and @c@ is the biggest we've
-    -- seen between adjacent values so far.
-    go (a, b) (c, d) [] = union (range w a b) (range w c d)
-    go (a, b) (c, d) (e : rest)
-      | e - d > c - b = go (a, d) (e, e) rest
-      | otherwise     = go (a, b) (c, e) rest
+fromAscEltList w xs = BVDArith (A.fromAscEltList w xs)
 
 -- | Return union of two domains.
 union :: (1 <= w) => BVDomain w -> BVDomain w -> BVDomain w
-union a b =
-  case a of
-    BVDAny _ -> a
-    BVDInterval _ al aw ->
-      case b of
-        BVDAny _ -> b
-        BVDInterval mask bl bw ->
-          interval mask cl (ch - cl)
-          where
-            size = mask + 1
-            ac = 2 * al + aw -- twice the average value of a
-            bc = 2 * bl + bw -- twice the average value of b
-            -- If the averages are 2^(w-1) or more apart,
-            -- then shift the lower interval up by 2^w.
-            al' = if ac + mask < bc then al + size else al
-            bl' = if bc + mask < ac then bl + size else bl
-            ah' = al' + aw
-            bh' = bl' + bw
-            cl = min al' bl'
-            ch = max ah' bh'
+union (BVDBitwise a) (BVDBitwise b) = BVDBitwise (B.union a b)
+union (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.union a b)
 
 -- | @concat a y@ returns domain where each element in @a@ has been
 -- concatenated with an element in @y@.  The most-significant bits
 -- are @a@, and the least significant bits are @y@.
 concat :: NatRepr u -> BVDomain u -> NatRepr v -> BVDomain v -> BVDomain (u + v)
-concat u a v b =
-  case a of
-    BVDAny _ -> BVDAny mask
-    BVDInterval _ al aw -> interval mask (cat al bl) (cat aw bw)
-  where
-    cat i j = i `shiftL` widthVal v + j
-    mask = maxUnsigned (addNat u v)
-    (bl, bh) = ubounds b
-    bw = bh - bl
-
--- | @shrink i a@ drops the @i@ least significant bits from @a@.
-shrink ::
-  NatRepr i ->
-  BVDomain (i + n) -> BVDomain n
-shrink i a =
-  case a of
-    BVDAny mask -> BVDAny (shr mask)
-    BVDInterval mask al aw ->
-      interval (shr mask) bl (bh - bl)
-      where
-        bl = shr al
-        bh = shr (al + aw)
-  where
-    shr x = x `shiftR` widthVal i
-
--- | @trunc n d@ selects the @n@ least significant bits from @d@.
-trunc ::
-  (n <= w) =>
-  NatRepr n ->
-  BVDomain w -> BVDomain n
-trunc n a =
-  case a of
-    BVDAny _ -> BVDAny mask
-    BVDInterval _ al aw -> interval mask al aw
-  where
-    mask = maxUnsigned n
+concat u (BVDBitwise a) v (BVDBitwise b) = BVDBitwise (B.concat u a v b)
+concat u (asArithDomain -> a) v (asArithDomain -> b) = BVDArith (A.concat u a v b)
 
 -- | @select i n a@ selects @n@ bits starting from index @i@ from @a@.
 select ::
@@ -313,11 +261,12 @@ select ::
   NatRepr i ->
   NatRepr n ->
   BVDomain w -> BVDomain n
-select i n a = shrink i (trunc (addNat i n) a)
+select i n (BVDArith a)   = BVDArith (A.select i n a)
+select i n (BVDBitwise b) = BVDBitwise (B.select i n b)
 
 zext :: (1 <= w, w+1 <= u) => BVDomain w -> NatRepr u -> BVDomain u
-zext a u = range u al ah
-  where (al, ah) = ubounds a
+zext (BVDArith a) u   = BVDArith (A.zext a u)
+zext (BVDBitwise b) u = BVDBitwise (B.zext b u)
 
 sext ::
   forall w u. (1 <= w, w + 1 <= u) =>
@@ -325,278 +274,240 @@ sext ::
   BVDomain w ->
   NatRepr u ->
   BVDomain u
-sext w a u =
-  case fProof of
-    LeqProof ->
-      range u al ah
-      where (al, ah) = sbounds w a
-  where
-    wProof :: LeqProof 1 w
-    wProof = LeqProof
-    uProof :: LeqProof (w+1) u
-    uProof = LeqProof
-    fProof :: LeqProof 1 u
-    fProof = leqTrans (leqAdd wProof (knownNat :: NatRepr 1)) uProof
+sext w (BVDArith a) u   = BVDArith (A.sext w a u)
+sext w (BVDBitwise b) u = BVDBitwise (B.sext w b u)
 
 --------------------------------------------------------------------------------
 -- Shifts
 
-shl :: BVDomain w -> BVDomain w -> BVDomain w
-shl a b
-  | isBVDAny a = a
-  | isSingletonZero a = a
-  | isSingletonZero b = a
-  | otherwise = interval mask lo (hi - lo)
-    where
-      mask = bvdMask a
-      size = mask + 1
-      (bl, bh) = ubounds b
-      bl' = clamp bl
-      bh' = clamp bh
-      -- compute bounds for c = 2^b
-      cl = if (mask `shiftR` bl' == 0) then size else bit bl'
-      ch = if (mask `shiftR` bh' == 0) then size else bit bh'
-      (lo, hi) = mulRange (zbounds a) (cl, ch)
+shl :: (1 <= w) => NatRepr w -> BVDomain w -> BVDomain w -> BVDomain w
+shl w (BVDBitwise a) (asSingleton -> Just x)    = BVDBitwise (B.shl w a x)
+shl w (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.shl w a b)
 
-lshr :: BVDomain w -> BVDomain w -> BVDomain w
-lshr a b = interval mask cl (ch - cl)
-  where
-    mask = bvdMask a
-    (al, ah) = ubounds a
-    (bl, bh) = ubounds b
-    cl = al `shiftR` clamp bh
-    ch = ah `shiftR` clamp bl
+lshr :: (1 <= w) => NatRepr w -> BVDomain w -> BVDomain w -> BVDomain w
+lshr w (BVDBitwise a) (asSingleton -> Just x) = BVDBitwise (B.lshr w a x)
+lshr w (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.lshr w a b)
 
 ashr :: (1 <= w) => NatRepr w -> BVDomain w -> BVDomain w -> BVDomain w
-ashr w a b = interval mask cl (ch - cl)
-  where
-    mask = bvdMask a
-    (al, ah) = sbounds w a
-    (bl, bh) = ubounds b
-    cl = al `shiftR` (if al < 0 then clamp bl else clamp bh)
-    ch = ah `shiftR` (if ah < 0 then clamp bh else clamp bl)
-
--- | Return nearest representable Int, suitable for use as a shift amount.
-clamp :: Integer -> Int
-clamp x
-  | x > toInteger (maxBound :: Int) = maxBound
-  | x < toInteger (minBound :: Int) = minBound
-  | otherwise = fromInteger x
+ashr w (BVDBitwise a) (asSingleton -> Just x) = BVDBitwise (B.ashr w a x)
+ashr w (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.ashr w a b)
 
 --------------------------------------------------------------------------------
 -- Arithmetic
 
 add :: (1 <= w) => BVDomain w -> BVDomain w -> BVDomain w
-add a b =
-  case a of
-    BVDAny _ -> a
-    BVDInterval _ al aw ->
-      case b of
-        BVDAny _ -> b
-        BVDInterval mask bl bw ->
-          interval mask (al + bl) (aw + bw)
+add a b
+  | Just 0 <- asSingleton a = b
+  | Just 0 <- asSingleton b = a
+  | otherwise = BVDArith (A.add (asArithDomain a) (asArithDomain b))
 
 negate :: (1 <= w) => BVDomain w -> BVDomain w
-negate a =
-  case a of
-    BVDAny _ -> a
-    BVDInterval mask al aw -> BVDInterval mask ((-ah) .&. mask) aw
-      where ah = al + aw
+negate (asArithDomain -> a) = BVDArith (A.negate a)
 
 scale :: (1 <= w) => Integer -> BVDomain w -> BVDomain w
 scale k a
-  | k == 0 = BVDInterval (bvdMask a) 0 0
   | k == 1 = a
-  | otherwise =
-    case a of
-      BVDAny _ -> a
-      BVDInterval mask al aw
-        | k >= 0 -> interval mask (k * al) (k * aw)
-        | otherwise -> interval mask (k * ah) (k * aw)
-        where ah = al + aw
+  | otherwise = BVDArith (A.scale k (asArithDomain a))
 
 mul :: (1 <= w) => BVDomain w -> BVDomain w -> BVDomain w
 mul a b
-  | isSingletonZero a = a
-  | isSingletonZero b = b
-  | isBVDAny a = a
-  | isBVDAny b = b
-  | otherwise = interval mask cl (ch - cl)
-    where
-      mask = bvdMask a
-      (cl, ch) = mulRange (zbounds a) (zbounds b)
-
--- | Choose a representative integer range (positive or negative) for
--- the given bitvector domain such that the endpoints are as close to
--- zero as possible.
-zbounds :: BVDomain w -> (Integer, Integer)
-zbounds a =
-  case a of
-    BVDAny mask -> (0, mask)
-    BVDInterval mask lo sz -> (lo', lo' + sz)
-      where lo' = if 2*lo + sz > mask then lo - (mask + 1) else lo
-
-mulRange :: (Integer, Integer) -> (Integer, Integer) -> (Integer, Integer)
-mulRange (al, ah) (bl, bh) = (cl, ch)
-  where
-    (albl, albh) = scaleRange al (bl, bh)
-    (ahbl, ahbh) = scaleRange ah (bl, bh)
-    cl = min albl ahbl
-    ch = max albh ahbh
-
-scaleRange :: Integer -> (Integer, Integer) -> (Integer, Integer)
-scaleRange k (lo, hi)
-  | k < 0 = (k * hi, k * lo)
-  | otherwise = (k * lo, k * hi)
+  | Just 1 <- asSingleton a = b
+  | Just 1 <- asSingleton b = a
+  | otherwise = BVDArith (A.mul (asArithDomain a) (asArithDomain b))
 
 udiv :: (1 <= w) => BVDomain w -> BVDomain w -> BVDomain w
-udiv a b = interval mask ql (qh - ql)
-  where
-    mask = bvdMask a
-    (al, ah) = ubounds a
-    (bl, bh) = ubounds b
-    ql = al `div` max 1 bh -- assume that division by 0 does not happen
-    qh = ah `div` max 1 bl -- assume that division by 0 does not happen
+udiv (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.udiv a b)
 
 urem :: (1 <= w) => BVDomain w -> BVDomain w -> BVDomain w
-urem a b
-  | qh == ql = interval mask rl (rh - rl)
-  | otherwise = interval mask 0 (bh - 1)
-  where
-    mask = bvdMask a
-    (al, ah) = ubounds a
-    (bl, bh) = ubounds b
-    (ql, rl) = al `divMod` max 1 bh -- assume that division by 0 does not happen
-    (qh, rh) = ah `divMod` max 1 bl -- assume that division by 0 does not happen
-
--- | Pairs of nonzero integers @(lo, hi)@ such that @1\/lo <= 1\/hi@.
--- This pair represents the set of all nonzero integers @x@ such that
--- @1\/lo <= 1\/x <= 1\/hi@.
-data ReciprocalRange = ReciprocalRange Integer Integer
-
--- | Nonzero signed values in a domain with the least and greatest
--- reciprocals.
-rbounds :: (1 <= w) => NatRepr w -> BVDomain w -> ReciprocalRange
-rbounds w a =
-  case a of
-    BVDAny _ -> ReciprocalRange (-1) 1
-    BVDInterval mask al aw
-      | ah > mask + 1 -> ReciprocalRange (-1) 1
-      | otherwise     -> ReciprocalRange (signed (min mask ah)) (signed (max 1 al))
-      where
-        ah = al + aw
-        signed x = if x < halfRange w then x else x - (mask + 1)
-
--- | Interval arithmetic for integer division (rounding towards 0).
--- Given @a@ and @b@ with @al <= a <= ah@ and @1\/bl <= 1\/b <= 1/bh@,
--- @sdivRange (al, ah) (ReciprocalRange bl bh)@ returns @(ql, qh)@
--- such that @ql <= a `quot` b <= qh@.
-sdivRange :: (Integer, Integer) -> ReciprocalRange -> (Integer, Integer)
-sdivRange (al, ah) (ReciprocalRange bl bh) = (ql, qh)
-  where
-    (ql1, qh1) = scaleDownRange (al, ah) bh
-    (ql2, qh2) = scaleDownRange (al, ah) bl
-    ql = min ql1 ql2
-    qh = max qh1 qh2
-
--- | @scaleDownRange (lo, hi) k@ returns an interval @(ql, qh)@ such that for any
--- @x@ in @[lo..hi]@, @x `quot` k@ is in @[ql..qh]@.
-scaleDownRange :: (Integer, Integer) -> Integer -> (Integer, Integer)
-scaleDownRange (lo, hi) k
-  | k > 0 = (lo `quot` k, hi `quot` k)
-  | k < 0 = (hi `quot` k, lo `quot` k)
-  | otherwise = (lo, hi) -- assume k is nonzero
+urem (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.urem a b)
 
 sdiv :: (1 <= w) => NatRepr w -> BVDomain w -> BVDomain w -> BVDomain w
-sdiv w a b = interval mask ql (qh - ql)
-  where
-    mask = bvdMask a
-    (ql, qh) = sdivRange (sbounds w a) (rbounds w b)
+sdiv w (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.sdiv w a b)
 
 srem :: (1 <= w) => NatRepr w -> BVDomain w -> BVDomain w -> BVDomain w
-srem w a b =
-  -- If the quotient is a singleton @q@, then we compute the remainder
-  -- @r = a - q*b@.
-  if ql == qh then
-    (if ql < 0
-     then interval mask (al - ql * bl) (aw - ql * bw)
-     else interval mask (al - ql * bh) (aw + ql * bw))
-  -- Otherwise the range of possible remainders is determined by the
-  -- modulus and the sign of the first argument.
-  else interval mask rl (rh - rl)
-  where
-    mask = bvdMask a
-    (al, ah) = sbounds w a
-    (bl, bh) = sbounds w b
-    (ql, qh) = sdivRange (al, ah) (rbounds w b)
-    rl = if al < 0 then min (bl+1) (-bh+1) else 0
-    rh = if ah > 0 then max (-bl-1) (bh-1) else 0
-    aw = ah - al
-    bw = bh - bl
+srem w (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.srem w a b)
 
 --------------------------------------------------------------------------------
 -- Bitwise logical
 
 -- | Complement bits in range.
 not :: BVDomain w -> BVDomain w
-not a =
-  case a of
-    BVDAny _ -> a
-    BVDInterval mask al aw ->
-      BVDInterval mask (Bits.complement ah .&. mask) aw
-      where ah = al + aw
+not (BVDArith a) = BVDArith (A.not a)
+not (BVDBitwise b) = BVDBitwise (B.not b)
 
 and :: BVDomain w -> BVDomain w -> BVDomain w
-and a b = interval mask cl (ch - cl)
-  where
-    mask = bvdMask a
-    (al, ah) = bitbounds a
-    (bl, bh) = bitbounds b
-    (cl, ch) = (al .&. bl, ah .&. bh)
+and a b
+  | Just x <- asSingleton a, x == mask = b
+  | Just x <- asSingleton b, x == mask = a
+  | otherwise = BVDBitwise (B.and (asBitwiseDomain a) (asBitwiseDomain b))
+ where
+ mask = bvdMask a
 
 or :: BVDomain w -> BVDomain w -> BVDomain w
-or a b = interval mask cl (ch - cl)
-  where
-    mask = bvdMask a
-    (al, ah) = bitbounds a
-    (bl, bh) = bitbounds b
-    (cl, ch) = (al .|. bl, ah .|. bh)
+or a b
+  | Just 0 <- asSingleton a = b
+  | Just 0 <- asSingleton b = a
+  | otherwise = BVDBitwise (B.or (asBitwiseDomain a) (asBitwiseDomain b))
 
 xor :: BVDomain w -> BVDomain w -> BVDomain w
-xor a b =
-  case a of
-    BVDAny _ -> a
-    BVDInterval _ al aw ->
-      case b of
-        BVDAny _ -> b
-        BVDInterval mask bl bw ->
-          interval mask cl cu
-          where
-            au = unknowns al (al + aw)
-            bu = unknowns bl (bl + bw)
-            cu = au .|. bu
-            cl = (al `Bits.xor` bl) .&. complement cu
+xor a b
+  | Just 0 <- asSingleton a = b
+  | Just 0 <- asSingleton b = a
+  | otherwise = BVDBitwise (B.xor (asBitwiseDomain a) (asBitwiseDomain b))
 
--- | Return bitwise bounds for domain (i.e. logical AND of all
--- possible values, paired with logical OR of all possible values).
-bitbounds :: BVDomain w -> (Integer, Integer)
-bitbounds a =
-  case a of
-    BVDAny mask -> (0, mask)
-    BVDInterval mask al aw
-      | al + aw > mask -> (0, mask)
-      | otherwise -> (al .&. complement au, al .|. au)
-      where au = unknowns al (al + aw)
 
--- | @unknowns lo hi@ returns a bitmask representing the set of bit
--- positions whose values are not constant throughout the range
--- @lo..hi@.
-unknowns :: Integer -> Integer -> Integer
-unknowns lo hi = fillright 1 (lo `Bits.xor` hi)
+
+------------------------------------------------------------------
+-- Correctness properties
+
+correct_arithToBitwise :: (A.Domain n, Integer) -> Property
+correct_arithToBitwise (a,x) = A.member a x ==> B.member (arithToBitwiseDomain a) x
+
+correct_bitwiseToArith :: (B.Domain n, Integer) -> Property
+correct_bitwiseToArith (b,x) = B.member b x ==> A.member (bitwiseToArithDomain b) x
+
+correct_any :: (1 <= n) => NatRepr n -> Integer -> Property
+correct_any w x = property (member (any w) x)
+
+correct_ubounds :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> Property
+correct_ubounds n (a,x) = member a x' ==> lo <= x' && x' <= hi
   where
-    -- @fillright 1 x@ rounds up @x@ to the nearest 2^n-1.
-    fillright :: Int -> Integer -> Integer
-    fillright i x
-      | x' == x = x
-      | otherwise = fillright (2 * i) x'
-      where x' = x .|. (x `shiftR` i)
+  x' = toUnsigned n x
+  (lo,hi) = ubounds a
+
+correct_sbounds :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> Property
+correct_sbounds n (a,x) = member a x' ==> lo <= x' && x' <= hi
+  where
+  x' = toSigned n x
+  (lo,hi) = sbounds n a
+
+correct_singleton :: (1 <= n) => NatRepr n -> Integer -> Integer -> Property
+correct_singleton n x y = property (member (singleton n x') y' == (x' == y'))
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_overlap :: BVDomain n -> BVDomain n -> Integer -> Property
+correct_overlap a b x =
+  member a x && member b x ==> domainsOverlap a b
+
+correct_union :: (1 <= n) => BVDomain n -> BVDomain n -> Integer -> Property
+correct_union a b x =
+  (member a x || member b x) ==> member (union a b) x
+
+correct_zero_ext :: (1 <= w, w+1 <= u) => NatRepr w -> BVDomain w -> NatRepr u -> Integer -> Property
+correct_zero_ext w a u x = member a x' ==> member (zext a u) x'
+  where
+  x' = toUnsigned w x
+
+correct_sign_ext :: (1 <= w, w+1 <= u) => NatRepr w -> BVDomain w -> NatRepr u -> Integer -> Property
+correct_sign_ext w a u x = member a x' ==> member (sext w a u) x'
+  where
+  x' = toSigned w x
+
+correct_concat :: NatRepr m -> (BVDomain m,Integer) -> NatRepr n -> (BVDomain n,Integer) -> Property
+correct_concat m (a,x) n (b,y) = member a x' ==> member b y' ==> member (concat m a n b) z
+  where
+  x' = toUnsigned m x
+  y' = toUnsigned n y
+  z  = x' `shiftL` (widthVal n) .|. y'
+
+correct_select :: (1 <= n, i + n <= w) =>
+  NatRepr i -> NatRepr n -> (BVDomain w, Integer) -> Property
+correct_select i n (a, x) = member a x ==> member (select i n a) y
+  where
+  y = toUnsigned n ((x .&. bvdMask a) `shiftR` (widthVal i))
+
+correct_add :: (1 <= n) => (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_add (a,x) (b,y) = member a x ==> member b y ==> member (add a b) (x + y)
+
+correct_neg :: (1 <= n) => (BVDomain n, Integer) -> Property
+correct_neg (a,x) = member a x ==> member (negate a) (Prelude.negate x)
+
+correct_mul :: (1 <= n) => (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_mul (a,x) (b,y) = member a x ==> member b y ==> member (mul a b) (x * y)
+
+correct_udiv :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_udiv n (a,x) (b,y) = member a x' ==> member b y' ==> y' /= 0 ==> member (udiv a b) (x' `quot` y')
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_urem :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_urem n (a,x) (b,y) = member a x' ==> member b y' ==> y' /= 0 ==> member (urem a b) (x' `rem` y')
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_sdiv :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_sdiv n (a,x) (b,y) = counterexample (show (n,a,b,x,x',y,y',sdiv n a b,x' `quot` y')) $
+    member a x' ==> member b y' ==> y' /= 0 ==> member (sdiv n a b) (x' `quot` y')
+  where
+  x' = toSigned n x
+  y' = toSigned n y
+
+correct_srem :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_srem n (a,x) (b,y) = counterexample (show (n,a,b,x',y',srem n a b, x' `rem` y')) $
+    member a x' ==> member b y' ==> y' /= 0 ==> member (srem n a b) (x' `rem` y')
+  where
+  x' = toSigned n x
+  y' = toSigned n y
+
+correct_shl :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_shl n (a,x) (b,y) = member a x ==> member b y ==> member (shl n a b) z
+  where
+  z = (toUnsigned n x) `shiftL` fromInteger (min (intValue n) y)
+
+correct_lshr :: (1 <= n) => NatRepr n ->  (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_lshr n (a,x) (b,y) = member a x ==> member b y ==> member (lshr n a b) z
+  where
+  z = (toUnsigned n x) `shiftR` fromInteger (min (intValue n) y)
+
+correct_ashr :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_ashr n (a,x) (b,y) = member a x ==> member b y ==> member (ashr n a b) z
+  where
+  z = (toSigned n x) `shiftR` fromInteger (min (intValue n) y)
+
+correct_eq :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_eq n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case eq a b of
+      Just True  -> toUnsigned n x == toUnsigned n y
+      Just False -> toUnsigned n x /= toUnsigned n y
+      Nothing    -> True
+
+correct_ult :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_ult n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case ult a b of
+      Just True  -> toUnsigned n x < toUnsigned n y
+      Just False -> toUnsigned n x >= toUnsigned n y
+      Nothing    -> True
+
+correct_slt :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_slt n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case slt n a b of
+      Just True  -> toSigned n x < toSigned n y
+      Just False -> toSigned n x >= toSigned n y
+      Nothing    -> True
+
+correct_not :: (1 <= n) => (BVDomain n, Integer) -> Property
+correct_not (a,x) = member a x ==> member (not a) (complement x)
+
+correct_and :: (1 <= n) => (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_and (a,x) (b,y) = member a x ==> member b y ==> member (and a b) (x .&. y)
+
+correct_or :: (1 <= n) => (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_or (a,x) (b,y) = member a x ==> member b y ==> member (or a b) (x .|. y)
+
+correct_xor :: (1 <= n) => (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
+correct_xor (a,x) (b,y) = member a x ==> member b y ==> member (xor a b) (x `Bits.xor` y)
+
+correct_testBit :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> Natural -> Property
+correct_testBit n (a,x) i =
+  i < natValue n ==>
+    case testBit n a i of
+      Just True  -> Bits.testBit x (fromIntegral i)
+      Just False -> Prelude.not (Bits.testBit x (fromIntegral i))
+      Nothing    -> True

--- a/what4/src/What4/Utils/BVDomain/Arith.hs
+++ b/what4/src/What4/Utils/BVDomain/Arith.hs
@@ -17,6 +17,7 @@ domains.
 
 module What4.Utils.BVDomain.Arith
   ( Domain
+  , bvdMask
   , member
   , interval
   -- * Projection functions
@@ -30,7 +31,6 @@ module What4.Utils.BVDomain.Arith
   , arithDomainData
   , bitbounds
   , unknowns
-  , bitle
     -- * Operations
   , any
   , singleton
@@ -72,6 +72,7 @@ module What4.Utils.BVDomain.Arith
   , correct_concat
   , correct_shrink
   , correct_trunc
+  , correct_select
   , correct_add
   , correct_neg
   , correct_mul
@@ -675,6 +676,12 @@ correct_trunc :: (n <= w) => NatRepr n -> (Domain w, Integer) -> Property
 correct_trunc n (a,x) = member a x' ==> member (trunc n a) (toUnsigned n x')
   where
   x' = x .&. bvdMask a
+
+correct_select :: (1 <= n, i + n <= w) =>
+  NatRepr i -> NatRepr n -> (Domain w, Integer) -> Property
+correct_select i n (a, x) = member a x ==> member (select i n a) y
+  where
+  y = toUnsigned n ((x .&. bvdMask a) `shiftR` (widthVal i))
 
 correct_add :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
 correct_add (a,x) (b,y) = member a x ==> member b y ==> member (add a b) (x + y)

--- a/what4/src/What4/Utils/BVDomain/Arith.hs
+++ b/what4/src/What4/Utils/BVDomain/Arith.hs
@@ -33,6 +33,7 @@ module What4.Utils.BVDomain.Arith
   , arithDomainData
   , bitbounds
   , unknowns
+  , fillright
     -- * Operations
   , any
   , singleton
@@ -617,17 +618,20 @@ bitbounds a =
 -- @lo..hi@.
 unknowns :: Domain w -> Integer
 unknowns (BVDAny mask) = mask
-unknowns (BVDInterval mask al aw) = mask .&. (fillright 1 (al `Bits.xor` (al+aw)))
-  where
-    -- @fillright 1 x@ rounds up @x@ to the nearest 2^n-1.
-    fillright :: Int -> Integer -> Integer
-    fillright i x
-      | x' == x = x
-      | otherwise = fillright (2 * i) x'
-      where x' = x .|. (x `shiftR` i)
+unknowns (BVDInterval mask al aw) = mask .&. (fillright (al `Bits.xor` (al+aw)))
 
 bitle :: Integer -> Integer -> Bool
 bitle x y = (x .|. y) == y
+
+-- | @fillright x@ rounds up @x@ to the nearest 2^n-1.
+fillright :: Integer -> Integer
+fillright = go 1
+  where
+  go :: Int -> Integer -> Integer
+  go i x
+    | x' == x = x
+    | otherwise = go (2 * i) x'
+    where x' = x .|. (x `shiftR` i)
 
 ------------------------------------------------------------------
 -- Correctness properties

--- a/what4/src/What4/Utils/BVDomain/Arith.hs
+++ b/what4/src/What4/Utils/BVDomain/Arith.hs
@@ -595,7 +595,7 @@ not a =
   case a of
     BVDAny _ -> a
     BVDInterval mask al aw ->
-      BVDInterval mask (ah `Bits.xor` mask) aw
+      BVDInterval mask (complement ah .&. mask) aw
       where ah = al + aw
 
 -- | Return bitwise bounds for domain (i.e. logical AND of all
@@ -617,7 +617,7 @@ bitbounds a =
 -- @lo..hi@.
 unknowns :: Domain w -> Integer
 unknowns (BVDAny mask) = mask
-unknowns (BVDInterval _mask al aw) = fillright 1 (al `Bits.xor` (al+aw))
+unknowns (BVDInterval mask al aw) = mask .&. (fillright 1 (al `Bits.xor` (al+aw)))
   where
     -- @fillright 1 x@ rounds up @x@ to the nearest 2^n-1.
     fillright :: Int -> Integer -> Integer

--- a/what4/src/What4/Utils/BVDomain/Arith.hs
+++ b/what4/src/What4/Utils/BVDomain/Arith.hs
@@ -1,0 +1,773 @@
+{-|
+Module      : What4.Utils.BVDomain.Arith
+Copyright   : (c) Galois Inc, 2019
+License     : BSD3
+Maintainer  : huffman@galois.com
+
+Provides an interval-based implementation of bitvector abstract
+domains.
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module What4.Utils.BVDomain.Arith
+  ( Domain
+  , member
+  , interval
+  -- * Projection functions
+  , asSingleton
+  , ubounds
+  , sbounds
+  , eq
+  , slt
+  , ult
+  , domainsOverlap
+  , arithDomainData
+  , bitbounds
+  , unknowns
+  , bitle
+    -- * Operations
+  , any
+  , singleton
+  , range
+  , fromAscEltList
+  , union
+  , concat
+  , select
+  , zext
+  , sext
+    -- ** Shifts
+  , shl
+  , lshr
+  , ashr
+    -- ** Arithmetic
+  , add
+  , negate
+  , scale
+  , mul
+  , udiv
+  , urem
+  , sdiv
+  , srem
+    -- ** Bitwise
+  , What4.Utils.BVDomain.Arith.not
+
+  -- * Correctness properties
+  , genDomain
+  , genElement
+  , genPair
+  , correct_any
+  , correct_ubounds
+  , correct_sbounds
+  , correct_singleton
+  , correct_overlap
+  , correct_union
+  , correct_zero_ext
+  , correct_sign_ext
+  , correct_concat
+  , correct_shrink
+  , correct_trunc
+  , correct_add
+  , correct_neg
+  , correct_mul
+  , correct_udiv
+  , correct_urem
+  , correct_sdivRange
+  , correct_sdiv
+  , correct_srem
+  , correct_not
+  , correct_shl
+  , correct_lshr
+  , correct_ashr
+  , correct_eq
+  , correct_ult
+  , correct_slt
+  , correct_unknowns
+  , correct_bitbounds
+  ) where
+
+import qualified Data.Bits as Bits
+import           Data.Bits hiding (testBit, xor)
+import           Data.Parameterized.NatRepr
+import           GHC.TypeNats
+import           GHC.Stack
+
+import qualified Prelude
+import           Prelude hiding (any, concat, negate, and, or, not)
+
+import           Test.QuickCheck (Property, property, (==>), Gen, chooseInteger, counterexample)
+
+--------------------------------------------------------------------------------
+-- BVDomain definition
+
+-- | A value of type @'BVDomain' w@ represents a set of bitvectors of
+-- width @w@. Each 'BVDomain' can represent a single contiguous
+-- interval of bitvectors that may wrap around from -1 to 0.
+data Domain (w :: Nat)
+  = BVDAny !Integer
+  -- ^ The set of all bitvectors of width @w@. Argument caches @2^w-1@.
+  | BVDInterval !Integer !Integer !Integer
+  -- ^ Intervals are represented by a starting value and a size.
+  -- @BVDInterval mask l d@ represents the set of values of the form
+  -- @x mod 2^w@ for @x@ such that @l <= x <= l + d@. It should
+  -- satisfy the invariants @0 <= l < 2^w@ and @0 <= d < 2^w@. The
+  -- first argument caches the value @2^w-1@.
+  deriving Show
+
+member :: Domain w -> Integer -> Bool
+member (BVDAny _) _ = True
+member (BVDInterval mask lo sz) x = ((x' - lo) .&. mask) <= sz
+  where x' = x .&. mask
+
+bvdMask :: Domain w -> Integer
+bvdMask x =
+  case x of
+    BVDAny mask -> mask
+    BVDInterval mask _ _ -> mask
+
+-- | Random generator for domain values
+genDomain :: NatRepr w -> Gen (Domain w)
+genDomain w =
+  do let mask = maxUnsigned w
+     lo <- chooseInteger (0, mask)
+     sz <- chooseInteger (0, mask)
+     pure $! interval mask lo sz
+
+genElement :: Domain w -> Gen Integer
+genElement (BVDAny mask) = chooseInteger (0, mask)
+genElement (BVDInterval mask lo sz) =
+   do x <- chooseInteger (0, sz)
+      pure ((x+lo) .&. mask)
+
+genPair :: NatRepr w -> Gen (Domain w, Integer)
+genPair w =
+  do a <- genDomain w
+     x <- genElement a
+     return (a,x)
+
+--------------------------------------------------------------------------------
+
+-- | @halfRange n@ returns @2^(n-1)@.
+halfRange :: (1 <= w) => NatRepr w -> Integer
+halfRange w = bit (widthVal w - 1)
+
+--------------------------------------------------------------------------------
+-- Projection functions
+
+-- | Return value if this is a singleton.
+asSingleton :: Domain w -> Maybe Integer
+asSingleton x =
+  case x of
+    BVDAny _ -> Nothing
+    BVDInterval _ xl xd
+      | xd == 0 -> Just xl
+      | otherwise -> Nothing
+
+isSingletonZero :: Domain w -> Bool
+isSingletonZero x =
+  case x of
+    BVDInterval _ 0 0 -> True
+    _ -> False
+
+isBVDAny :: Domain w -> Bool
+isBVDAny x =
+  case x of
+    BVDAny {} -> True
+    BVDInterval {} -> False
+
+-- | Return unsigned bounds for domain.
+ubounds :: Domain w -> (Integer, Integer)
+ubounds a =
+  case a of
+    BVDAny mask -> (0, mask)
+    BVDInterval mask al aw
+      | ah > mask -> (0, mask)
+      | otherwise -> (al, ah)
+      where ah = al + aw
+
+-- | Return signed bounds for domain.
+sbounds :: (1 <= w) => NatRepr w -> Domain w -> (Integer, Integer)
+sbounds w a = (lo - delta, hi - delta)
+  where
+    delta = halfRange w
+    (lo, hi) = ubounds (add a (BVDInterval (bvdMask a) delta 0))
+
+-- | Return the @(lo,sz)@, the low bound and size
+--   of the given arithmetic interval.  A value @x@ is in
+--   the set defined by this domain iff
+--   @(x - lo) `mod` w <= sz@ holds.
+--   Returns @Nothing@ if the domain contains all values.
+arithDomainData :: Domain w -> Maybe (Integer, Integer)
+arithDomainData (BVDAny _) = Nothing
+arithDomainData (BVDInterval _ al aw) = Just (al, aw)
+
+-- | Return true if domains contain a common element.
+domainsOverlap :: Domain w -> Domain w -> Bool
+domainsOverlap a b =
+  case a of
+    BVDAny _ -> True
+    BVDInterval _ al aw ->
+      case b of
+        BVDAny _ -> True
+        BVDInterval mask bl bw ->
+          diff <= bw || diff + aw > mask
+          where diff = (al - bl) .&. mask
+
+eq :: Domain w -> Domain w -> Maybe Bool
+eq a b
+  | Just x <- asSingleton a
+  , Just y <- asSingleton b = Just (x == y)
+  | domainsOverlap a b == False = Just False
+  | otherwise = Nothing
+
+-- | Check if all elements in one domain are less than all elements in other.
+slt :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Maybe Bool
+slt w a b
+  | a_max < b_min = Just True
+  | a_min >= b_max = Just False
+  | otherwise = Nothing
+  where
+    (a_min, a_max) = sbounds w a
+    (b_min, b_max) = sbounds w b
+
+-- | Check if all elements in one domain are less than all elements in other.
+ult :: (1 <= w) => Domain w -> Domain w -> Maybe Bool
+ult a b
+  | a_max < b_min = Just True
+  | a_min >= b_max = Just False
+  | otherwise = Nothing
+  where
+    (a_min, a_max) = ubounds a
+    (b_min, b_max) = ubounds b
+
+--------------------------------------------------------------------------------
+-- Operations
+
+-- | Represents all values
+any :: (1 <= w) => NatRepr w -> Domain w
+any w = BVDAny (maxUnsigned w)
+
+-- | Create a bitvector domain representing the integer.
+singleton :: (HasCallStack, 1 <= w) => NatRepr w -> Integer -> Domain w
+singleton w x = BVDInterval mask (x .&. mask) 0
+  where mask = maxUnsigned w
+
+-- | @range w l u@ returns domain containing all bitvectors formed
+-- from the @w@ low order bits of some @i@ in @[l,u]@.  Note that per
+-- @testBit@, the least significant bit has index @0@.
+range :: NatRepr w -> Integer -> Integer -> Domain w
+range w al ah = interval mask al ((ah - al) .&. mask)
+  where mask = maxUnsigned w
+
+-- | Unsafe constructor for internal use only. Caller must ensure that
+-- @mask = maxUnsigned w@, and that @aw@ is non-negative.
+interval :: Integer -> Integer -> Integer -> Domain w
+interval mask al aw =
+  if aw >= mask then BVDAny mask else BVDInterval mask (al .&. mask) aw
+
+-- | Create an abstract domain from an ascending list of elements.
+-- The elements are assumed to be distinct.
+fromAscEltList :: (1 <= w) => NatRepr w -> [Integer] -> Domain w
+fromAscEltList w [] = singleton w 0
+fromAscEltList w [x] = singleton w x
+fromAscEltList w (x0 : x1 : xs) = go (x0, x0) (x1, x1) xs
+  where
+    -- Invariant: the gap between @b@ and @c@ is the biggest we've
+    -- seen between adjacent values so far.
+    go (a, b) (c, d) [] = union (range w a b) (range w c d)
+    go (a, b) (c, d) (e : rest)
+      | e - d > c - b = go (a, d) (e, e) rest
+      | otherwise     = go (a, b) (c, e) rest
+
+-- | Return union of two domains.
+union :: (1 <= w) => Domain w -> Domain w -> Domain w
+union a b =
+  case a of
+    BVDAny _ -> a
+    BVDInterval _ al aw ->
+      case b of
+        BVDAny _ -> b
+        BVDInterval mask bl bw ->
+          interval mask cl (ch - cl)
+          where
+            size = mask + 1
+            ac = 2 * al + aw -- twice the average value of a
+            bc = 2 * bl + bw -- twice the average value of b
+            -- If the averages are 2^(w-1) or more apart,
+            -- then shift the lower interval up by 2^w.
+            al' = if ac + mask < bc then al + size else al
+            bl' = if bc + mask < ac then bl + size else bl
+            ah' = al' + aw
+            bh' = bl' + bw
+            cl = min al' bl'
+            ch = max ah' bh'
+
+-- | @concat a y@ returns domain where each element in @a@ has been
+-- concatenated with an element in @y@.  The most-significant bits
+-- are @a@, and the least significant bits are @y@.
+concat :: NatRepr u -> Domain u -> NatRepr v -> Domain v -> Domain (u + v)
+concat u a v b =
+  case a of
+    BVDAny _ -> BVDAny mask
+    BVDInterval _ al aw -> interval mask (cat al bl) (cat aw bw)
+  where
+    cat i j = i `shiftL` widthVal v + j
+    mask = maxUnsigned (addNat u v)
+    (bl, bh) = ubounds b
+    bw = bh - bl
+
+-- | @shrink i a@ drops the @i@ least significant bits from @a@.
+shrink ::
+  NatRepr i ->
+  Domain (i + n) -> Domain n
+shrink i a =
+  case a of
+    BVDAny mask -> BVDAny (shr mask)
+    BVDInterval mask al aw ->
+      interval (shr mask) bl (bh - bl)
+      where
+        bl = shr al
+        bh = shr (al + aw)
+  where
+    shr x = x `shiftR` widthVal i
+
+-- | @trunc n d@ selects the @n@ least significant bits from @d@.
+trunc ::
+  (n <= w) =>
+  NatRepr n ->
+  Domain w -> Domain n
+trunc n a =
+  case a of
+    BVDAny _ -> BVDAny mask
+    BVDInterval _ al aw -> interval mask al aw
+  where
+    mask = maxUnsigned n
+
+-- | @select i n a@ selects @n@ bits starting from index @i@ from @a@.
+select ::
+  (1 <= n, i + n <= w) =>
+  NatRepr i ->
+  NatRepr n ->
+  Domain w -> Domain n
+select i n a = shrink i (trunc (addNat i n) a)
+
+zext :: (1 <= w, w+1 <= u) => Domain w -> NatRepr u -> Domain u
+zext a u = range u al ah
+  where (al, ah) = ubounds a
+
+sext ::
+  forall w u. (1 <= w, w + 1 <= u) =>
+  NatRepr w ->
+  Domain w ->
+  NatRepr u ->
+  Domain u
+sext w a u =
+  case fProof of
+    LeqProof ->
+      range u al ah
+      where (al, ah) = sbounds w a
+  where
+    wProof :: LeqProof 1 w
+    wProof = LeqProof
+    uProof :: LeqProof (w+1) u
+    uProof = LeqProof
+    fProof :: LeqProof 1 u
+    fProof = leqTrans (leqAdd wProof (knownNat :: NatRepr 1)) uProof
+
+--------------------------------------------------------------------------------
+-- Shifts
+
+shl :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+shl w a b
+  | isBVDAny a = a
+  | isSingletonZero a = a
+  | isSingletonZero b = a
+  | otherwise = interval mask lo (hi - lo)
+    where
+      mask = bvdMask a
+      size = mask + 1
+      (bl, bh) = ubounds b
+      bl' = clamp w bl
+      bh' = clamp w bh
+      -- compute bounds for c = 2^b
+      cl = if (mask `shiftR` bl' == 0) then size else bit bl'
+      ch = if (mask `shiftR` bh' == 0) then size else bit bh'
+      (lo, hi) = mulRange (zbounds a) (cl, ch)
+
+lshr :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+lshr w a b = interval mask cl (ch - cl)
+  where
+    mask = bvdMask a
+    (al, ah) = ubounds a
+    (bl, bh) = ubounds b
+    cl = al `shiftR` clamp w bh
+    ch = ah `shiftR` clamp w bl
+
+ashr :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+ashr w a b = interval mask cl (ch - cl)
+  where
+    mask = bvdMask a
+    (al, ah) = sbounds w a
+    (bl, bh) = ubounds b
+    cl = al `shiftR` (if al < 0 then clamp w bl else clamp w bh)
+    ch = ah `shiftR` (if ah < 0 then clamp w bh else clamp w bl)
+
+-- | Clamp the given shift amount to the word width indicated by the
+--   nat repr
+clamp :: NatRepr w -> Integer -> Int
+clamp w x = fromInteger (min (intValue w) x)
+
+--------------------------------------------------------------------------------
+-- Arithmetic
+
+add :: (1 <= w) => Domain w -> Domain w -> Domain w
+add a b =
+  case a of
+    BVDAny _ -> a
+    BVDInterval _ al aw ->
+      case b of
+        BVDAny _ -> b
+        BVDInterval mask bl bw ->
+          interval mask (al + bl) (aw + bw)
+
+negate :: (1 <= w) => Domain w -> Domain w
+negate a =
+  case a of
+    BVDAny _ -> a
+    BVDInterval mask al aw -> BVDInterval mask ((-ah) .&. mask) aw
+      where ah = al + aw
+
+scale :: (1 <= w) => Integer -> Domain w -> Domain w
+scale k a
+  | k == 0 = BVDInterval (bvdMask a) 0 0
+  | k == 1 = a
+  | otherwise =
+    case a of
+      BVDAny _ -> a
+      BVDInterval mask al aw
+        | k >= 0 -> interval mask (k * al) (k * aw)
+        | otherwise -> interval mask (k * ah) (k * aw)
+        where ah = al + aw
+
+mul :: (1 <= w) => Domain w -> Domain w -> Domain w
+mul a b
+  | isSingletonZero a = a
+  | isSingletonZero b = b
+  | isBVDAny a = a
+  | isBVDAny b = b
+  | otherwise = interval mask cl (ch - cl)
+    where
+      mask = bvdMask a
+      (cl, ch) = mulRange (zbounds a) (zbounds b)
+
+-- | Choose a representative integer range (positive or negative) for
+-- the given bitvector domain such that the endpoints are as close to
+-- zero as possible.
+zbounds :: Domain w -> (Integer, Integer)
+zbounds a =
+  case a of
+    BVDAny mask -> (0, mask)
+    BVDInterval mask lo sz -> (lo', lo' + sz)
+      where lo' = if 2*lo + sz > mask then lo - (mask + 1) else lo
+
+mulRange :: (Integer, Integer) -> (Integer, Integer) -> (Integer, Integer)
+mulRange (al, ah) (bl, bh) = (cl, ch)
+  where
+    (albl, albh) = scaleRange al (bl, bh)
+    (ahbl, ahbh) = scaleRange ah (bl, bh)
+    cl = min albl ahbl
+    ch = max albh ahbh
+
+scaleRange :: Integer -> (Integer, Integer) -> (Integer, Integer)
+scaleRange k (lo, hi)
+  | k < 0 = (k * hi, k * lo)
+  | otherwise = (k * lo, k * hi)
+
+udiv :: (1 <= w) => Domain w -> Domain w -> Domain w
+udiv a b = interval mask ql (qh - ql)
+  where
+    mask = bvdMask a
+    (al, ah) = ubounds a
+    (bl, bh) = ubounds b
+    ql = al `div` max 1 bh -- assume that division by 0 does not happen
+    qh = ah `div` max 1 bl -- assume that division by 0 does not happen
+
+urem :: (1 <= w) => Domain w -> Domain w -> Domain w
+urem a b
+  | qh == ql = interval mask rl (rh - rl)
+  | otherwise = interval mask 0 (bh - 1)
+  where
+    mask = bvdMask a
+    (al, ah) = ubounds a
+    (bl, bh) = ubounds b
+    (ql, rl) = al `divMod` max 1 bh -- assume that division by 0 does not happen
+    (qh, rh) = ah `divMod` max 1 bl -- assume that division by 0 does not happen
+
+-- | Pairs of nonzero integers @(lo, hi)@ such that @1\/lo <= 1\/hi@.
+-- This pair represents the set of all nonzero integers @x@ such that
+-- @1\/lo <= 1\/x <= 1\/hi@.
+data ReciprocalRange = ReciprocalRange Integer Integer
+
+-- | Nonzero signed values in a domain with the least and greatest
+-- reciprocals.
+rbounds :: (1 <= w) => NatRepr w -> Domain w -> ReciprocalRange
+rbounds w a =
+  case a of
+    BVDAny _ -> ReciprocalRange (-1) 1
+    BVDInterval mask al aw
+      | ah > mask + 1 -> ReciprocalRange (-1) 1
+      | otherwise     -> ReciprocalRange (signed (min mask ah)) (signed (max 1 al))
+      where
+        ah = al + aw
+        signed x = if x < halfRange w then x else x - (mask + 1)
+
+-- | Interval arithmetic for integer division (rounding towards 0).
+-- Given @a@ and @b@ with @al <= a <= ah@ and @1\/bl <= 1\/b <= 1/bh@,
+-- @sdivRange (al, ah) (ReciprocalRange bl bh)@ returns @(ql, qh)@
+-- such that @ql <= a `quot` b <= qh@.
+sdivRange :: (Integer, Integer) -> ReciprocalRange -> (Integer, Integer)
+sdivRange (al, ah) (ReciprocalRange bl bh) = (ql, qh)
+  where
+    (ql1, qh1) = scaleDownRange (al, ah) bh
+    (ql2, qh2) = scaleDownRange (al, ah) bl
+    ql = min ql1 ql2
+    qh = max qh1 qh2
+
+-- | @scaleDownRange (lo, hi) k@ returns an interval @(ql, qh)@ such that for any
+-- @x@ in @[lo..hi]@, @x `quot` k@ is in @[ql..qh]@.
+scaleDownRange :: (Integer, Integer) -> Integer -> (Integer, Integer)
+scaleDownRange (lo, hi) k
+  | k > 0 = (lo `quot` k, hi `quot` k)
+  | k < 0 = (hi `quot` k, lo `quot` k)
+  | otherwise = (lo, hi) -- assume k is nonzero
+
+
+sdiv :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+sdiv w a b = interval mask ql (qh - ql)
+  where
+    mask = bvdMask a
+    (ql, qh) = sdivRange (sbounds w a) (rbounds w b)
+
+srem :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+srem w a b =
+  -- If the quotient is a singleton @q@, then we compute the remainder
+  -- @r = a - q*b@.
+  if ql == qh then
+    (if ql < 0
+     then interval mask (al - ql * bl) (aw - ql * bw)
+     else interval mask (al - ql * bh) (aw + ql * bw))
+  -- Otherwise the range of possible remainders is determined by the
+  -- modulus and the sign of the first argument.
+  else interval mask rl (rh - rl)
+  where
+    mask = bvdMask a
+    (al, ah) = sbounds w a
+    (bl, bh) = sbounds w b
+    (ql, qh) = sdivRange (al, ah) (rbounds w b)
+    rl = if al < 0 then min (bl+1) (-bh+1) else 0
+    rh = if ah > 0 then max (-bl-1) (bh-1) else 0
+    aw = ah - al
+    bw = bh - bl
+
+--------------------------------------------------------------------------------
+-- Bitwise logical
+
+-- | Complement bits in range.
+not :: Domain w -> Domain w
+not a =
+  case a of
+    BVDAny _ -> a
+    BVDInterval mask al aw ->
+      BVDInterval mask (ah `Bits.xor` mask) aw
+      where ah = al + aw
+
+-- | Return bitwise bounds for domain (i.e. logical AND of all
+-- possible values, paired with logical OR of all possible values).
+bitbounds :: Domain w -> (Integer, Integer)
+bitbounds a =
+  case a of
+    BVDAny mask -> (0, mask)
+    BVDInterval mask al aw
+      | al + aw > mask -> (0, mask)
+      | otherwise -> (lo, hi)
+      where
+        au = unknowns a
+        hi = al .|. au
+        lo = hi `Bits.xor` au
+
+-- | @unknowns lo hi@ returns a bitmask representing the set of bit
+-- positions whose values are not constant throughout the range
+-- @lo..hi@.
+unknowns :: Domain w -> Integer
+unknowns (BVDAny mask) = mask
+unknowns (BVDInterval _mask al aw) = fillright 1 (al `Bits.xor` (al+aw))
+  where
+    -- @fillright 1 x@ rounds up @x@ to the nearest 2^n-1.
+    fillright :: Int -> Integer -> Integer
+    fillright i x
+      | x' == x = x
+      | otherwise = fillright (2 * i) x'
+      where x' = x .|. (x `shiftR` i)
+
+bitle :: Integer -> Integer -> Bool
+bitle x y = (x .|. y) == y
+
+------------------------------------------------------------------
+-- Correctness properties
+
+correct_any :: (1 <= n) => NatRepr n -> Integer -> Property
+correct_any w x = property (member (any w) x)
+
+correct_ubounds :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_ubounds n (a,x) = member a x' ==> lo <= x' && x' <= hi
+  where
+  x' = toUnsigned n x
+  (lo,hi) = ubounds a
+
+correct_sbounds :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_sbounds n (a,x) = member a x' ==> lo <= x' && x' <= hi
+  where
+  x' = toSigned n x
+  (lo,hi) = sbounds n a
+
+correct_singleton :: (1 <= n) => NatRepr n -> Integer -> Integer -> Property
+correct_singleton n x y = property (member (singleton n x') y' == (x' == y'))
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_overlap :: Domain n -> Domain n -> Integer -> Property
+correct_overlap a b x =
+  member a x && member b x ==> domainsOverlap a b
+
+correct_union :: (1 <= n) => Domain n -> Domain n -> Integer -> Property
+correct_union a b x =
+  (member a x || member b x) ==> member (union a b) x
+
+correct_zero_ext :: (1 <= w, w+1 <= u) => NatRepr w -> Domain w -> NatRepr u -> Integer -> Property
+correct_zero_ext w a u x = member a x' ==> member (zext a u) x'
+  where
+  x' = toUnsigned w x
+
+correct_sign_ext :: (1 <= w, w+1 <= u) => NatRepr w -> Domain w -> NatRepr u -> Integer -> Property
+correct_sign_ext w a u x = member a x' ==> member (sext w a u) x'
+  where
+  x' = toSigned w x
+
+correct_concat :: NatRepr m -> (Domain m,Integer) -> NatRepr n -> (Domain n,Integer) -> Property
+correct_concat m (a,x) n (b,y) = member a x' ==> member b y' ==> member (concat m a n b) z
+  where
+  x' = toUnsigned m x
+  y' = toUnsigned n y
+  z  = x' `shiftL` (widthVal n) .|. y'
+
+correct_shrink :: NatRepr i -> (Domain (i + n), Integer) -> Property
+correct_shrink i (a,x) = member a x' ==> member (shrink i a) (x' `shiftR` widthVal i)
+  where
+  x' = x .&. bvdMask a
+
+correct_trunc :: (n <= w) => NatRepr n -> (Domain w, Integer) -> Property
+correct_trunc n (a,x) = member a x' ==> member (trunc n a) (toUnsigned n x')
+  where
+  x' = x .&. bvdMask a
+
+correct_add :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_add (a,x) (b,y) = member a x ==> member b y ==> member (add a b) (x + y)
+
+correct_neg :: (1 <= n) => (Domain n, Integer) -> Property
+correct_neg (a,x) = member a x ==> member (negate a) (Prelude.negate x)
+
+correct_not :: (1 <= n) => (Domain n, Integer) -> Property
+correct_not (a,x) = member a x ==> member (not a) (complement x)
+
+correct_mul :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_mul (a,x) (b,y) = member a x ==> member b y ==> member (mul a b) (x * y)
+
+correct_udiv :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_udiv n (a,x) (b,y) = member a x' ==> member b y' ==> y' /= 0 ==> member (udiv a b) (x' `quot` y')
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_urem :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_urem n (a,x) (b,y) = member a x' ==> member b y' ==> y' /= 0 ==> member (urem a b) (x' `rem` y')
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_sdivRange :: (Integer, Integer) -> (Integer, Integer) -> Integer -> Integer -> Property
+correct_sdivRange a b x y =
+   mem a x ==> mem b y ==> y /= 0 ==> mem (sdivRange a b') (x `quot` y)
+ where
+ b' = ReciprocalRange (snd b) (fst b)
+ mem (lo,hi) v = lo <= v && v <= hi
+
+correct_sdiv :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_sdiv n (a,x) (b,y) =
+    member a x ==> member b y ==> y /= 0 ==> member (sdiv n a b) (x' `quot` y')
+  where
+  x' = toSigned n x
+  y' = toSigned n y
+
+correct_srem :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_srem n (a,x) (b,y) =
+    member a x ==> member b y ==> y /= 0 ==> member (srem n a b) (x' `rem` y')
+  where
+  x' = toSigned n x
+  y' = toSigned n y
+
+correct_shl :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_shl n (a,x) (b,y) = member a x ==> member b y ==> member (shl n a b) z
+  where
+  z = (toUnsigned n x) `shiftL` fromInteger (min (intValue n) y)
+
+correct_lshr :: (1 <= n) => NatRepr n ->  (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_lshr n (a,x) (b,y) = member a x ==> member b y ==> member (lshr n a b) z
+  where
+  z = (toUnsigned n x) `shiftR` fromInteger (min (intValue n) y)
+
+correct_ashr :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_ashr n (a,x) (b,y) = member a x ==> member b y ==> member (ashr n a b) z
+  where
+  z = (toSigned n x) `shiftR` fromInteger (min (intValue n) y)
+
+correct_eq :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_eq n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case eq a b of
+      Just True  -> toUnsigned n x == toUnsigned n y
+      Just False -> toUnsigned n x /= toUnsigned n y
+      Nothing    -> True
+
+correct_ult :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_ult n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case ult a b of
+      Just True  -> toUnsigned n x < toUnsigned n y
+      Just False -> toUnsigned n x >= toUnsigned n y
+      Nothing    -> True
+
+correct_slt :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_slt n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case slt n a b of
+      Just True  -> toSigned n x < toSigned n y
+      Just False -> toSigned n x >= toSigned n y
+      Nothing    -> True
+
+correct_unknowns :: (1 <= n) => Domain n -> Integer -> Integer -> Property
+correct_unknowns a x y = member a x ==> member a y ==> ((x .|. u) == (y .|. u))
+  where
+  u = unknowns a
+
+correct_bitbounds :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_bitbounds n (a,x) = counterexample (show (n,a,x,x',lo,hi)) $
+    member a x ==> (bitle lo x' && bitle x' hi)
+  where
+  x' = toUnsigned n x
+  (lo, hi) = bitbounds a

--- a/what4/src/What4/Utils/BVDomain/Bitwise.hs
+++ b/what4/src/What4/Utils/BVDomain/Bitwise.hs
@@ -1,0 +1,365 @@
+{-|
+Module      : What4.Utils.BVDomain.Bitwise
+Copyright   : (c) Galois Inc, 2020
+License     : BSD3
+Maintainer  : huffman@galois.com
+
+Provides a bitwise implementation of bitvector abstract domains.
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+module What4.Utils.BVDomain.Bitwise
+  ( Domain
+  , bvdMask
+  , member
+  , asSingleton
+  , nonempty
+  , eq
+  , domainsOverlap
+  , bitrange
+  -- * Operations
+  , any
+  , singleton
+  , range
+  , interval
+  , union
+  , intersection
+  , concat
+  , select
+  , zext
+  , sext
+  , testBit
+  -- ** shifts
+  , shl
+  , lshr
+  , ashr
+  -- ** bitwise logical
+  , and
+  , or
+  , xor
+  , not
+
+  -- * Correctness properties
+  , genDomain
+  , genElement
+  , genPair
+  , correct_any
+  , correct_singleton
+  , correct_overlap
+  , correct_union
+  , correct_intersection
+  , correct_zero_ext
+  , correct_sign_ext
+  , correct_concat
+  , correct_shrink
+  , correct_trunc
+  , correct_shl
+  , correct_lshr
+  , correct_ashr
+  , correct_eq
+  , correct_and
+  , correct_or
+  , correct_not
+  , correct_xor
+  , correct_testBit
+  ) where
+
+import           Data.Bits hiding (testBit, xor)
+import qualified Data.Bits as Bits
+import           Data.Parameterized.NatRepr
+import           Numeric.Natural
+import           GHC.TypeNats
+import           Test.QuickCheck (Property, property, (==>), Gen, chooseInteger, counterexample)
+
+import qualified Prelude
+import           Prelude hiding (any, concat, negate, and, or, not)
+
+-- | A bitwise interval domain, defined via a
+--   bitwise upper and lower bound.  The ordering
+--   used here to construct the interval is the pointwise
+--   ordering on bits.  In particular @x [= y iff x .|. y == y@,
+--   and a value @x@ is in the set defined by the pair @(lo,hi)@
+--   just when @lo [= x && x [= hi@.
+data Domain (w :: Nat) =
+  BVBitInterval !Integer !Integer !Integer
+  -- ^ @BVDBitInterval mask lo hi@.
+  --  @mask@ caches the value of @2^w - 1@
+ deriving (Show)
+
+member :: Domain w -> Integer -> Bool
+member (BVBitInterval mask lo hi) x = bitle lo x' && bitle x' hi
+  where x' = x .&. mask
+
+bitle :: Integer -> Integer -> Bool
+bitle x y = (x .|. y) == y
+
+bvdMask :: Domain w -> Integer
+bvdMask (BVBitInterval mask _ _) = mask
+
+-- | Random generator for domain values.  We always generate
+--   nonempty domains values.
+genDomain :: NatRepr w -> Gen (Domain w)
+genDomain w =
+  do let mask = maxUnsigned w
+     lo <- chooseInteger (0, mask)
+     hi <- chooseInteger (0, mask)
+     pure $! interval mask lo (lo .|. hi)
+
+genElement :: Domain w -> Gen Integer
+genElement (BVBitInterval mask lo hi) =
+  do let u = Bits.xor lo hi
+     x <- chooseInteger (0, mask)
+     pure ((x .&. u) .|. lo)
+
+genPair :: NatRepr w -> Gen (Domain w, Integer)
+genPair w =
+  do a <- genDomain w
+     x <- genElement a
+     return (a,x)
+
+-- | Unsafe constructor for internal use.
+interval :: Integer -> Integer -> Integer -> Domain w
+interval mask lo hi = BVBitInterval mask lo hi
+
+range :: NatRepr w -> Integer -> Integer -> Domain w
+range w lo hi = BVBitInterval (maxUnsigned w) lo' hi'
+  where
+  lo'  = lo .&. mask
+  hi'  = hi .&. mask
+  mask = maxUnsigned w
+
+bitrange :: Domain w -> (Integer, Integer)
+bitrange (BVBitInterval _ lo hi) = (lo, hi)
+
+-- | Test if this domain contains a single value, and return it if so
+asSingleton :: Domain w -> Maybe Integer
+asSingleton (BVBitInterval _ lo hi) = if lo == hi then Just lo else Nothing
+
+-- | Returns true iff there is at least on element
+--   in this bitwise domain.
+nonempty :: Domain w -> Bool
+nonempty (BVBitInterval _mask lo hi) = bitle lo hi
+
+-- | Return a domain containing just the given value
+singleton :: NatRepr w -> Integer -> Domain w
+singleton w x = BVBitInterval mask x' x'
+  where
+  x' = x .&. mask
+  mask = maxUnsigned w
+
+any :: NatRepr w -> Domain w
+any w = BVBitInterval mask 0 mask
+  where
+  mask = maxUnsigned w
+
+-- | Returns true iff the domains have some value in common
+domainsOverlap :: Domain w -> Domain w -> Bool
+domainsOverlap a b = nonempty (intersection a b)
+
+eq :: Domain w -> Domain w -> Maybe Bool
+eq a b
+  | Just x <- asSingleton a
+  , Just y <- asSingleton b
+  = Just (x == y)
+
+  | Prelude.not (domainsOverlap a b) = Just False
+  | otherwise = Nothing
+
+intersection :: Domain w -> Domain w -> Domain w
+intersection (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
+  BVBitInterval mask (alo .|. blo) (ahi .&. bhi)
+
+union :: Domain w -> Domain w -> Domain w
+union (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
+  BVBitInterval mask (alo .&. blo) (ahi .|. bhi)
+
+-- | @concat a y@ returns domain where each element in @a@ has been
+-- concatenated with an element in @y@.  The most-significant bits
+-- are @a@, and the least significant bits are @y@.
+concat :: NatRepr u -> Domain u -> NatRepr v -> Domain v -> Domain (u + v)
+concat u (BVBitInterval _ alo ahi) v (BVBitInterval _ blo bhi) =
+    BVBitInterval mask (cat alo blo) (cat ahi bhi)
+  where
+    cat i j = i `shiftL` widthVal v + j
+    mask = maxUnsigned (addNat u v)
+
+-- | @shrink i a@ drops the @i@ least significant bits from @a@.
+shrink ::
+  NatRepr i ->
+  Domain (i + n) -> Domain n
+shrink i (BVBitInterval mask lo hi) = BVBitInterval (shr mask) (shr lo) (shr hi)
+  where
+  shr x = x `shiftR` widthVal i
+
+-- | @trunc n d@ selects the @n@ least significant bits from @d@.
+trunc ::
+  (n <= w) =>
+  NatRepr n ->
+  Domain w ->
+  Domain n
+trunc n (BVBitInterval _ lo hi) = range n lo hi
+
+-- | @select i n a@ selects @n@ bits starting from index @i@ from @a@.
+select ::
+  (1 <= n, i + n <= w) =>
+  NatRepr i ->
+  NatRepr n ->
+  Domain w -> Domain n
+select i n a = shrink i (trunc (addNat i n) a)
+
+zext :: (1 <= w, w+1 <= u) => Domain w -> NatRepr u -> Domain u
+zext (BVBitInterval _ lo hi) u = range u lo hi
+
+sext :: (1 <= w, w+1 <= u) => NatRepr w -> Domain w -> NatRepr u -> Domain u
+sext w (BVBitInterval _ lo hi) u = range u lo' hi'
+  where
+  lo' = toSigned w lo
+  hi' = toSigned w hi
+
+testBit :: Domain w -> Natural -> Maybe Bool
+testBit (BVBitInterval _mask lo hi) i = if lob == hib then Just lob else Nothing
+  where
+  lob = Bits.testBit lo j
+  hib = Bits.testBit hi j
+  j = fromIntegral i
+
+shl :: NatRepr w -> Domain w -> Integer -> Domain w
+shl w (BVBitInterval mask lo hi) y = BVBitInterval mask (shleft lo) (shleft hi)
+  where
+  y' = fromInteger (min y (intValue w))
+  shleft x = (x `shiftL` y') .&. mask
+
+lshr :: NatRepr w -> Domain w -> Integer -> Domain w
+lshr w (BVBitInterval mask lo hi) y = BVBitInterval mask (shr lo) (shr hi)
+  where
+  y' = fromInteger (min y (intValue w))
+  shr x = x `shiftR` y'
+
+ashr :: (1 <= w) => NatRepr w -> Domain w -> Integer -> Domain w
+ashr w (BVBitInterval mask lo hi) y = BVBitInterval mask (shr lo) (shr hi)
+  where
+  y' = fromInteger (min y (intValue w))
+  shr x = ((toSigned w x) `shiftR` y') .&. mask
+
+not :: Domain w -> Domain w
+not (BVBitInterval mask alo ahi) =
+  BVBitInterval mask (ahi `Bits.xor` mask) (alo `Bits.xor` mask)
+
+and :: Domain w -> Domain w -> Domain w
+and (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
+  BVBitInterval mask (alo .&. blo) (ahi .&. bhi)
+
+or :: Domain w -> Domain w -> Domain w
+or (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
+  BVBitInterval mask (alo .|. blo) (ahi .|. bhi)
+
+xor :: Domain w -> Domain w -> Domain w
+xor (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) = BVBitInterval mask clo chi
+  where
+  au  = alo `Bits.xor` ahi
+  bu  = blo `Bits.xor` bhi
+  c   = alo `Bits.xor` blo
+  cu  = au .|. bu
+  chi = c  .|. cu
+  clo = chi `Bits.xor` cu
+
+
+---------------------------------------------------------------------------------------
+-- Correctness properties
+
+correct_any :: (1 <= n) => NatRepr n -> Integer -> Property
+correct_any w x = property (member (any w) x)
+
+correct_singleton :: (1 <= n) => NatRepr n -> Integer -> Integer -> Property
+correct_singleton n x y = property (member (singleton n x') y' == (x' == y'))
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_overlap :: Domain n -> Domain n -> Integer -> Property
+correct_overlap a b x =
+  member a x && member b x ==> domainsOverlap a b
+
+correct_union :: (1 <= n) => Domain n -> Domain n -> Integer -> Property
+correct_union a b x =
+  member a x || member b x ==> member (union a b) x
+
+correct_intersection :: (1 <= n) => Domain n -> Domain n -> Integer -> Property
+correct_intersection a b x =
+  member a x && member b x ==> member (intersection a b) x
+
+correct_zero_ext :: (1 <= w, w+1 <= u) => NatRepr w -> Domain w -> NatRepr u -> Integer -> Property
+correct_zero_ext w a u x = member a x' ==> member (zext a u) x'
+  where
+  x' = toUnsigned w x
+
+correct_sign_ext :: (1 <= w, w+1 <= u) => NatRepr w -> Domain w -> NatRepr u -> Integer -> Property
+correct_sign_ext w a u x = member a x' ==> member (sext w a u) x'
+  where
+  x' = toSigned w x
+
+correct_concat :: NatRepr m -> (Domain m,Integer) -> NatRepr n -> (Domain n,Integer) -> Property
+correct_concat m (a,x) n (b,y) = member a x' ==> member b y' ==> member (concat m a n b) z
+  where
+  x' = toUnsigned m x
+  y' = toUnsigned n y
+  z  = x' `shiftL` (widthVal n) .|. y'
+
+correct_shrink :: NatRepr i -> (Domain (i + n), Integer) -> Property
+correct_shrink i (a,x) = member a x' ==> member (shrink i a) (x' `shiftR` widthVal i)
+  where
+  x' = x .&. bvdMask a
+
+correct_trunc :: (n <= w) => NatRepr n -> (Domain w, Integer) -> Property
+correct_trunc n (a,x) = member a x' ==> member (trunc n a) (toUnsigned n x')
+  where
+  x' = x .&. bvdMask a
+
+correct_eq :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_eq n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case eq a b of
+      Just True  -> toUnsigned n x == toUnsigned n y
+      Just False -> toUnsigned n x /= toUnsigned n y
+      Nothing    -> True
+
+correct_shl :: (1 <= n) => NatRepr n -> (Domain n,Integer) -> Integer -> Property
+correct_shl n (a,x) y = member a x ==> member (shl n a y) z
+  where
+  z = (toUnsigned n x) `shiftL` fromInteger (min (intValue n) y)
+
+correct_lshr :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Integer -> Property
+correct_lshr n (a,x) y = member a x ==> member (lshr n a y) z
+  where
+  z = (toUnsigned n x) `shiftR` fromInteger (min (intValue n) y)
+
+correct_ashr :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Integer -> Property
+correct_ashr n (a,x) y = member a x ==> member (ashr n a y) z
+  where
+  z = (toSigned n x) `shiftR` fromInteger (min (intValue n) y)
+
+correct_not :: (1 <= n) => (Domain n, Integer) -> Property
+correct_not (a,x) = counterexample (show (a,x,not a,complement x)) $
+  member a x ==> member (not a) (complement x)
+
+correct_and :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_and (a,x) (b,y) = member a x ==> member b y ==> member (and a b) (x .&. y)
+
+correct_or :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_or (a,x) (b,y) = member a x ==> member b y ==> member (or a b) (x .|. y)
+
+correct_xor :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_xor (a,x) (b,y) = member a x ==> member b y ==> member (xor a b) (x `Bits.xor` y)
+
+correct_testBit :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Natural -> Property
+correct_testBit n (a,x) i =
+  i < natValue n ==>
+    case testBit a i of
+      Just True  -> Bits.testBit x (fromIntegral i)
+      Just False -> Prelude.not (Bits.testBit x (fromIntegral i))
+      Nothing    -> True

--- a/what4/src/What4/Utils/BVDomain/Bitwise.hs
+++ b/what4/src/What4/Utils/BVDomain/Bitwise.hs
@@ -15,6 +15,7 @@ Provides a bitwise implementation of bitvector abstract domains.
 
 module What4.Utils.BVDomain.Bitwise
   ( Domain(..)
+  , bitle
   , proper
   , bvdMask
   , member

--- a/what4/src/What4/Utils/BVDomain/XOR.hs
+++ b/what4/src/What4/Utils/BVDomain/XOR.hs
@@ -1,0 +1,163 @@
+{-|
+Module      : What4.Utils.BVDomain.XOR
+Copyright   : (c) Galois Inc, 2019
+License     : BSD3
+Maintainer  : huffman@galois.com
+
+Provides an implementation of bitvecotr abstract domains
+optimized for performing XOR operations.
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module What4.Utils.BVDomain.XOR
+  ( -- * XOR Domains
+    Domain(..)
+  , bvdMask
+  , member
+  , range
+  , interval
+  , bitbounds
+  , asSingleton
+    -- ** Operations
+  , singleton
+  , xor
+  , and
+  , and_scalar
+
+    -- * Correctness properties
+  , genDomain
+  , genElement
+  , genPair
+
+  , correct_singleton
+  , correct_xor
+  , correct_and
+  , correct_and_scalar
+  , correct_bitbounds
+  ) where
+
+
+import qualified Data.Bits as Bits
+import           Data.Bits hiding (testBit, xor)
+import           Data.Parameterized.NatRepr
+import           GHC.TypeNats
+
+import           Prelude hiding (any, concat, negate, and, or, not)
+
+import           Test.QuickCheck (Property, property, (==>), Gen, chooseInteger)
+
+-- | A value of type @'BVDomain' w@ represents a set of bitvectors of
+-- width @w@.  This is an alternate representation of the bitwise
+-- domain values, optimized to compute XOR operations.
+data Domain (w :: Nat) =
+    BVDXor !Integer !Integer !Integer
+    -- ^ @BVDXor mask hi unknown@ represents a set of values where
+    --   @hi@ is a bitwise high bound, and @unknown@ represents
+    --   the bits whose values are not known.  The value @mask@
+    --   caches the value @2^w-1@.
+  deriving (Show)
+
+member :: Domain w -> Integer -> Bool
+member (BVDXor mask hi unknown) x = hi == (x .&. mask) .|. unknown
+
+bvdMask :: Domain w -> Integer
+bvdMask (BVDXor mask _ _) = mask
+
+range :: NatRepr w -> Integer -> Integer -> Domain w
+range w lo hi = interval mask lo' hi'
+  where
+  lo'  = lo .&. mask
+  hi'  = hi .&. mask
+  mask = maxUnsigned w
+
+-- | Unsafe constructor for internal use.
+interval :: Integer -> Integer -> Integer -> Domain w
+interval mask lo hi = BVDXor mask hi (Bits.xor lo hi)
+
+bitbounds :: Domain w -> (Integer, Integer)
+bitbounds (BVDXor _ hi u) = (Bits.xor u hi, hi)
+
+-- | Test if this domain contains a single value, and return it if so
+asSingleton :: Domain w -> Maybe Integer
+asSingleton (BVDXor _ hi u) = if u == 0 then Just hi else Nothing
+
+genDomain :: NatRepr w -> Gen (Domain w)
+genDomain w =
+  do let mask = maxUnsigned w
+     val <- chooseInteger (0, mask)
+     u   <- chooseInteger (0, mask)
+     pure $ BVDXor mask (val .|. u) u
+
+genElement :: Domain w -> Gen Integer
+genElement (BVDXor _mask v u) =
+   do x <- chooseInteger (0, bit bs - 1)
+      pure $ stripe lo x 0
+
+  where
+  lo = v `Bits.xor` u
+  bs = Bits.popCount u
+  stripe val x i
+   | x == 0 = val
+   | Bits.testBit u i =
+       let val' = if Bits.testBit x 0 then setBit val i else val in
+       stripe val' (x `shiftR` 1) (i+1)
+   | otherwise = stripe val x (i+1)
+
+genPair :: NatRepr w -> Gen (Domain w, Integer)
+genPair w =
+  do a <- genDomain w
+     x <- genElement a
+     pure (a,x)
+
+
+singleton :: NatRepr w -> Integer -> Domain w
+singleton w x = BVDXor mask (x .&. mask) 0
+  where
+  mask = maxUnsigned w
+
+xor :: Domain w -> Domain w -> Domain w
+xor (BVDXor mask va ua) (BVDXor _ vb ub) = BVDXor mask (v .|. u) u
+  where
+  v = Bits.xor va vb
+  u = ua .|. ub
+
+and :: Domain w -> Domain w -> Domain w
+and (BVDXor mask va ua) (BVDXor _ vb ub) = BVDXor mask v (v .&. u)
+  where
+  v = va .&. vb
+  u = ua .|. ub
+
+and_scalar :: Integer -> Domain w -> Domain w
+and_scalar x (BVDXor mask va ua) = BVDXor mask (va .&. x) (ua .&. x)
+
+-----------------------------------------------------------------------
+-- Correctness properties
+
+correct_singleton :: (1 <= n) => NatRepr n -> Integer -> Integer -> Property
+correct_singleton n x y = property (member (singleton n x') y' == (x' == y'))
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_xor :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_xor (a,x) (b,y) = member a x ==> member b y ==> member (xor a b) (x `Bits.xor` y)
+
+correct_and :: (1 <= n) => (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_and (a,x) (b,y) = member a x ==> member b y ==> member (and a b) (x .&. y)
+
+correct_and_scalar :: (1 <= n) => Integer -> (Domain n, Integer) -> Property
+correct_and_scalar y (a,x) = member a x ==> member (and_scalar y a) (y .&. x)
+
+bitle :: Integer -> Integer -> Bool
+bitle x y = (x .|. y) == y
+
+correct_bitbounds :: Domain n -> Integer -> Property
+correct_bitbounds a x = property (member a x == (bitle lo x && bitle x hi))
+  where
+  (lo,hi) = bitbounds a

--- a/what4/test/BVDomTests.hs
+++ b/what4/test/BVDomTests.hs
@@ -1,0 +1,262 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-
+Module      : BVDomTest
+Copyright   : (c) Galois Inc, 2020
+License     : BSD3
+Maintainer  : rdockins@galois.com
+
+This module performs randomized testing of the bitvector abstract domain
+computations, which are among relatively complex.
+
+The intended meaning of the abstract domain computations are
+specified using Cryptol in "doc/bvdoman.cry" and realated files.
+In those files soundness properites are proved for the implementations.
+These tests are intended to supplement those proofs for the actual
+implementations, which are transliterated from the Cryptol.
+-}
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Data.Parameterized.NatRepr
+import           Data.Parameterized.Some
+
+import qualified What4.Utils.BVDomain.Arith as A
+import qualified What4.Utils.BVDomain.Bitwise as B
+
+main :: IO ()
+main = defaultMain $
+  localOption (QuickCheckTests 5000) $
+    testGroup "Bitvector Domain"
+    [ arithDomainTests
+    , bitwiseDomainTests
+    ]
+
+data SomeWidth where
+  SW :: (1 <= w) => NatRepr w -> SomeWidth
+
+genWidth :: Gen SomeWidth
+genWidth =
+  do sz <- getSize
+     x <- chooseInt (1, sz+4)
+     case someNat x of
+       Just (Some n)
+         | Just LeqProof <- isPosNat n -> pure (SW n)
+       _ -> fail "test panic! genWidth"
+
+genBV :: NatRepr w -> Gen Integer
+genBV w = chooseInteger (minUnsigned w, maxUnsigned w)
+
+genTest :: String -> Gen Property -> TestTree
+genTest nm p = testProperty nm p
+
+arithDomainTests :: TestTree
+arithDomainTests = testGroup "Arith Domain"
+  [ genTest "correct_any" $
+      do SW n <- genWidth
+         A.correct_any n <$> genBV n
+  , genTest "correct_ubounds" $
+      do SW n <- genWidth
+         A.correct_ubounds n <$> A.genPair n
+  , genTest "correct_sbounds" $
+      do SW n <- genWidth
+         A.correct_sbounds n <$> A.genPair n
+  , genTest "correct_singleton" $
+      do SW n <- genWidth
+         A.correct_singleton n <$> genBV n <*> genBV n
+  , genTest "correct_overlap" $
+      do SW n <- genWidth
+         A.correct_overlap <$> A.genDomain n <*> A.genDomain n <*> genBV n
+  , genTest "correct_union" $
+      do SW n <- genWidth
+         A.correct_union <$> A.genDomain n <*> A.genDomain n <*> genBV n
+  , genTest "correct_zero_ext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- A.genDomain w
+                x <- A.genElement a
+                pure $ A.correct_zero_ext w a u x
+  , genTest "correct_sign_ext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- A.genDomain w
+                x <- A.genElement a
+                pure $ A.correct_sign_ext w a u x
+  , genTest "correct_concat" $
+      do SW m <- genWidth
+         SW n <- genWidth
+         A.correct_concat m <$> A.genPair m <*> pure n <*> A.genPair n
+  , genTest "correct_shrink" $
+      do SW i <- genWidth
+         SW n <- genWidth
+         A.correct_shrink i <$> A.genPair (addNat i n)
+  , genTest "correct_trunc" $
+      do SW n <- genWidth
+         SW m <- genWidth
+         let w = addNat n m
+         LeqProof <- pure $ addIsLeq n m
+         A.correct_trunc n <$> A.genPair w
+  , genTest "correct_add" $
+      do SW n <- genWidth
+         A.correct_add <$> A.genPair n <*> A.genPair n
+  , genTest "correct_neg" $
+      do SW n <- genWidth
+         A.correct_neg <$> A.genPair n
+  , genTest "correct_not" $
+      do SW n <- genWidth
+         A.correct_not <$> A.genPair n
+  , genTest "correct_mul" $
+      do SW n <- genWidth
+         A.correct_mul <$> A.genPair n <*> A.genPair n
+  , genTest "correct_udiv" $
+      do SW n <- genWidth
+         A.correct_udiv n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_urem" $
+      do SW n <- genWidth
+         A.correct_urem n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_sdiv" $
+      do SW n <- genWidth
+         A.correct_sdiv n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_sdivRange" $
+      do SW n <- genWidth
+         a <- (,) <$> genBV n <*> genBV n
+         b <- (,) <$> genBV n <*> genBV n
+         x <- genBV n
+         y <- genBV n
+         pure $ A.correct_sdivRange a b x y
+  , genTest "correct_srem" $
+      do SW n <- genWidth
+         A.correct_srem n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_shl"$
+      do SW n <- genWidth
+         A.correct_shl n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_lshr"$
+      do SW n <- genWidth
+         A.correct_lshr n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_ashr"$
+      do SW n <- genWidth
+         A.correct_ashr n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_eq" $
+      do SW n <- genWidth
+         A.correct_eq n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_ult" $
+      do SW n <- genWidth
+         A.correct_ult n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_slt" $
+      do SW n <- genWidth
+         A.correct_slt n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_unknowns" $
+      do SW n <- genWidth
+         a <- A.genDomain n
+         x <- A.genElement a
+         y <- A.genElement a
+         pure $ A.correct_unknowns a x y
+  , genTest "correct_bitbounds" $
+      do SW n <- genWidth
+         A.correct_bitbounds n <$> A.genPair n
+  ]
+
+bitwiseDomainTests :: TestTree
+bitwiseDomainTests = localOption (QuickCheckMaxRatio 1000) $
+  testGroup "Bitwise Domain"
+  [ genTest "correct_any" $
+      do SW n <- genWidth
+         B.correct_any n <$> genBV n
+  , genTest "correct_singleton" $
+      do SW n <- genWidth
+         B.correct_singleton n <$> genBV n <*> genBV n
+  , genTest "correct_overlap" $
+      do SW n <- genWidth
+         B.correct_overlap <$> B.genDomain n <*> B.genDomain n <*> genBV n
+  , genTest "correct_union1" $
+      do SW n <- genWidth
+         (a,x) <- B.genPair n
+         b <- B.genDomain n
+         pure $ B.correct_union a b x
+  , genTest "correct_union2" $
+      do SW n <- genWidth
+         a <- B.genDomain n
+         (b,x) <- B.genPair n
+         pure $ B.correct_union a b x
+  , genTest "correct_intersection" $
+      do SW n <- genWidth
+         B.correct_intersection <$> B.genDomain n <*> B.genDomain n <*> genBV n
+  , genTest "correct_zero_ext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- B.genDomain w
+                x <- B.genElement a
+                pure $ B.correct_zero_ext w a u x
+  , genTest "correct_sign_ext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- B.genDomain w
+                x <- B.genElement a
+                pure $ B.correct_sign_ext w a u x
+  , genTest "correct_concat" $
+      do SW m <- genWidth
+         SW n <- genWidth
+         B.correct_concat m <$> B.genPair m <*> pure n <*> B.genPair n
+  , genTest "correct_shrink" $
+      do SW i <- genWidth
+         SW n <- genWidth
+         B.correct_shrink i <$> B.genPair (addNat i n)
+  , genTest "correct_trunc" $
+      do SW n <- genWidth
+         SW m <- genWidth
+         let w = addNat n m
+         LeqProof <- pure $ addIsLeq n m
+         B.correct_trunc n <$> B.genPair w
+  , genTest "correct_shl"$
+      do SW n <- genWidth
+         B.correct_shl n <$> B.genPair n <*> chooseInteger (0, intValue n)
+  , genTest "correct_lshr"$
+      do SW n <- genWidth
+         B.correct_lshr n <$> B.genPair n <*> chooseInteger (0, intValue n)
+  , genTest "correct_ashr"$
+      do SW n <- genWidth
+         B.correct_ashr n <$> B.genPair n <*> chooseInteger (0, intValue n)
+  , genTest "correct_eq" $
+      do SW n <- genWidth
+         B.correct_eq n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_not" $
+      do SW n <- genWidth
+         B.correct_not <$> B.genPair n
+  , genTest "correct_and" $
+      do SW n <- genWidth
+         B.correct_and <$> B.genPair n <*> B.genPair n
+  , genTest "correct_or" $
+      do SW n <- genWidth
+         B.correct_or <$> B.genPair n <*> B.genPair n
+  , genTest "correct_xor" $
+      do SW n <- genWidth
+         B.correct_xor <$> B.genPair n <*> B.genPair n
+  , genTest "correct_testBit" $
+      do SW n <- genWidth
+         i <- fromInteger <$> chooseInteger (0, intValue n - 1)
+         B.correct_testBit n <$> B.genPair n <*> pure i
+  ]

--- a/what4/test/BVDomTests.hs
+++ b/what4/test/BVDomTests.hs
@@ -317,23 +317,36 @@ bitwiseDomainTests =
 
 overallDomainTests :: TestTree
 overallDomainTests = testGroup "Overall Domain"
-  [ genTest "correct_any" $
+  [ genTest "correct_bra1" $
+      do SW n <- genWidth
+         O.correct_bra1 n <$> genBV n <*> genBV n
+  , genTest "correct_bra2" $
+      do SW n <- genWidth
+         O.correct_bra2 n <$> genBV n <*> genBV n <*> genBV n
+  , genTest "correct_brb1" $
+      do SW n <- genWidth
+         O.correct_brb1 n <$> genBV n <*> genBV n <*> genBV n
+  , genTest "correct_brb2" $
+      do SW n <- genWidth
+         O.correct_brb2 n <$> genBV n <*> genBV n <*> genBV n <*> genBV n
+  , genTest "correct_any" $
       do SW n <- genWidth
          O.correct_any n <$> genBV n
   , genTest "correct_ubounds" $
       do SW n <- genWidth
          O.correct_ubounds n <$> O.genPair n
-
   , genTest "correct_sbounds" $
       do SW n <- genWidth
          O.correct_sbounds n <$> O.genPair n
-
   , genTest "correct_singleton" $
       do SW n <- genWidth
          O.correct_singleton n <$> genBV n <*> genBV n
   , genTest "correct_overlap" $
       do SW n <- genWidth
          O.correct_overlap <$> O.genDomain n <*> O.genDomain n <*> genBV n
+  , genTest "precise_overlap" $
+      do SW n <- genWidth
+         O.precise_overlap <$> O.genDomain n <*> O.genDomain n
   , genTest "correct_union" $
       do SW n <- genWidth
          O.correct_union n <$> O.genDomain n <*> O.genDomain n <*> genBV n

--- a/what4/test/BVDomTests.hs
+++ b/what4/test/BVDomTests.hs
@@ -62,7 +62,7 @@ genWidth =
      case someNat x of
        Just (Some n)
          | Just LeqProof <- isPosNat n -> pure (SW n)
-       _ -> fail "test panic! genWidth"
+       _ -> error "test panic! genWidth"
 
 genBV :: NatRepr w -> Gen Integer
 genBV w = chooseInteger (minUnsigned w, maxUnsigned w)

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -116,6 +116,7 @@ library
     What4.Utils.BVDomain
     What4.Utils.BVDomain.Arith
     What4.Utils.BVDomain.Bitwise
+    What4.Utils.BVDomain.XOR
     What4.Utils.Complex
     What4.Utils.Endian
     What4.Utils.Environment

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -40,6 +40,7 @@ library
     panic >= 0.3,
     parameterized-utils >= 1.0.8 && < 2.1,
     process,
+    QuickCheck >= 2.14 && < 2.15,
     scientific,
     temporary >= 1.2,
     template-haskell,
@@ -113,6 +114,8 @@ library
     What4.Utils.AnnotatedMap
     What4.Utils.Arithmetic
     What4.Utils.BVDomain
+    What4.Utils.BVDomain.Arith
+    What4.Utils.BVDomain.Bitwise
     What4.Utils.Complex
     What4.Utils.Endian
     What4.Utils.Environment
@@ -188,6 +191,24 @@ test-suite iteexprs_tests
                , tasty >= 0.10
                , tasty-hunit >= 0.9
                , tasty-hedgehog
+               , what4
+
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+
+test-suite bvdomain_tests
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+
+  hs-source-dirs: test
+  main-is: BVDomTests.hs
+
+  other-modules:
+
+  build-depends: base
+               , parameterized-utils
+               , tasty >= 0.10
+               , tasty-quickcheck >= 0.10
+               , QuickCheck
                , what4
 
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns


### PR DESCRIPTION
The bitvector abstract domain has been split into two subdomains: one for dealing with arithmetic operations and one for dealing with bitwise operations.  We attempt to minimize information loss by only shifting between the two modes when necessary.  The Cryptol specification of the these domains is likewise split between the two modes.

I've added a new test suite specifically to test the same correctness assertions as found in the Cryptol specification.  This exposed bugs in the `sdiv` and `srem` operations, where the implementations did not meet the specification.

There is also a third domain optimized for performing XOR operations.  It is essentially isomorphic to the bitwise domain, but requires fewer operations to compute XOR.  It is specifically for use in the bitwise XOR semi-ring.

Finally, fill in a few missing operations: there are now abstract implementations for rotates, popcount, count leading zeros and count trailing zeros.
