### PR TITLE
[what4] Provide SolverGoalTimeout as part of SolverProcess.

### DIFF
--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -1133,6 +1133,7 @@ startSolver solver ack setup feats auxOutput sym = do
             , solverName     = show solver
             , solverEarlyUnsat = earlyUnsatRef
             , solverSupportsResetAssertions = supportsResetAssertions solver
+            , solverGoalTimeout = SolverGoalTimeout 0 -- no timeout by default
             }
 
 shutdownSolver

--- a/what4/src/What4/Solver/CVC4.hs
+++ b/what4/src/What4/Solver/CVC4.hs
@@ -206,5 +206,10 @@ setInteractiveLogicAndOptions writer = do
     SMT2.setLogic writer SMT2.allSupported
 
 instance OnlineSolver (SMT2.Writer CVC4) where
-  startSolverProcess = SMT2.startSolver CVC4 SMT2.smtAckResult setInteractiveLogicAndOptions
+  startSolverProcess feat mbIOh sym = do
+    sp <- SMT2.startSolver CVC4 SMT2.smtAckResult setInteractiveLogicAndOptions feat mbIOh sym
+    timeout <- SolverGoalTimeout <$>
+               (getOpt =<< getOptionSetting cvc4Timeout (getConfiguration sym))
+    return $ sp { solverGoalTimeout = timeout }
+
   shutdownSolverProcess = SMT2.shutdownSolver CVC4

--- a/what4/src/What4/Solver/Z3.hs
+++ b/what4/src/What4/Solver/Z3.hs
@@ -195,5 +195,10 @@ setInteractiveLogicAndOptions writer = do
       SMT2.setOption writer "produce-unsat-cores" "true"
 
 instance OnlineSolver (SMT2.Writer Z3) where
-  startSolverProcess = SMT2.startSolver Z3 SMT2.smtAckResult setInteractiveLogicAndOptions
+  startSolverProcess feat mbIOh sym = do
+    sp <- SMT2.startSolver Z3 SMT2.smtAckResult setInteractiveLogicAndOptions feat mbIOh sym
+    timeout <- SolverGoalTimeout <$>
+               (getOpt =<< getOptionSetting z3Timeout (getConfiguration sym))
+    return $ sp { solverGoalTimeout = timeout }
+
   shutdownSolverProcess = SMT2.shutdownSolver Z3


### PR DESCRIPTION
Allows clients using the started solver (e.g. crucible) to access the
timeout value.

Updates each solver's startSolverProcess to get the solver's goal
timeout configuration value (if any) to set the solverGoalTimeout
field.

This is support for fixing crucible issue #439, as well as providing
the ability to timeout other solvers that don't have native timeout
support (e.g. boolector, see what4 issue #16), albeit in a cruder,
heavy-handed, yet implacable manner.