### PR TITLE
Fix use of BVDomain.Arith.scale.

### DIFF
--- a/what4/src/What4/Expr/WeightedSum.hs
+++ b/what4/src/What4/Expr/WeightedSum.hs
@@ -120,9 +120,11 @@ abstractTerm sr c e =
     SR.SemiRingNatRepr     -> SRAbsNatAdd (AD.natRangeScalarMul c (AD.getAbsValue e))
     SR.SemiRingIntegerRepr -> SRAbsIntAdd (AD.rangeScalarMul c (AD.getAbsValue e))
     SR.SemiRingRealRepr    -> SRAbsRealAdd (AD.ravScalarMul c (AD.getAbsValue e))
-    SR.SemiRingBVRepr fv _w ->
+    SR.SemiRingBVRepr fv w ->
       case fv of
-        SR.BVArithRepr -> SRAbsBVAdd (A.scale (BV.asUnsigned c) (BVD.asArithDomain (AD.getAbsValue e)))
+        SR.BVArithRepr ->
+          -- A.scale expects a signed integer coefficient
+          SRAbsBVAdd (A.scale (BV.asSigned w c) (BVD.asArithDomain (AD.getAbsValue e)))
         SR.BVBitsRepr  -> SRAbsBVXor (X.and_scalar (BV.asUnsigned c) (BVD.asXorDomain (AD.getAbsValue e)))
 
 abstractVal :: AD.HasAbsValue f => SR.SemiRingRepr sr -> f (SR.SemiRingBase sr) -> SRAbsValue sr

--- a/what4/src/What4/Utils/BVDomain.hs
+++ b/what4/src/What4/Utils/BVDomain.hs
@@ -112,6 +112,7 @@ module What4.Utils.BVDomain
   , correct_add
   , correct_neg
   , correct_mul
+  , correct_scale
   , correct_udiv
   , correct_urem
   , correct_sdiv
@@ -745,6 +746,11 @@ correct_neg n (a,x) = member a x ==> pmember n (negate a) (Prelude.negate x)
 
 correct_mul :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
 correct_mul n (a,x) (b,y) = member a x ==> member b y ==> pmember n (mul a b) (x * y)
+
+correct_scale :: (1 <= n) => NatRepr n -> Integer -> (BVDomain n, Integer) -> Property
+correct_scale n k (a,x) = member a x ==> pmember n (scale k' a) (k' * x)
+  where
+  k' = toSigned n k
 
 correct_udiv :: (1 <= n) => NatRepr n -> (BVDomain n, Integer) -> (BVDomain n, Integer) -> Property
 correct_udiv n (a,x) (b,y) = member a x' ==> member b y' ==> y' /= 0 ==> pmember n (udiv a b) (x' `quot` y')

--- a/what4/src/What4/Utils/BVDomain/Arith.hs
+++ b/what4/src/What4/Utils/BVDomain/Arith.hs
@@ -469,7 +469,7 @@ scale k a
       BVDAny _ -> a
       BVDInterval mask al aw
         | k >= 0 -> interval mask (k * al) (k * aw)
-        | otherwise -> interval mask (k * ah) (k * aw)
+        | otherwise -> interval mask (k * ah) (abs k * aw)
         where ah = al + aw
 
 mul :: (1 <= w) => Domain w -> Domain w -> Domain w

--- a/what4/test/BVDomTests.hs
+++ b/what4/test/BVDomTests.hs
@@ -145,6 +145,12 @@ arithDomainTests = testGroup "Arith Domain"
   , genTest "correct_mul" $
       do SW n <- genWidth
          A.correct_mul n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_scale" $
+      do SW n <- genWidth
+         A.correct_scale n <$> genBV n <*> A.genPair n
+  , genTest "correct_scale_eq" $
+      do SW n <- genWidth
+         A.correct_scale_eq n <$> genBV n <*> A.genDomain n
   , genTest "correct_udiv" $
       do SW n <- genWidth
          A.correct_udiv n <$> A.genPair n <*> A.genPair n
@@ -398,6 +404,9 @@ overallDomainTests = testGroup "Overall Domain"
   , genTest "correct_neg" $
       do SW n <- genWidth
          O.correct_neg n <$> O.genPair n
+  , genTest "correct_scale" $
+      do SW n <- genWidth
+         O.correct_scale n <$> genBV n <*> O.genPair n
   , genTest "correct_mul" $
       do SW n <- genWidth
          O.correct_mul n <$> O.genPair n <*> O.genPair n

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -911,8 +911,9 @@ testBVDomainArithScale = testCase "bv domain arith scale" $
     x  <- freshConstant sym (userSymbol' "x") (BaseBVRepr $ knownNat @8)
     e0 <- bvZext sym (knownNat @16) x
     e1 <- bvNeg sym e0
-    e2 <- bvUgt sym e1 =<< bvLit sym knownRepr (BV.mkBV knownNat 256)
-    e2 @?= truePred sym
+    e2 <- bvSub sym e1 =<< bvLit sym knownRepr (BV.mkBV knownNat 1)
+    e3 <- bvUgt sym e2 =<< bvLit sym knownRepr (BV.mkBV knownNat 256)
+    e3 @?= truePred sym
 
 main :: IO ()
 main = defaultMain $ testGroup "Tests"

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -905,6 +905,15 @@ testSolverVersion = testCase "test solver version bounds" $
                     , _vRel = [] }
     checkSolverVersion' (Map.singleton "Z3" v) Map.empty proc >> return ()
 
+testBVDomainArithScale :: TestTree
+testBVDomainArithScale = testCase "bv domain arith scale" $
+  withSym FloatIEEERepr $ \sym -> do
+    x  <- freshConstant sym (userSymbol' "x") (BaseBVRepr $ knownNat @8)
+    e0 <- bvZext sym (knownNat @16) x
+    e1 <- bvNeg sym e0
+    e2 <- bvUgt sym e1 =<< bvLit sym knownRepr (BV.mkBV knownNat 256)
+    e2 @?= truePred sym
+
 main :: IO ()
 main = defaultMain $ testGroup "Tests"
   [ testInterpretedFloatReal
@@ -933,6 +942,7 @@ main = defaultMain $ testGroup "Tests"
   , testBoundVarAsFree
   , testSolverInfo
   , testSolverVersion
+  , testBVDomainArithScale
 
   , testCase "Yices 0-tuple" $ withYices zeroTupleTest
   , testCase "Yices 1-tuple" $ withYices oneTupleTest


### PR DESCRIPTION
Currently, `bvSub` or any other operation that introduces a negative coefficient in the semi-ring makes the abstract domain go to `BVAny`.

cc @travitch 