### PR TITLE
Fixes documentation for intDiv in What4.Interface

### DIFF
--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -622,8 +622,9 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
   --   zero" nor "round toward -inf" definitions.
   --
   --   Some useful theorems that are true of this division/modulus pair:
-  --    * @mod x y == mod x (- y) == mod x (abs y)@
-  --    * @div x (-y) == -(div x y)@
+  --
+  --   * @mod x y == mod x (- y) == mod x (abs y)@
+  --   * @div x (-y) == -(div x y)@
   intDiv :: sym -> SymInteger sym -> SymInteger sym -> IO (SymInteger sym)
 
   -- | @intMod x y@ computes the integer modulus of @x@ by @y@.  See 'intDiv' for


### PR DESCRIPTION
Address https://github.com/GaloisInc/what4/issues/72.

I believe Brian's concern about "undefined" is addressed in the documentation for the `IsExprBuilder` class itself, but perhaps there is a way to make it more explicit in the various functions that have certain conditional undefined behavior.