### PR TITLE
Make ADT field comments normal, not haddock for internal structure.

### DIFF
--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -737,11 +737,11 @@ parseFloatSolverValue (FloatingPointPrecisionRepr eb sb) s = do
     _ -> fail $ "Unexpected float precision: " <> show eb' <> ", " <> show sb'
 
 data ParsedFloatResult = forall eb sb . ParsedFloatResult
-  (BV.BV 1)    -- ^ sign
-  (NatRepr eb) -- ^ exponent width
-  (BV.BV eb)   -- ^ exponent
-  (NatRepr sb) -- ^ significand bit width
-  (BV.BV sb)   -- ^ significand bit
+  (BV.BV 1)    -- sign
+  (NatRepr eb) -- exponent width
+  (BV.BV eb)   -- exponent
+  (NatRepr sb) -- significand bit width
+  (BV.BV sb)   -- significand bit
 
 parseFloatLitHelper :: MonadFail m => SExp -> m ParsedFloatResult
 parseFloatLitHelper (SApp ["fp", sign_s, expt_s, scand_s])


### PR DESCRIPTION
GHC 8.4 haddock does not support comments on individual fields of an
ADT.  This particular structure is internal only and lacks general
description haddocks, so simply converting these from haddock comments
to normal comments resolves this issue.