### PR TITLE
Adapter enhancements

### DIFF
--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -35,7 +35,7 @@ module What4.Protocol.Online
   ) where
 
 import           Control.Exception
-                   ( SomeException(..), catch, catchJust, tryJust, displayException )
+                   ( SomeException(..), catchJust, tryJust, displayException )
 import           Control.Monad ( unless )
 import           Control.Monad (void, forM, forM_)
 import           Control.Monad.Catch ( MonadMask, bracket_, onException )

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -225,7 +225,7 @@ inNewFrame p action = inNewFrameWithVars p [] action
 
 -- | Perform an action in the scope of a solver assumption frame, where the given
 -- bound variables are considered free within that frame.
-inNewFrameWithVars :: (MonadIO m, MonadMask m, SMTReadWriter solver) 
+inNewFrameWithVars :: (MonadIO m, MonadMask m, SMTReadWriter solver)
                    => SolverProcess scope solver
                    -> [Some (ExprBoundVar scope)]
                    -> m a
@@ -358,9 +358,11 @@ getSatResult yp = do
     Right ok -> return ok
 
     Left (SomeException e) ->
-       do txt <- readAllLines err_reader
-          -- Interrupt process; suppress any exceptions that occur.
-          catch (terminateProcess ph) (\(_ :: IOError) -> return ())
+       do -- Interrupt process
+          terminateProcess ph
+
+          txt <- readAllLines err_reader
+
           -- Wait for process to end
           ec <- waitForProcess ph
           let ec_code = case ec of

--- a/what4/src/What4/Utils/HandleReader.hs
+++ b/what4/src/What4/Utils/HandleReader.hs
@@ -1,4 +1,4 @@
-
+{-# LANGUAGE ScopedTypeVariables #-}
 module What4.Utils.HandleReader where
 
 import           Control.Monad (unless)
@@ -7,11 +7,10 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Text.IO as Text
-import           Control.Exception(bracket,catch)
+import           Control.Exception(bracket,catch,IOException)
 import           Control.Concurrent(ThreadId,forkIO,killThread)
 import           Control.Concurrent.Chan(Chan,newChan,readChan,writeChan)
 import           System.IO(Handle,hPutStrLn,stderr,hClose)
-import           System.IO.Error(isEOFError,ioeGetErrorType)
 import           System.IO.Streams( OutputStream, InputStream )
 import qualified System.IO.Streams as Streams
 
@@ -113,12 +112,7 @@ streamLines c h (Just auxstr) = go
 startHandleReader :: Handle -> Maybe (OutputStream Text) -> IO HandleReader
 startHandleReader h auxOutput = do
   c <- newChan
-  let handle_err e
-        | isEOFError e = do
-            writeChan c Nothing
-        | otherwise = do
-            hPutStrLn stderr $ show (ioeGetErrorType e)
-            hPutStrLn stderr $ show e
+  let handle_err (_e :: IOException) = writeChan c Nothing
   tid <- forkIO $ streamLines c h auxOutput `catch` handle_err
 
   return $! HandleReader { hrChan     = c

--- a/what4/src/What4/Utils/HandleReader.hs
+++ b/what4/src/What4/Utils/HandleReader.hs
@@ -10,7 +10,7 @@ import qualified Data.Text.IO as Text
 import           Control.Exception(bracket,catch,IOException)
 import           Control.Concurrent(ThreadId,forkIO,killThread)
 import           Control.Concurrent.Chan(Chan,newChan,readChan,writeChan)
-import           System.IO(Handle,hPutStrLn,stderr,hClose)
+import           System.IO(Handle,hClose)
 import           System.IO.Streams( OutputStream, InputStream )
 import qualified System.IO.Streams as Streams
 


### PR DESCRIPTION
Some minor changes to support Cryptol.  The `smokeTest` simply performs a trivial query to verify that we can communicate with a particular solver, and some minor changes to the exception-handling stack allow more graceful interruption.