### PR TITLE
Add basic test cases for more of the Builder interface

### DIFF
--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -2801,7 +2801,12 @@ asConcrete x =
     BaseBVRepr w    -> ConcreteBV w <$> asBV x
     BaseFloatRepr _ -> Nothing
     BaseStructRepr _ -> ConcreteStruct <$> (asStruct x >>= traverseFC asConcrete)
-    BaseArrayRepr _ _ -> Nothing -- FIXME?
+    BaseArrayRepr idx _tp -> do
+      def <- asConstantArray x
+      c_def <- asConcrete def
+      -- TODO: what about cases where there are updates to the array?
+      -- Passing Map.empty is probably wrong.
+      pure (ConcreteArray idx c_def Map.empty)
 
 -- | Create a literal symbolic value from a concrete value.
 concreteToSym :: IsExprBuilder sym => sym -> ConcreteVal tp -> IO (SymExpr sym tp)

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -608,7 +608,7 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
   --   @div@ and @mod@ are the unique Euclidean division operations satisfying the
   --   following for all @y /= 0@:
   --
-  --   * @x * (div x y) + (mod x y) == x@
+  --   * @y * (div x y) + (mod x y) == x@
   --   * @ 0 <= mod x y < abs y@
   --
   --   The value of @intDiv x y@ is undefined when @y = 0@.

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -2800,9 +2800,8 @@ asConcrete x =
     BaseComplexRepr -> ConcreteComplex <$> asComplex x
     BaseBVRepr w    -> ConcreteBV w <$> asBV x
     BaseFloatRepr _ -> Nothing
-    BaseStructRepr _ -> Nothing -- FIXME?
+    BaseStructRepr _ -> ConcreteStruct <$> (asStruct x >>= traverseFC asConcrete)
     BaseArrayRepr _ _ -> Nothing -- FIXME?
-
 
 -- | Create a literal symbolic value from a concrete value.
 concreteToSym :: IsExprBuilder sym => sym -> ConcreteVal tp -> IO (SymExpr sym tp)

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -808,10 +808,6 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
 
   -- | returns true if the given bitvector is non-zero.
   bvIsNonzero :: (1 <= w) => sym -> SymBV sym w -> IO (Pred sym)
-  bvIsNonzero sym x = do
-     let w = bvWidth x
-     zro <- bvLit sym w (BV.zero w)
-     notPred sym  =<< bvEq sym x zro
 
   -- | Left shift.  The shift amount is treated as an unsigned value.
   bvShl :: (1 <= w) => sym ->

--- a/what4/test/IteExprs.hs
+++ b/what4/test/IteExprs.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-|
 Module      : IteExprs test
@@ -22,6 +23,7 @@ import           Control.Monad.IO.Class ( liftIO )
 import qualified Data.BitVector.Sized as BV
 import           Data.List ( isInfixOf )
 import           Data.Parameterized.Nonce
+import qualified Data.Parameterized.Context as Ctx
 import           GenWhat4Expr
 import           Hedgehog
 import qualified Hedgehog.Internal.Gen as IGen
@@ -109,6 +111,20 @@ calcBVIte itc =
             Else -> BV.mkBV w 8293
   return (asConcrete i, ConcreteBV w e, desc itc, show c)
 
+-- | Create an ITE whose type is Struct and return the concrete value, the
+-- expected value, and the string description
+calcStructIte :: ITETestCond -> CalcReturn (BaseStructType (Ctx.EmptyCtx Ctx.::> BaseBoolType))
+calcStructIte itc =
+  withTestSolver $ \sym -> do
+  l <- mkStruct sym (Ctx.Empty Ctx.:> truePred sym)
+  r <- mkStruct sym (Ctx.Empty Ctx.:> falsePred sym)
+  c <- cond itc sym
+  i <- baseTypeIte sym c l r
+  let e = case expect itc of
+            Then -> Ctx.Empty Ctx.:> ConcreteBool True
+            Else -> Ctx.Empty Ctx.:> ConcreteBool False
+  return (asConcrete i, ConcreteStruct e, desc itc, show c)
+
 -- | Given a function that returns a condition, generate ITE's of
 -- various types and ensure that the ITE's all choose the same arm to
 -- execute.
@@ -134,6 +150,11 @@ checkIte itc =
        case i of
          Just v -> v @?= e
          Nothing -> assertBool ("no concrete ITE BV16 result for " <> what) False
+  , testCase ("concrete Struct " <> what) $
+    do (i,e,_,_) <- calcStructIte  itc
+       case i of
+         Just v -> v @?= e
+         Nothing -> assertBool ("no concrete ITE Struct result for " <> what) False
   ]
 
 
@@ -289,6 +310,7 @@ testConcretePredProps = testGroup "generated concrete predicates" $
     tt "bool" calcBoolIte
   , tt "nat" calcNatIte
   , tt "bv16" calcBVIte
+  , tt "struct" calcStructIte
   ]
 
 ----------------------------------------------------------------------

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -306,6 +306,7 @@ test-suite iteexprs_tests
                , tasty >= 0.10
                , tasty-hunit >= 0.9
                , tasty-hedgehog
+               , containers >= 0.5.0.0
                , what4
 
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns


### PR DESCRIPTION
Adds basic test cases for:

    * intAbs
    * intDiv
    * intMod
    * structIte
    * stringEmpty
    * realToInteger
    * bvToNat
    * bvToInteger
    * sbvToInteger
    * predToBV
    * integerToBV

I also had to extend `asConcrete` with a case for structs. I tried to also add one for arrays but gave up when I realize there's something going on with arrays that I don't understand. I also found and fixed one documentation bug when testing `intDiv`.

There's still a lot of interesting cases in many of these functions but constructing tests that get full coverage is tricky. We deemed it more important to go for breadth than depth at this time.