### PR TITLE
Tweak the BVDomain to handle common cases better

### DIFF
--- a/what4/src/What4/Utils/BVDomain.hs
+++ b/what4/src/What4/Utils/BVDomain.hs
@@ -20,6 +20,7 @@ module What4.Utils.BVDomain
     BVDomain(..)
   , proper
   , member
+  , size
     -- ** Domain transfer functions
   , asArithDomain
   , asBitwiseDomain
@@ -234,6 +235,10 @@ member :: BVDomain w -> Integer -> Bool
 member (BVDArith a) x = A.member a x
 member (BVDBitwise a) x = B.member a x
 
+size :: BVDomain w -> Integer
+size (BVDArith a)   = A.size a
+size (BVDBitwise b) = B.size b
+
 genDomain :: NatRepr w -> Gen (BVDomain w)
 genDomain w =
   do b <- arbitrary
@@ -407,7 +412,7 @@ any w = BVDBitwise (B.any w)
 
 -- | Create a bitvector domain representing the integer.
 singleton :: (HasCallStack, 1 <= w) => NatRepr w -> Integer -> BVDomain w
-singleton w x = BVDBitwise (B.singleton w x)
+singleton w x = BVDArith (A.singleton w x)
 
 -- | @range w l u@ returns domain containing all bitvectors formed
 -- from the @w@ low order bits of some @i@ in @[l,u]@.  Note that per
@@ -423,7 +428,14 @@ fromAscEltList w xs = BVDArith (A.fromAscEltList w xs)
 -- | Return union of two domains.
 union :: (1 <= w) => BVDomain w -> BVDomain w -> BVDomain w
 union (BVDBitwise a) (BVDBitwise b) = BVDBitwise (B.union a b)
-union (asArithDomain -> a) (asArithDomain -> b) = BVDArith (A.union a b)
+union (BVDArith a) (BVDArith b) = BVDArith (A.union a b)
+union (BVDBitwise a) (BVDArith b) = mixedUnion b a
+union (BVDArith a) (BVDBitwise b) = mixedUnion a b
+
+mixedUnion :: (1 <= w) => A.Domain w -> B.Domain w  -> BVDomain w
+mixedUnion a b
+  | Just _ <- A.asSingleton a = BVDBitwise (B.union (arithToBitwiseDomain a) b)
+  | otherwise = BVDArith (A.union a (bitwiseToArithDomain b))
 
 -- | @concat a y@ returns domain where each element in @a@ has been
 -- concatenated with an element in @y@.  The most-significant bits

--- a/what4/src/What4/Utils/BVDomain/Arith.hs
+++ b/what4/src/What4/Utils/BVDomain/Arith.hs
@@ -22,6 +22,7 @@ module What4.Utils.BVDomain.Arith
   , member
   , pmember
   , interval
+  , size
   -- * Projection functions
   , asSingleton
   , ubounds
@@ -122,6 +123,10 @@ data Domain (w :: Nat)
   -- satisfy the invariants @0 <= l < 2^w@ and @0 <= d < 2^w@. The
   -- first argument caches the value @2^w-1@.
   deriving Show
+
+size :: Domain w -> Integer
+size (BVDAny mask)        = mask + 1
+size (BVDInterval _ _ sz) = sz + 1
 
 member :: Domain w -> Integer -> Bool
 member (BVDAny _) _ = True
@@ -308,13 +313,13 @@ union a b =
         BVDInterval mask bl bw ->
           interval mask cl (ch - cl)
           where
-            size = mask + 1
+            sz = mask + 1
             ac = 2 * al + aw -- twice the average value of a
             bc = 2 * bl + bw -- twice the average value of b
             -- If the averages are 2^(w-1) or more apart,
             -- then shift the lower interval up by 2^w.
-            al' = if ac + mask < bc then al + size else al
-            bl' = if bc + mask < ac then bl + size else bl
+            al' = if ac + mask < bc then al + sz else al
+            bl' = if bc + mask < ac then bl + sz else bl
             ah' = al' + aw
             bh' = bl' + bw
             cl = min al' bl'
@@ -403,13 +408,13 @@ shl w a b
   | otherwise = interval mask lo (hi - lo)
     where
       mask = bvdMask a
-      size = mask + 1
+      sz = mask + 1
       (bl, bh) = ubounds b
       bl' = clamp w bl
       bh' = clamp w bh
       -- compute bounds for c = 2^b
-      cl = if (mask `shiftR` bl' == 0) then size else bit bl'
-      ch = if (mask `shiftR` bh' == 0) then size else bit bh'
+      cl = if (mask `shiftR` bl' == 0) then sz else bit bl'
+      ch = if (mask `shiftR` bh' == 0) then sz else bit bh'
       (lo, hi) = mulRange (zbounds a) (cl, ch)
 
 lshr :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w

--- a/what4/src/What4/Utils/BVDomain/Bitwise.hs
+++ b/what4/src/What4/Utils/BVDomain/Bitwise.hs
@@ -20,6 +20,7 @@ module What4.Utils.BVDomain.Bitwise
   , bvdMask
   , member
   , pmember
+  , size
   , asSingleton
   , nonempty
   , eq
@@ -112,6 +113,14 @@ proper w (BVBitInterval mask lo hi) =
 member :: Domain w -> Integer -> Bool
 member (BVBitInterval mask lo hi) x = bitle lo x' && bitle x' hi
   where x' = x .&. mask
+
+size :: Domain w -> Integer
+size (BVBitInterval _ lo hi)
+  | bitle lo hi = Bits.bit p
+  | otherwise   = 0
+ where
+ u = Bits.xor lo hi
+ p = Bits.popCount u
 
 bitle :: Integer -> Integer -> Bool
 bitle x y = (x .|. y) == y

--- a/what4/test/BVDomTests.hs
+++ b/what4/test/BVDomTests.hs
@@ -24,6 +24,7 @@ These tests are intended to supplement those proofs for the actual
 implementations, which are transliterated from the Cryptol.
 -}
 
+import qualified Data.Bits as Bits
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Data.Parameterized.NatRepr
@@ -317,7 +318,16 @@ bitwiseDomainTests =
 
 overallDomainTests :: TestTree
 overallDomainTests = testGroup "Overall Domain"
-  [ genTest "correct_bra1" $
+  [ -- test that the union of consecutive singletons gives a precise interval
+    genTest "singleton/union size" $
+      do SW n <- genWidth
+         let w =  maxUnsigned n
+         x <- genBV n
+         y <- min 1000 <$> genBV n
+         let as = [ O.singleton n ((x + i) Bits..&. w) | i <- [0 .. y] ]
+         let a = foldl1 O.union as
+         pure $ property (O.size a == y+1)
+  , genTest "correct_bra1" $
       do SW n <- genWidth
          O.correct_bra1 n <$> genBV n <*> genBV n
   , genTest "correct_bra2" $


### PR DESCRIPTION
Default to using the arithmetic mode so that when we union together
a collection of consecutive singleton values, we get a precise arithmetic
interval.  Add a test to the test suite to check for this property.