### PR TITLE
Expose some SMT collector operations in SMTWriter.

### DIFF
--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -72,6 +72,7 @@ module What4.Protocol.SMTWriter
   , mkFreeVar
   , bindVarAsFree
   , TypeMap(..)
+  , typeMap
   , freshBoundVarName
   , assumeFormula
   , assumeFormulaWithName
@@ -86,6 +87,9 @@ module What4.Protocol.SMTWriter
   , mkAtomicFormula
   , SMTEvalFunctions(..)
   , smtExprGroundEvalFn
+  , CollectorResults(..)
+  , mkBaseExpr
+  , runInSandbox
     -- * Reexports
   , What4.Interface.RoundingMode(..)
   ) where


### PR DESCRIPTION
As discussed in #44 , those changes will allow implementing language-sally by leveraging What4's SMTWriter.

Speaking of which, the language-sally package will need to depend on a version of what4 that exposes those functions. Does this warrant a new minor version number? Should I just hardcode this commit number until what4 is ready for a version bump?

EDIT: Come to think about it, I will be using language-sally within crucible and can just use a submodule to pinpoint the commit for the time being.