### PR TITLE
Concrete floats

### DIFF
--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -218,6 +218,7 @@ eval _ (SemiRingLiteral SemiRingRealRepr r _) = return (GroundRat r)
 eval ntk (SemiRingLiteral (SemiRingBVRepr _ w) bv _) =
     return $ BV w $ AIG.bvFromInteger (gia ntk) (widthVal w) (BV.asUnsigned bv)
 eval _ (StringExpr s _) = return (GroundString s)
+eval _ e@FloatExpr{} = failTerm e "floating-point expression"
 
 eval ntk (NonceAppExpr e) = do
   memoExprNonce ntk (nonceExprId e) $ do
@@ -475,11 +476,6 @@ bitblastExpr h ae = do
     ------------------------------------------------------------------------
     -- Floating point operations
 
-    FloatPZero{} -> floatFail
-    FloatNZero{} -> floatFail
-    FloatNaN{}   -> floatFail
-    FloatPInf{}  -> floatFail
-    FloatNInf{}  -> floatFail
     FloatNeg{}  -> floatFail
     FloatAbs{}  -> floatFail
     FloatSqrt{}  -> floatFail
@@ -488,11 +484,8 @@ bitblastExpr h ae = do
     FloatMul{}  -> floatFail
     FloatDiv{}  -> floatFail
     FloatRem{}  -> floatFail
-    FloatMin{}  -> floatFail
-    FloatMax{}  -> floatFail
     FloatFMA{}  -> floatFail
     FloatFpEq{}  -> floatFail
-    FloatFpNe{}  -> floatFail
     FloatLe{}  -> floatFail
     FloatLt{}  -> floatFail
     FloatIsNaN{}  -> floatFail

--- a/what4/src/What4/Expr/App.hs
+++ b/what4/src/What4/Expr/App.hs
@@ -1324,16 +1324,6 @@ data App (e :: BaseType -> Type) (tp :: BaseType) where
     -> !(e (BaseFloatType fpp))
     -> !(e (BaseFloatType fpp))
     -> App e (BaseFloatType fpp)
-  FloatMin
-    :: !(FloatPrecisionRepr fpp)
-    -> !(e (BaseFloatType fpp))
-    -> !(e (BaseFloatType fpp))
-    -> App e (BaseFloatType fpp)
-  FloatMax
-    :: !(FloatPrecisionRepr fpp)
-    -> !(e (BaseFloatType fpp))
-    -> !(e (BaseFloatType fpp))
-    -> App e (BaseFloatType fpp)
   FloatFMA
     :: !(FloatPrecisionRepr fpp)
     -> !RoundingMode
@@ -1342,10 +1332,6 @@ data App (e :: BaseType -> Type) (tp :: BaseType) where
     -> !(e (BaseFloatType fpp))
     -> App e (BaseFloatType fpp)
   FloatFpEq
-    :: !(e (BaseFloatType fpp))
-    -> !(e (BaseFloatType fpp))
-    -> App e BaseBoolType
-  FloatFpNe
     :: !(e (BaseFloatType fpp))
     -> !(e (BaseFloatType fpp))
     -> App e BaseBoolType
@@ -1617,11 +1603,8 @@ appType a =
     FloatMul fpp _ _ _ -> BaseFloatRepr fpp
     FloatDiv fpp _ _ _ -> BaseFloatRepr fpp
     FloatRem fpp _ _ -> BaseFloatRepr fpp
-    FloatMin fpp _ _ -> BaseFloatRepr fpp
-    FloatMax fpp _ _ -> BaseFloatRepr fpp
     FloatFMA fpp _ _ _ _ -> BaseFloatRepr fpp
     FloatFpEq{} -> knownRepr
-    FloatFpNe{} -> knownRepr
     FloatLe{} -> knownRepr
     FloatLt{} -> knownRepr
     FloatIsNaN{} -> knownRepr
@@ -1780,11 +1763,8 @@ abstractEval f a0 = do
     FloatMul{} -> ()
     FloatDiv{} -> ()
     FloatRem{} -> ()
-    FloatMin{} -> ()
-    FloatMax{} -> ()
     FloatFMA{} -> ()
     FloatFpEq{} -> Nothing
-    FloatFpNe{} -> Nothing
     FloatLe{} -> Nothing
     FloatLt{} -> Nothing
     FloatIsNaN{} -> Nothing
@@ -1971,11 +1951,8 @@ reduceApp sym unary a0 = do
     FloatMul _ r x y -> floatMul sym r x y
     FloatDiv _ r x y -> floatDiv sym r x y
     FloatRem _ x y -> floatRem sym x y
-    FloatMin _ x y -> floatMin sym x y
-    FloatMax _ x y -> floatMax sym x y
     FloatFMA _ r x y z -> floatFMA sym r x y z
     FloatFpEq x y -> floatFpEq sym x y
-    FloatFpNe x y -> floatFpNe sym x y
     FloatLe   x y -> floatLe sym x y
     FloatLt   x y -> floatLt sym x y
     FloatIsNaN     x -> floatIsNaN sym x
@@ -2278,11 +2255,8 @@ ppApp' a0 = do
     FloatMul _ r x y -> ppSExpr (Text.pack $ "floatMul " <> show r) [x, y]
     FloatDiv _ r x y -> ppSExpr (Text.pack $ "floatDiv " <> show r) [x, y]
     FloatRem _ x y -> ppSExpr "floatRem" [x, y]
-    FloatMin _ x y -> ppSExpr "floatMin" [x, y]
-    FloatMax _ x y -> ppSExpr "floatMax" [x, y]
     FloatFMA _ r x y z -> ppSExpr (Text.pack $ "floatFMA " <> show r) [x, y, z]
     FloatFpEq x y -> ppSExpr "floatFpEq" [x, y]
-    FloatFpNe x y -> ppSExpr "floatFpNe" [x, y]
     FloatLe x y -> ppSExpr "floatLe" [x, y]
     FloatLt x y -> ppSExpr "floatLt" [x, y]
     FloatIsNaN x -> ppSExpr "floatIsNaN" [x]

--- a/what4/src/What4/Expr/App.hs
+++ b/what4/src/What4/Expr/App.hs
@@ -223,6 +223,9 @@ instance IsExpr (Expr t) where
 
   rationalBounds x = ravRange $ exprAbsValue x
 
+  asFloat (FloatExpr _fpp bf _) = Just bf
+  asFloat _ = Nothing
+
   asComplex e
     | Just (Cplx c) <- asApp e = traverse asRational c
     | otherwise = Nothing
@@ -1277,11 +1280,6 @@ data App (e :: BaseType -> Type) (tp :: BaseType) where
   --------------------------------
   -- Float operations
 
-  FloatPZero :: !(FloatPrecisionRepr fpp) -> App e (BaseFloatType fpp)
-  FloatNZero :: !(FloatPrecisionRepr fpp) -> App e (BaseFloatType fpp)
-  FloatNaN :: !(FloatPrecisionRepr fpp) -> App e (BaseFloatType fpp)
-  FloatPInf :: !(FloatPrecisionRepr fpp) -> App e (BaseFloatType fpp)
-  FloatNInf :: !(FloatPrecisionRepr fpp) -> App e (BaseFloatType fpp)
   FloatNeg
     :: !(FloatPrecisionRepr fpp)
     -> !(e (BaseFloatType fpp))
@@ -1590,11 +1588,6 @@ appType a =
     BVSext  w _ -> BaseBVRepr w
     BVFill w _ -> BaseBVRepr w
 
-    FloatPZero fpp -> BaseFloatRepr fpp
-    FloatNZero fpp -> BaseFloatRepr fpp
-    FloatNaN fpp -> BaseFloatRepr fpp
-    FloatPInf fpp -> BaseFloatRepr fpp
-    FloatNInf fpp -> BaseFloatRepr fpp
     FloatNeg fpp _ -> BaseFloatRepr fpp
     FloatAbs fpp _ -> BaseFloatRepr fpp
     FloatSqrt fpp _ _ -> BaseFloatRepr fpp
@@ -1750,11 +1743,6 @@ abstractEval f a0 = do
     BVCountLeadingZeros w x -> BVD.clz w (f x)
     BVCountTrailingZeros w x -> BVD.ctz w (f x)
 
-    FloatPZero{} -> ()
-    FloatNZero{} -> ()
-    FloatNaN{} -> ()
-    FloatPInf{} -> ()
-    FloatNInf{} -> ()
     FloatNeg{} -> ()
     FloatAbs{} -> ()
     FloatSqrt{} -> ()
@@ -1938,11 +1926,6 @@ reduceApp sym unary a0 = do
     BVCountLeadingZeros _ x -> bvCountLeadingZeros sym x
     BVCountTrailingZeros _ x -> bvCountTrailingZeros sym x
 
-    FloatPZero fpp -> floatPZero sym fpp
-    FloatNZero fpp -> floatNZero sym fpp
-    FloatNaN   fpp -> floatNaN sym fpp
-    FloatPInf  fpp -> floatPInf sym fpp
-    FloatNInf  fpp -> floatNInf sym fpp
     FloatNeg _ x -> floatNeg sym x
     FloatAbs _ x -> floatAbs sym x
     FloatSqrt _ r x -> floatSqrt sym r x
@@ -2242,11 +2225,7 @@ ppApp' a0 = do
 
     --------------------------------
     -- Float operations
-    FloatPZero _ -> prettyApp "floatPZero" []
-    FloatNZero _ -> prettyApp "floatNZero" []
-    FloatNaN _ -> prettyApp "floatNaN" []
-    FloatPInf _ -> prettyApp "floatPInf" []
-    FloatNInf _ -> prettyApp "floatNInf" []
+
     FloatNeg _ x -> ppSExpr "floatNeg" [x]
     FloatAbs _ x -> ppSExpr "floatAbs" [x]
     FloatSqrt _ r x -> ppSExpr (Text.pack $ "floatSqrt " <> show r) [x]

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -159,12 +159,8 @@ appTheory a0 =
     BVFill{} -> BitvectorTheory
 
     ----------------------------
-    -- Bitvector operations
-    FloatPZero{}      -> FloatingPointTheory
-    FloatNZero{}      -> FloatingPointTheory
-    FloatNaN{}        -> FloatingPointTheory
-    FloatPInf{}       -> FloatingPointTheory
-    FloatNInf{}       -> FloatingPointTheory
+    -- Float operations
+
     FloatNeg{}        -> FloatingPointTheory
     FloatAbs{}        -> FloatingPointTheory
     FloatSqrt{}       -> FloatingPointTheory

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -173,11 +173,8 @@ appTheory a0 =
     FloatMul{}        -> FloatingPointTheory
     FloatDiv{}        -> FloatingPointTheory
     FloatRem{}        -> FloatingPointTheory
-    FloatMin{}        -> FloatingPointTheory
-    FloatMax{}        -> FloatingPointTheory
     FloatFMA{}        -> FloatingPointTheory
     FloatFpEq{}       -> FloatingPointTheory
-    FloatFpNe{}       -> FloatingPointTheory
     FloatLe{}         -> FloatingPointTheory
     FloatLt{}         -> FloatingPointTheory
     FloatIsNaN{}      -> FloatingPointTheory

--- a/what4/src/What4/Expr/Simplify.hs
+++ b/what4/src/What4/Expr/Simplify.hs
@@ -147,6 +147,7 @@ count_subterms' e0 =
     BoolExpr{} -> pure () 
     SemiRingLiteral{} -> pure ()
     StringExpr{} -> pure ()
+    FloatExpr{} -> pure ()
     AppExpr ae -> do
       is_new <- recordExpr (appExprId ae)
       when is_new $ do

--- a/what4/src/What4/Expr/VarIdentification.hs
+++ b/what4/src/What4/Expr/VarIdentification.hs
@@ -341,6 +341,7 @@ recordExprVars _ (SemiRingLiteral sr _ _) =
     SR.SemiRingBVRepr _ _ -> addFeatures useBitvectors
     _                     -> addFeatures useLinearArithmetic
 recordExprVars _ StringExpr{} = addFeatures useStrings
+recordExprVars _ FloatExpr{} = addFeatures useFloatingPoint
 recordExprVars _ BoolExpr{} = return ()
 recordExprVars scope (NonceAppExpr e0) = do
   memoExprVars (nonceExprId e0) $ do

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -183,6 +183,7 @@ import           Data.Ratio
 import           Data.Scientific (Scientific)
 import           GHC.Generics (Generic)
 import           Numeric.Natural
+import           LibBF (BigFloat)
 import           Prettyprinter (Doc)
 
 import           What4.BaseTypes
@@ -1738,8 +1739,14 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
   floatNInf :: sym -> FloatPrecisionRepr fpp -> IO (SymFloat sym fpp)
 
   -- | Create a floating point literal from a rational literal.
-  floatLit
+  --   The rational value will be rounded if necessary using the
+  --   "round to nearest even" rounding mode.
+  floatLitRational
     :: sym -> FloatPrecisionRepr fpp -> Rational -> IO (SymFloat sym fpp)
+  floatLitRational sym fpp x = realToFloat sym fpp RNE =<< realLit sym x
+
+  -- | Create a floating point literal from a @BigFloat@ value.
+  floatLit :: sym -> FloatPrecisionRepr fpp -> BigFloat -> IO (SymFloat sym fpp)
 
   -- | Negate a floating point number.
   floatNeg

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -298,6 +298,9 @@ class HasAbsValue e => IsExpr e where
   asRational :: e BaseRealType -> Maybe Rational
   asRational _ = Nothing
 
+  -- | Return floating-point value if this is a constant
+  asFloat :: e (BaseFloatType fpp) -> Maybe BigFloat
+
   -- | Return any bounding information we have about the term
   rationalBounds :: e BaseRealType -> ValueRange Rational
 
@@ -348,6 +351,12 @@ class HasAbsValue e => IsExpr e where
   bvWidth e =
     case exprType e of
       BaseBVRepr w -> w
+
+  -- | Get the precision of a floating-point expression
+  floatPrecision :: e (BaseFloatType fpp) -> FloatPrecisionRepr fpp
+  floatPrecision e =
+    case exprType e of
+      BaseFloatRepr fpp -> fpp
 
   -- | Print a sym expression for debugging or display purposes.
   printSymExpr :: e tp -> Doc ann

--- a/what4/src/What4/InterpretedFloatingPoint.hs
+++ b/what4/src/What4/InterpretedFloatingPoint.hs
@@ -222,7 +222,7 @@ class IsExprBuilder sym => IsInterpretedFloatExprBuilder sym where
   iFloatNInf :: sym -> FloatInfoRepr fi -> IO (SymInterpretedFloat sym fi)
 
   -- | Create a floating point literal from a rational literal.
-  iFloatLit
+  iFloatLitRational
     :: sym -> FloatInfoRepr fi -> Rational -> IO (SymInterpretedFloat sym fi)
 
   -- | Create a (single precision) floating point literal.

--- a/what4/src/What4/InterpretedFloatingPoint.hs
+++ b/what4/src/What4/InterpretedFloatingPoint.hs
@@ -334,8 +334,8 @@ class IsExprBuilder sym => IsInterpretedFloatExprBuilder sym where
     -> SymInterpretedFloat sym fi
     -> IO (Pred sym)
 
-  -- | Check IEEE non-equality of two floating point numbers.
-  iFloatFpNe
+  -- | Check IEEE apartness of two floating point numbers.
+  iFloatFpApart
     :: sym
     -> SymInterpretedFloat sym fi
     -> SymInterpretedFloat sym fi

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -125,6 +125,7 @@ import qualified System.IO.Streams.Attoparsec.Text as Streams
 import           Data.Versions (Version(..))
 import qualified Data.Versions as Versions
 import qualified Prettyprinter as PP
+import           LibBF( bfToBits )
 
 import           Prelude hiding (writeFile)
 
@@ -142,7 +143,7 @@ import qualified What4.Protocol.SMTLib2.Syntax as SMT2 hiding (Term)
 import qualified What4.Protocol.SMTWriter as SMTWriter
 import           What4.Protocol.SMTWriter hiding (assume, Term)
 import           What4.SatResult
-import           What4.Utils.FloatHelpers (floatToBits)
+import           What4.Utils.FloatHelpers (fppOpts)
 import           What4.Utils.HandleReader
 import           What4.Utils.Process
 import           What4.Utils.Versions
@@ -508,8 +509,6 @@ instance SupportTermOps Term where
   floatMul r = bin_app $ mkRoundingOp "fp.mul" r
   floatDiv r = bin_app $ mkRoundingOp "fp.div" r
   floatRem = bin_app "fp.rem"
-  floatMin = bin_app "fp.min"
-  floatMax = bin_app "fp.max"
 
   floatFMA r x y z = term_app (mkRoundingOp "fp.fma" r) [x, y, z]
 
@@ -530,7 +529,7 @@ instance SupportTermOps Term where
       un_app (mkFloatSymbol "to_fp" (asSMTFloatPrecision fpp)) (bvTerm w bv)
     where
       w = addNat eb sb
-      bv = BV.mkBV w (floatToBits (intValue eb) (intValue sb) bf)
+      bv = BV.mkBV w (bfToBits (fppOpts fpp RNE) bf)
 
   floatCast fpp r = un_app $ mkRoundingOp (mkFloatSymbol "to_fp" (asSMTFloatPrecision fpp)) r
   floatRound r = un_app $ mkRoundingOp "fp.roundToIntegral" r

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -494,12 +494,6 @@ instance SupportTermOps Term where
   bvExtract _ b n x | n > 0 = SMT2.extract (b+n-1) b x
                     | otherwise = error $ "bvExtract given non-positive width " ++ show n
 
-  floatPZero fpp = term_app (mkFloatSymbol "+zero" (asSMTFloatPrecision fpp)) []
-  floatNZero fpp = term_app (mkFloatSymbol "-zero" (asSMTFloatPrecision fpp)) []
-  floatNaN fpp   = term_app (mkFloatSymbol "NaN"   (asSMTFloatPrecision fpp)) []
-  floatPInf fpp  = term_app (mkFloatSymbol "+oo"   (asSMTFloatPrecision fpp)) []
-  floatNInf fpp  = term_app (mkFloatSymbol "-oo"   (asSMTFloatPrecision fpp)) []
-
   floatNeg  = un_app "fp.neg"
   floatAbs  = un_app "fp.abs"
   floatSqrt r = un_app $ mkRoundingOp "fp.sqrt " r

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -46,6 +46,7 @@ module What4.Protocol.SMTLib2
   , getName
   , nameResult
   , setProduceModels
+  , smtLibEvalFuns
     -- * Logic
   , SMT2.Logic(..)
   , SMT2.qf_bv

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -141,6 +141,7 @@ import qualified What4.Protocol.SMTLib2.Syntax as SMT2 hiding (Term)
 import qualified What4.Protocol.SMTWriter as SMTWriter
 import           What4.Protocol.SMTWriter hiding (assume, Term)
 import           What4.SatResult
+import           What4.Utils.FloatHelpers (floatToBits)
 import           What4.Utils.HandleReader
 import           What4.Utils.Process
 import           What4.Utils.Versions
@@ -523,6 +524,12 @@ instance SupportTermOps Term where
   floatIsNeg      = un_app "fp.isNegative"
   floatIsSubnorm  = un_app "fp.isSubnormal"
   floatIsNorm     = un_app "fp.isNormal"
+
+  floatTerm fpp@(FloatingPointPrecisionRepr eb sb) bf =
+      un_app (mkFloatSymbol "to_fp" (asSMTFloatPrecision fpp)) (bvTerm w bv)
+    where
+      w = addNat eb sb
+      bv = BV.mkBV w (floatToBits (intValue eb) (intValue sb) bf)
 
   floatCast fpp r = un_app $ mkRoundingOp (mkFloatSymbol "to_fp" (asSMTFloatPrecision fpp)) r
   floatRound r = un_app $ mkRoundingOp "fp.roundToIntegral" r

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -388,11 +388,6 @@ class Num v => SupportTermOps v where
   bvSumExpr _ (h:r) = foldl bvAdd h r
 
   floatTerm  :: FloatPrecisionRepr fpp -> BigFloat -> v
-  floatPZero :: FloatPrecisionRepr fpp -> v
-  floatNZero :: FloatPrecisionRepr fpp  -> v
-  floatNaN   :: FloatPrecisionRepr fpp  -> v
-  floatPInf  :: FloatPrecisionRepr fpp -> v
-  floatNInf  :: FloatPrecisionRepr fpp -> v
 
   floatNeg  :: v -> v
   floatAbs  :: v -> v
@@ -2395,16 +2390,7 @@ appSMTExpr ae = do
 
     ------------------------------------------
     -- Floating-point operations
-    FloatPZero fpp ->
-      freshBoundTerm (FloatTypeMap fpp) $ floatPZero fpp
-    FloatNZero fpp ->
-      freshBoundTerm (FloatTypeMap fpp) $ floatNZero fpp
-    FloatNaN fpp ->
-      freshBoundTerm (FloatTypeMap fpp) $ floatNaN fpp
-    FloatPInf fpp ->
-      freshBoundTerm (FloatTypeMap fpp) $ floatPInf fpp
-    FloatNInf fpp ->
-      freshBoundTerm (FloatTypeMap fpp) $ floatNInf fpp
+
     FloatNeg fpp x -> do
       xe <- mkBaseExpr x
       freshBoundTerm (FloatTypeMap fpp) $ floatNeg xe

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -306,11 +306,6 @@ appVerilogExpr app =
       doNotSupportError "bit vector count leading zeros" -- TODO
 
     -- Float operations
-    FloatPZero _ -> doNotSupportError "floats"
-    FloatNZero _ -> doNotSupportError "floats"
-    FloatNaN _ -> doNotSupportError "floats"
-    FloatPInf _ -> doNotSupportError "floats"
-    FloatNInf _ -> doNotSupportError "floats"
     FloatNeg _ _ -> doNotSupportError "floats"
     FloatAbs _ _ -> doNotSupportError "floats"
     FloatSqrt _ _ _ -> doNotSupportError "floats"

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -319,11 +319,8 @@ appVerilogExpr app =
     FloatMul  _ _ _ _ -> doNotSupportError "floats"
     FloatDiv _ _ _ _ -> doNotSupportError "floats"
     FloatRem _ _ _ -> doNotSupportError "floats"
-    FloatMin _ _ _ -> doNotSupportError "floats"
-    FloatMax _ _ _ -> doNotSupportError "floats"
     FloatFMA _ _ _ _ _ -> doNotSupportError "floats"
     FloatFpEq _ _ -> doNotSupportError "floats"
-    FloatFpNe _ _ -> doNotSupportError "floats"
     FloatLe _ _ -> doNotSupportError "floats"
     FloatLt _ _ -> doNotSupportError "floats"
 

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -58,6 +58,7 @@ exprToVerilogExpr e = do
         doNotSupportError "non-bit-vector literals"
       BoolExpr b _   -> litBool b
       StringExpr _ _ -> doNotSupportError "strings"
+      FloatExpr{} -> doNotSupportError "floating-point values"
       AppExpr app -> appExprVerilogExpr app
       NonceAppExpr n -> nonceAppExprVerilogExpr n
       BoundVarExpr x ->

--- a/what4/src/What4/SFloat.hs
+++ b/what4/src/What4/SFloat.hs
@@ -1,0 +1,359 @@
+{-# Language DataKinds #-}
+{-# Language FlexibleContexts #-}
+{-# Language GADTs #-}
+{-# Language RankNTypes #-}
+{-# Language TypeApplications #-}
+{-# Language TypeOperators #-}
+
+-- | Working with floats of dynamic sizes.
+module What4.SFloat
+  ( -- * Interface
+    SFloat(..)
+  , fpReprOf
+  , fpSize
+  , fpRepr
+
+    -- * Constants
+  , fpFresh
+  , fpNaN
+  , fpPosInf
+  , fpFromRationalLit
+
+    -- * Interchange formats
+  , fpFromBinary
+  , fpToBinary
+
+    -- * Relations
+  , SFloatRel
+  , fpEq
+  , fpEqIEEE
+  , fpLtIEEE
+  , fpGtIEEE
+
+    -- * Arithmetic
+  , SFloatBinArith
+  , fpNeg
+  , fpAdd
+  , fpSub
+  , fpMul
+  , fpDiv
+
+    -- * Conversions
+  , fpRound
+  , fpToReal
+  , fpFromReal
+  , fpFromRational
+  , fpToRational
+  , fpFromInteger
+
+    -- * Queries
+  , fpIsInf, fpIsNaN
+
+  -- * Exceptions
+  , UnsupportedFloat(..)
+  , FPTypeError(..)
+  ) where
+
+import Control.Exception
+
+import Data.Parameterized.Some
+import Data.Parameterized.NatRepr
+
+import What4.BaseTypes
+import What4.Panic(panic)
+import What4.SWord
+import What4.Interface
+
+-- | Symbolic floating point numbers.
+data SFloat sym where
+  SFloat :: IsExpr (SymExpr sym) => SymFloat sym fpp -> SFloat sym
+
+
+
+--------------------------------------------------------------------------------
+
+-- | This exception is thrown if the operations try to create a
+-- floating point value we do not support
+data UnsupportedFloat =
+  UnsupportedFloat { fpWho :: String, exponentBits, precisionBits :: Integer }
+  deriving Show
+
+
+-- | Throw 'UnsupportedFloat' exception
+unsupported ::
+  String  {- ^ Label -} ->
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision width -} ->
+  IO a
+unsupported l e p =
+  throwIO UnsupportedFloat { fpWho         = l
+                           , exponentBits  = e
+                           , precisionBits = p }
+
+instance Exception UnsupportedFloat
+
+-- | This exceptoin is throws if the types don't match.
+data FPTypeError =
+  FPTypeError { fpExpected :: Some BaseTypeRepr
+              , fpActual   :: Some BaseTypeRepr
+              }
+    deriving Show
+
+instance Exception FPTypeError
+
+fpTypeMismatch :: BaseTypeRepr t1 -> BaseTypeRepr t2 -> IO a
+fpTypeMismatch expect actual =
+  throwIO FPTypeError { fpExpected = Some expect
+                      , fpActual   = Some actual
+                      }
+fpTypeError :: FloatPrecisionRepr t1 -> FloatPrecisionRepr t2 -> IO a
+fpTypeError t1 t2 =
+  fpTypeMismatch (BaseFloatRepr t1) (BaseFloatRepr t2)
+
+
+--------------------------------------------------------------------------------
+-- | Construct the 'FloatPrecisionRepr' with the given parameters.
+fpRepr ::
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision width -} ->
+  Maybe (Some FloatPrecisionRepr)
+fpRepr iE iP =
+  do Some e    <- someNat iE
+     LeqProof  <- testLeq (knownNat @2) e
+     Some p    <- someNat iP
+     LeqProof  <- testLeq (knownNat @2) p
+     pure (Some (FloatingPointPrecisionRepr e p))
+
+fpReprOf ::
+  IsExpr (SymExpr sym) => sym -> SymFloat sym fpp -> FloatPrecisionRepr fpp
+fpReprOf _ e =
+  case exprType e of
+    BaseFloatRepr r -> r
+
+fpSize :: SFloat sym -> (Integer,Integer)
+fpSize (SFloat f) =
+  case exprType f of
+    BaseFloatRepr (FloatingPointPrecisionRepr e p) -> (intValue e, intValue p)
+
+
+--------------------------------------------------------------------------------
+-- Constants
+
+-- | A fresh variable of the given type.
+fpFresh ::
+  IsSymExprBuilder sym =>
+  sym ->
+  Integer ->
+  Integer ->
+  IO (SFloat sym)
+fpFresh sym e p
+  | Just (Some fpp) <- fpRepr e p =
+    SFloat <$> freshConstant sym emptySymbol (BaseFloatRepr fpp)
+  | otherwise = unsupported "fpFresh" e p
+
+-- | Not a number
+fpNaN ::
+  IsExprBuilder sym =>
+  sym ->
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision width -} ->
+  IO (SFloat sym)
+fpNaN sym e p
+  | Just (Some fpp) <- fpRepr e p = SFloat <$> floatNaN sym fpp
+  | otherwise = unsupported "fpNaN" e p
+
+
+-- | Positive infinity
+fpPosInf ::
+  IsExprBuilder sym =>
+  sym ->
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision width -} ->
+  IO (SFloat sym)
+fpPosInf sym e p
+  | Just (Some fpp) <- fpRepr e p = SFloat <$> floatPInf sym fpp
+  | otherwise = unsupported "fpPosInf" e p
+
+-- | A floating point number corresponding to the given rations.
+fpFromRationalLit ::
+  IsExprBuilder sym =>
+  sym ->
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision width -} ->
+  Rational ->
+  IO (SFloat sym)
+fpFromRationalLit sym e p r
+  | Just (Some fpp) <- fpRepr e p = SFloat <$> floatLitRational sym fpp r
+  | otherwise = unsupported "fpFromRational" e p
+
+
+-- | Make a floating point number with the given bit representation.
+fpFromBinary ::
+  IsExprBuilder sym =>
+  sym ->
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision width -} ->
+  SWord sym ->
+  IO (SFloat sym)
+fpFromBinary sym e p swe
+  | DBV sw <- swe
+  , Just (Some fpp) <- fpRepr e p
+  , FloatingPointPrecisionRepr ew pw <- fpp
+  , let expectW = addNat ew pw
+  , actual@(BaseBVRepr actualW)  <- exprType sw =
+    case testEquality expectW actualW of
+      Just Refl -> SFloat <$> floatFromBinary sym fpp sw
+      Nothing -- we want to report type correct type errors! :-)
+        | Just LeqProof <- testLeq (knownNat @1) expectW ->
+                fpTypeMismatch (BaseBVRepr expectW) actual
+        | otherwise -> panic "fpFromBits" [ "1 >= 2" ]
+  | otherwise = unsupported "fpFromBits" e p
+
+fpToBinary :: IsExprBuilder sym => sym -> SFloat sym -> IO (SWord sym)
+fpToBinary sym (SFloat f)
+  | FloatingPointPrecisionRepr e p <- fpReprOf sym f
+  , Just LeqProof <- testLeq (knownNat @1) (addNat e p)
+    = DBV <$> floatToBinary sym f
+  | otherwise = panic "fpToBinary" [ "we messed up the types" ]
+
+
+--------------------------------------------------------------------------------
+-- Arithmetic
+
+fpNeg :: IsExprBuilder sym => sym -> SFloat sym -> IO (SFloat sym)
+fpNeg sym (SFloat fl) = SFloat <$> floatNeg sym fl
+
+fpBinArith ::
+  IsExprBuilder sym =>
+  (forall t.
+      sym ->
+      RoundingMode ->
+      SymFloat sym t ->
+      SymFloat sym t ->
+      IO (SymFloat sym t)
+  ) ->
+  sym -> RoundingMode -> SFloat sym -> SFloat sym -> IO (SFloat sym)
+fpBinArith fun sym r (SFloat x) (SFloat y) =
+  let t1 = sym `fpReprOf` x
+      t2 = sym `fpReprOf` y
+  in
+  case testEquality t1 t2 of
+    Just Refl -> SFloat <$> fun sym r x y
+    _         -> fpTypeError t1 t2
+
+type SFloatBinArith sym =
+  sym -> RoundingMode -> SFloat sym -> SFloat sym -> IO (SFloat sym)
+
+fpAdd :: IsExprBuilder sym => SFloatBinArith sym
+fpAdd = fpBinArith floatAdd
+
+fpSub :: IsExprBuilder sym => SFloatBinArith sym
+fpSub = fpBinArith floatSub
+
+fpMul :: IsExprBuilder sym => SFloatBinArith sym
+fpMul = fpBinArith floatMul
+
+fpDiv :: IsExprBuilder sym => SFloatBinArith sym
+fpDiv = fpBinArith floatDiv
+
+
+
+
+--------------------------------------------------------------------------------
+
+fpRel ::
+  IsExprBuilder sym =>
+  (forall t.
+    sym ->
+    SymFloat sym t ->
+    SymFloat sym t ->
+    IO (Pred sym)
+  ) ->
+  sym -> SFloat sym -> SFloat sym -> IO (Pred sym)
+fpRel fun sym (SFloat x) (SFloat y) =
+  let t1 = sym `fpReprOf` x
+      t2 = sym `fpReprOf` y
+  in
+  case testEquality t1 t2 of
+    Just Refl -> fun sym x y
+    _         -> fpTypeError t1 t2
+
+
+
+
+type SFloatRel sym =
+  sym -> SFloat sym -> SFloat sym -> IO (Pred sym)
+
+fpEq :: IsExprBuilder sym => SFloatRel sym
+fpEq = fpRel floatEq
+
+fpEqIEEE :: IsExprBuilder sym => SFloatRel sym
+fpEqIEEE = fpRel floatFpEq
+
+fpLtIEEE :: IsExprBuilder sym => SFloatRel sym
+fpLtIEEE = fpRel floatLt
+
+fpGtIEEE :: IsExprBuilder sym => SFloatRel sym
+fpGtIEEE = fpRel floatGt
+
+
+--------------------------------------------------------------------------------
+fpRound ::
+  IsExprBuilder sym => sym -> RoundingMode -> SFloat sym -> IO (SFloat sym)
+fpRound sym r (SFloat x) = SFloat <$> floatRound sym r x
+
+-- | This is undefined on "special" values (NaN,infinity)
+fpToReal :: IsExprBuilder sym => sym -> SFloat sym -> IO (SymReal sym)
+fpToReal sym (SFloat x) = floatToReal sym x
+
+fpFromReal ::
+  IsExprBuilder sym =>
+  sym -> Integer -> Integer -> RoundingMode -> SymReal sym -> IO (SFloat sym)
+fpFromReal sym e p r x
+  | Just (Some repr) <- fpRepr e p = SFloat <$> realToFloat sym repr r x
+  | otherwise = unsupported "fpFromReal" e p
+
+
+fpFromInteger ::
+  IsExprBuilder sym =>
+  sym -> Integer -> Integer -> RoundingMode -> SymInteger sym -> IO (SFloat sym)
+fpFromInteger sym e p r x = fpFromReal sym e p r =<< integerToReal sym x
+
+
+fpFromRational ::
+  IsExprBuilder sym =>
+  sym -> Integer -> Integer -> RoundingMode ->
+  SymInteger sym -> SymInteger sym -> IO (SFloat sym)
+fpFromRational sym e p r x y =
+  do num <- integerToReal sym x
+     den <- integerToReal sym y
+     res <- realDiv sym num den
+     fpFromReal sym e p r res
+
+{- | Returns a predicate and two integers, @x@ and @y@.
+If the the predicate holds, then @x / y@ is a rational representing
+the floating point number. Assumes the FP number is not one of the
+special ones that has no real representation. -}
+fpToRational ::
+  IsSymExprBuilder sym =>
+  sym ->
+  SFloat sym ->
+  IO (Pred sym, SymInteger sym, SymInteger sym)
+fpToRational sym fp =
+  do r    <- fpToReal sym fp
+     x    <- freshConstant sym emptySymbol BaseIntegerRepr
+     y    <- freshConstant sym emptySymbol BaseIntegerRepr
+     num  <- integerToReal sym x
+     den  <- integerToReal sym y
+     res  <- realDiv sym num den
+     same <- realEq sym r res
+     pure (same, x, y)
+
+
+
+--------------------------------------------------------------------------------
+fpIsInf :: IsExprBuilder sym => sym -> SFloat sym -> IO (Pred sym)
+fpIsInf sym (SFloat x) = floatIsInf sym x
+
+fpIsNaN :: IsExprBuilder sym => sym -> SFloat sym -> IO (Pred sym)
+fpIsNaN sym (SFloat x) = floatIsNaN sym x

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -304,8 +304,6 @@ instance SupportTermOps YicesTerm where
   floatMul _ _ _ = floatFail
   floatDiv _ _ _ = floatFail
   floatRem _ _   = floatFail
-  floatMin _ _   = floatFail
-  floatMax _ _   = floatFail
 
   floatFMA _ _ _ _ = floatFail
 

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -287,12 +287,6 @@ instance SupportTermOps YicesTerm where
 
   lambdaTerm = Just yicesLambda
 
-
-  floatPZero _ = floatFail
-  floatNZero _ = floatFail
-  floatNaN   _ = floatFail
-  floatPInf  _ = floatFail
-  floatNInf  _ = floatFail
   floatTerm _ _ = floatFail
 
   floatNeg  _   = floatFail

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -293,6 +293,7 @@ instance SupportTermOps YicesTerm where
   floatNaN   _ = floatFail
   floatPInf  _ = floatFail
   floatNInf  _ = floatFail
+  floatTerm _ _ = floatFail
 
   floatNeg  _   = floatFail
   floatAbs  _   = floatFail

--- a/what4/src/What4/Utils/FloatHelpers.hs
+++ b/what4/src/What4/Utils/FloatHelpers.hs
@@ -1,0 +1,161 @@
+{-# Language BlockArguments, OverloadedStrings #-}
+{-# Language BangPatterns #-}
+module What4.Utils.FloatHelpers where
+
+import Data.Ratio(numerator,denominator)
+import Data.Int(Int64)
+import Data.Bits(testBit,setBit,shiftL,shiftR,(.&.),(.|.))
+import LibBF
+
+import What4.Panic (panic)
+
+
+-- | Make LibBF options for the given precision and rounding mode.
+fpOpts :: Integer -> Integer -> RoundMode -> BFOpts
+fpOpts e p r =
+  case ok of
+    Just opts -> opts
+    Nothing   -> panic "floatOpts" [ "Invalid Float size"
+                                   , "exponent: " ++ show e
+                                   , "precision: " ++ show p
+                                   ]
+  where
+  ok = do eb <- rng expBits expBitsMin expBitsMax e
+          pb <- rng precBits precBitsMin precBitsMax p
+          pure (eb <> pb <> allowSubnormal <> rnd r)
+
+  rng f a b x = if toInteger a <= x && x <= toInteger b
+                  then Just (f (fromInteger x))
+                  else Nothing
+
+
+-- | Check that we didn't get an unexpected status.
+fpCheckStatus :: (BigFloat,Status) -> BigFloat
+fpCheckStatus (r,s) =
+  case s of
+    MemError  -> panic "checkStatus" [ "libBF: Memory error" ]
+    _         -> r
+
+-- | Make a floating point number from a rational, using the given rounding mode
+floatFromRational :: Integer -> Integer -> RoundMode -> Rational -> BigFloat
+floatFromRational e p r rat = fpCheckStatus
+    if den == 1 then bfRoundFloat opts num
+                else bfDiv opts num (bfFromInteger den)
+  where
+  opts  = fpOpts e p r
+
+  num   = bfFromInteger (numerator rat)
+  den   = denominator rat
+
+
+-- | Convert a floating point number to a rational, if possible.
+floatToRational :: String -> BigFloat -> Maybe Rational
+floatToRational fun bf =
+  case bfToRep bf of
+    BFNaN -> Nothing
+    BFRep s num ->
+      case num of
+        Inf  -> Nothing
+        Zero -> Just 0
+        Num i ev -> Just case s of
+                           Pos -> ab
+                           Neg -> negate ab
+          where ab = fromInteger i * (2 ^^ ev)
+
+
+-- | Convert a floating point number to an integer, if possible.
+floatToInteger :: String -> RoundMode -> BigFloat -> Maybe Integer
+floatToInteger fun r fp =
+  do rat <- floatToRational fun fp
+     pure case r of
+            NearEven -> round rat
+            NearAway -> if rat > 0 then ceiling rat else floor rat
+            ToPosInf -> ceiling rat
+            ToNegInf -> floor rat
+            ToZero   -> truncate rat
+            _        -> panic "fpCvtToInteger"
+                              ["Unexpected rounding mode", show r]
+
+
+-- | Make a float using "raw" bits.
+floatFromBits ::
+  Integer {- ^ Exponent width -} ->
+  Integer {- ^ Precision widht -} ->
+  Integer {- ^ Raw bits -} ->
+  BigFloat
+
+floatFromBits e p bits
+  | expoBiased == 0 && mant == 0 =            -- zero
+    if isNeg then bfNegZero else bfPosZero
+
+  | expoBiased == eMask && mant ==  0 =       -- infinity
+    if isNeg then bfNegInf else bfPosInf
+
+  | expoBiased == eMask = bfNaN               -- NaN
+
+  | expoBiased == 0 =                         -- Subnormal
+    case bfMul2Exp opts (bfFromInteger mant) (expoVal + 1) of
+      (num,Ok) -> if isNeg then bfNeg num else num
+      (_,s)    -> panic "floatFromBits" [ "Unexpected status: " ++ show s ]
+
+  | otherwise =                               -- Normal
+    case bfMul2Exp opts (bfFromInteger mantVal) expoVal of
+      (num,Ok) -> if isNeg then bfNeg num else num
+      (_,s)    -> panic "floatFromBits" [ "Unexpected status: " ++ show s ]
+
+  where
+  opts       = expBits e' <> precBits (p' + 1) <> allowSubnormal
+
+  e'         = fromInteger e                               :: Int
+  p'         = fromInteger p - 1                           :: Int
+  eMask      = (1 `shiftL` e') - 1                         :: Int64
+  pMask      = (1 `shiftL` p') - 1                         :: Integer
+
+  isNeg      = testBit bits (e' + p')
+
+  mant       = pMask .&. bits                              :: Integer
+  mantVal    = mant `setBit` p'                            :: Integer
+  -- accounts for the implicit 1 bit
+
+  expoBiased = eMask .&. fromInteger (bits `shiftR` p')    :: Int64
+  bias       = eMask `shiftR` 1                            :: Int64
+  expoVal    = expoBiased - bias - fromIntegral p'         :: Int64
+
+
+-- | Turn a float into raw bits.
+-- @NaN@ is represented as a positive "quiet" @NaN@
+-- (most significant bit in the significand is set, the rest of it is 0)
+floatToBits :: Integer -> Integer -> BigFloat -> Integer
+floatToBits e p bf =  (isNeg      `shiftL` (e' + p'))
+                  .|. (expBiased  `shiftL` p')
+                  .|. (mant       `shiftL` 0)
+  where
+  e' = fromInteger e     :: Int
+  p' = fromInteger p - 1 :: Int
+
+  eMask = (1 `shiftL` e') - 1   :: Integer
+  pMask = (1 `shiftL` p') - 1   :: Integer
+
+  (isNeg, expBiased, mant) =
+    case bfToRep bf of
+      BFNaN       -> (0,  eMask, 1 `shiftL` (p' - 1))
+      BFRep s num -> (sign, be, ma)
+        where
+        sign = case s of
+                Neg -> 1
+                Pos -> 0
+
+        (be,ma) =
+          case num of
+            Zero     -> (0,0)
+            Num i ev
+              | ex == 0   -> (0, i `shiftL` (p' - m  -1))
+              | otherwise -> (ex, (i `shiftL` (p' - m)) .&. pMask)
+              where
+              m    = msb 0 i - 1
+              bias = eMask `shiftR` 1
+              ex   = toInteger ev + bias + toInteger m
+
+            Inf -> (eMask,0)
+
+  msb !n j = if j == 0 then n else msb (n+1) (j `shiftR` 1)

--- a/what4/src/What4/Utils/FloatHelpers.hs
+++ b/what4/src/What4/Utils/FloatHelpers.hs
@@ -49,8 +49,8 @@ floatFromRational e p r rat = fpCheckStatus
 
 
 -- | Convert a floating point number to a rational, if possible.
-floatToRational :: String -> BigFloat -> Maybe Rational
-floatToRational fun bf =
+floatToRational :: BigFloat -> Maybe Rational
+floatToRational bf =
   case bfToRep bf of
     BFNaN -> Nothing
     BFRep s num ->
@@ -64,9 +64,9 @@ floatToRational fun bf =
 
 
 -- | Convert a floating point number to an integer, if possible.
-floatToInteger :: String -> RoundMode -> BigFloat -> Maybe Integer
-floatToInteger fun r fp =
-  do rat <- floatToRational fun fp
+floatToInteger :: RoundMode -> BigFloat -> Maybe Integer
+floatToInteger r fp =
+  do rat <- floatToRational fp
      pure case r of
             NearEven -> round rat
             NearAway -> if rat > 0 then ceiling rat else floor rat

--- a/what4/test/TestTemplate.hs
+++ b/what4/test/TestTemplate.hs
@@ -1,0 +1,288 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+--module TestTemplate where
+
+module Main where
+
+import Control.Monad ((<=<))
+import Control.Monad.IO.Class (liftIO)
+import Data.Bits
+import Data.Parameterized.Map (MapF)
+import qualified Data.Parameterized.Map as MapF
+import Data.Parameterized.Nonce
+import Data.Parameterized.Pair
+import Data.String
+
+import LibBF
+import qualified Data.BitVector.Sized as BV
+
+import What4.BaseTypes
+import What4.Interface
+
+import           What4.Protocol.SMTWriter ((.==), mkSMTTerm)
+import qualified What4.Protocol.SMTWriter as SMT
+import qualified What4.Protocol.SMTLib2 as SMT2
+import qualified What4.Solver.Z3 as Z3
+import           What4.Solver.Adapter (defaultLogData)
+
+import What4.Expr.Builder
+import What4.Expr.GroundEval
+import What4.Utils.FloatHelpers
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Gen
+
+data State t = State
+
+main :: IO ()
+main =
+  do let xs = do r <- [RNE]
+                 floatTemplates [r] 1 (knownRepr :: FloatPrecisionRepr Prec32)
+     sym <- newExprBuilder FloatIEEERepr State globalNonceGenerator 
+     _ <- checkSequential $ Group "Float tests"
+       [ ( fromString (show t), templateGroundEvalTest sym t)
+       | t <- xs
+       ] 
+     return ()
+
+data FUnOp
+  = FNeg
+  | FAbs
+  | FSqrt RoundingMode
+  | FRound RoundingMode
+ deriving (Show)
+
+data FBinOp
+  = FAdd RoundingMode
+  | FSub RoundingMode
+  | FMul RoundingMode
+  | FDiv RoundingMode
+  | FRem
+  | FMin
+  | FMax
+ deriving (Show)
+
+roundingModes :: [RoundingMode]
+roundingModes = [ RNE, RNA, RTP, RTN, RTZ ]
+
+fBinOps :: [RoundingMode] -> [FBinOp]
+fBinOps rs =
+  (FAdd <$> rs) <>
+  (FSub <$> rs) <>
+  (FMul <$> rs) <>
+  (FDiv <$> rs) <>
+  [ FRem, FMin, FMax ]
+
+fUnOps :: [RoundingMode] -> [FUnOp]
+fUnOps rs =
+  [ FNeg, FAbs ] <>
+  (FSqrt <$> rs) <>
+  (FRound <$> rs)
+
+-- | This datatype essentially mirrors the public API of the
+--   What4 interface.  There should (eventually) be one element
+--   of this datatype per syntax former method in "What4.Interface".
+--   Each template represents a fragment of syntax that could be
+--   generated.  We use these templates to test constant folding,
+--   ground evaluation, term simplifications, fidelity
+--   WRT solver term semantics and soundness of abstract domains.
+--
+--   The overall idea is that we want to enumerate all small
+--   templates and use each template to generate a collection of test
+--   cases.  Hopefully we can achieve high code path coverages with
+--   a relatively small depth of templates, which should keep this process
+--   managable.  We also have the option to manually generate templates
+--   if necessary to increase test coverage.
+data TestTemplate tp where
+  TVar :: BaseTypeRepr tp -> TestTemplate tp
+
+  TFloatPZero :: FloatPrecisionRepr fpp -> TestTemplate (BaseFloatType fpp)
+  TFloatNZero :: FloatPrecisionRepr fpp -> TestTemplate (BaseFloatType fpp)
+  TFloatNaN   :: FloatPrecisionRepr fpp -> TestTemplate (BaseFloatType fpp)
+
+  TFloatUnOp ::
+    FUnOp ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp)
+
+  TFloatBinOp ::
+    FBinOp ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp)
+
+instance Show (TestTemplate tp) where
+  showsPrec d tt = case tt of
+    TVar{}        -> showString "_"
+    TFloatPZero{} -> showString "+0.0"
+    TFloatNZero{} -> showString "-0.0"
+    TFloatNaN{}   -> showString "NaN"
+    TFloatUnOp op x -> showParen (d > 0) $
+       shows op . showString " " . showsPrec 10 x
+    TFloatBinOp op x y -> showParen (d > 0) $
+       shows op . showString " " . showsPrec 10 x . showString " " . showsPrec 10 y
+
+templateDepth :: TestTemplate tp -> Integer
+templateDepth = f
+  where
+  f :: TestTemplate tp -> Integer
+  f t = case t of
+          TVar{} -> 0
+
+          TFloatPZero{} -> 0
+          TFloatNZero{} -> 0
+          TFloatNaN{}  -> 0
+
+          TFloatUnOp _op x    -> 1 + (f x)
+          TFloatBinOp _op x y -> 1 + max (f x) (f y)
+
+
+floatOps ::
+  [RoundingMode] ->
+  [TestTemplate (BaseFloatType fpp)] ->
+  [TestTemplate (BaseFloatType fpp)]
+floatOps rs subterms = uops <> bops
+  where
+    uops = [ TFloatUnOp op x | op <- fUnOps rs, x <- subterms ]
+    bops = [ TFloatBinOp op x y | op <- fBinOps rs, x <- subterms, y <- subterms ]
+
+floatTemplates ::
+  [RoundingMode] ->
+  Integer ->
+  FloatPrecisionRepr fpp ->
+  [TestTemplate (BaseFloatType fpp)]
+floatTemplates rs n fpp
+  | n <= 0 = base
+  | n == 1 = floatOps rs base
+  | otherwise = f n
+
+  where
+   base = [ TVar (BaseFloatRepr fpp), TFloatPZero fpp, TFloatNZero fpp, TFloatNaN fpp ]
+
+   f d | d < 1 = [ TVar (BaseFloatRepr fpp) ]
+   f d = let xs = f (d-1) in xs <> floatOps rs xs
+
+
+generateByType :: BaseTypeRepr tp -> Gen (GroundValue tp)
+generateByType (BaseFloatRepr fpp) = genFloat fpp
+generateByType tp = error ("generateByType! TODO " ++ show tp)
+
+genFloat :: FloatPrecisionRepr fpp -> Gen BigFloat
+genFloat (FloatingPointPrecisionRepr eb sb) =
+    Gen.frequency
+        [(1, pure bfPosZero)
+        ,(1, pure bfNegZero)
+        ,(1, pure bfPosInf)
+        ,(1, pure bfNegInf)
+        ,(1, pure bfNaN)
+        ,(95, genNormal)
+        ]
+ where
+  genNormal =
+    do let emax = bit (fromInteger (intValue eb - 1)) - 1
+       let smax = bit (fromInteger (intValue sb)) - 1
+       let opts = fpOpts (intValue sb) (intValue sb) NearEven
+       sgn <- Gen.bool
+       ex  <- Gen.integral (Gen.linearFrom 0 (1-emax) emax)
+       mag <- Gen.integral (Gen.linear 0 smax)
+       let (x,Ok) = bfMul2Exp opts (bfFromInteger mag) ex
+       pure $ (if sgn then bfNeg x else x)
+
+
+mapGroundEval :: forall t. MapF (Expr t) GroundValueWrapper -> GroundEvalFn t
+mapGroundEval m = GroundEvalFn f
+  where
+    f :: forall tp. Expr t tp -> IO (GroundValue tp)
+    f x = case MapF.lookup x m of
+            Just v -> pure (unGVW v)
+            Nothing -> evalGroundExpr f x
+
+solverEval :: forall t st fs tp.
+  ExprBuilder t st fs -> MapF (Expr t) GroundValueWrapper -> Expr t tp -> IO (GroundValue tp)
+solverEval sym gmap expr = Z3.withZ3 sym "z3" defaultLogData $ \s ->
+  do let f :: Pair (Expr t) GroundValueWrapper -> IO SMT2.Term
+         f (Pair e (GVW v)) =
+            case exprType e of
+              BaseFloatRepr fpp ->
+                do e' <- mkSMTTerm (SMT2.sessionWriter s) e
+                   return (e' .== SMT.floatTerm fpp v)
+              tp -> fail ("solverEval: TODO " ++ show tp)
+
+     mapM_ (SMT.assumeFormula (SMT2.sessionWriter s) <=< f) (MapF.toList gmap)
+
+     e' <- mkSMTTerm (SMT2.sessionWriter s) expr
+     SMT2.writeGetValue (SMT2.sessionWriter s) [e']
+      
+     case exprType expr of
+       BaseFloatRepr fpp@(FloatingPointPrecisionRepr eb sb) ->
+          do bv <- SMT.smtEvalFloat (SMT2.smtLibEvalFuns s) fpp e'
+             return (floatFromBits (intValue eb) (intValue sb) (BV.asUnsigned bv))
+       tp -> fail ("solverEval: TODO2 " ++ show tp)
+
+showMap :: MapF (Expr t) GroundValueWrapper -> String
+showMap gmap = unlines (map f (MapF.toList gmap))
+  where
+    f :: Pair (Expr t) (GroundValueWrapper) -> String
+    f (Pair e (GVW v)) =
+      case exprType e of
+        BaseFloatRepr _ -> show (printSymExpr e) <> " " <> show v
+        tp -> "showMap : TODO " <> show tp
+
+templateGroundEvalTest ::
+  ExprBuilder t st fs ->
+  TestTemplate tp ->
+  Property
+templateGroundEvalTest sym t = property $
+  do (gmapGen, expr) <- liftIO (templateGen sym t)
+     annotateShow (printSymExpr expr)
+     gmap <- forAllWith showMap gmapGen
+     v  <- liftIO (groundEval (mapGroundEval gmap) expr)
+     v' <- liftIO (solverEval sym gmap expr)
+     Just True === groundEq (exprType expr) v v'
+
+-- | Use the template to create an expression, and a Hedgehog generator that
+--   builds a map from variables to concrete values for creating individual
+--   test cases.
+templateGen :: ExprBuilder t st fs -> TestTemplate tp -> IO (Gen (MapF (Expr t) GroundValueWrapper), Expr t tp)
+templateGen sym = f
+  where
+    f (TVar bt) =
+       do v <- freshConstant sym emptySymbol bt
+          return (MapF.singleton v . GVW <$> generateByType bt, v)
+
+    f (TFloatPZero fpp) =
+       do e <- floatPZero sym fpp
+          return (pure MapF.empty, e)
+
+    f (TFloatNZero fpp) =
+       do e <- floatNZero sym fpp
+          return (pure MapF.empty, e)
+
+    f (TFloatNaN fpp) =
+        do e <- floatNaN sym fpp
+           return (pure MapF.empty, e)
+
+    f (TFloatUnOp op x) =
+        do (xg,xe) <- f x
+           e <- case op of
+                  FNeg     -> floatNeg sym xe
+                  FAbs     -> floatAbs sym xe
+                  FSqrt  r -> floatSqrt sym r xe
+                  FRound r -> floatRound sym r xe
+           return (xg, e)
+
+    f (TFloatBinOp op x y) =
+        do (xg,xe) <- f x
+           (yg,ye) <- f y
+           e <- case op of
+                  FAdd r -> floatAdd sym r xe ye
+                  FSub r -> floatSub sym r xe ye
+                  FMul r -> floatMul sym r xe ye
+                  FDiv r -> floatDiv sym r xe ye
+                  FRem   -> floatRem sym xe ye
+                  FMin   -> floatMin sym xe ye
+                  FMax   -> floatMax sym xe ye
+
+           return (MapF.union <$> xg <*> yg, e)

--- a/what4/test/TestTemplate.hs
+++ b/what4/test/TestTemplate.hs
@@ -1,50 +1,86 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 --module TestTemplate where
 
 module Main where
 
-import Control.Monad ((<=<))
+import Control.Exception
+import Control.Monad ((<=<)) -- , when)
+import           Control.Monad.Trans.Maybe
 import Control.Monad.IO.Class (liftIO)
 import Data.Bits
 import Data.Parameterized.Map (MapF)
 import qualified Data.Parameterized.Map as MapF
 import Data.Parameterized.Nonce
 import Data.Parameterized.Pair
+import Data.Parameterized.Some
 import Data.String
+import Numeric (showHex)
+-- import System.IO
 
 import LibBF
 import qualified Data.BitVector.Sized as BV
 
 import What4.BaseTypes
+import What4.Config
 import What4.Interface
 
 import           What4.Protocol.SMTWriter ((.==), mkSMTTerm)
 import qualified What4.Protocol.SMTWriter as SMT
 import qualified What4.Protocol.SMTLib2 as SMT2
-import qualified What4.Solver.Z3 as Z3
-import           What4.Solver.Adapter (defaultLogData)
+import qualified What4.Protocol.Online as Online
+import           What4.Protocol.Online (SolverProcess(..), OnlineSolver(..))
+--import qualified What4.Solver.Z3 as Z3
+import qualified What4.Solver.CVC4 as CVC4
 
 import What4.Expr.Builder
 import What4.Expr.GroundEval
+import What4.SatResult
+
+import What4.Utils.Arithmetic
 import What4.Utils.FloatHelpers
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Gen
 
+--import Debug.Trace (trace)
+
 data State t = State
+
+
 
 main :: IO ()
 main =
-  do let xs = do r <- [RNE]
-                 floatTemplates [r] 1 (knownRepr :: FloatPrecisionRepr Prec32)
-     sym <- newExprBuilder FloatIEEERepr State globalNonceGenerator 
-     _ <- checkSequential $ Group "Float tests"
-       [ ( fromString (show t), templateGroundEvalTest sym t)
-       | t <- xs
-       ] 
+  do let fpp = knownRepr :: FloatPrecisionRepr Prec32 -- (FloatingPointPrecision 4 4)
+
+     let xs = castTemplates RNE <>
+              (Some <$> floatTestTemplates [] 0 fpp) <>
+              (do r <- roundingModes
+                  (Some <$> floatTemplates [r] 1 fpp))
+
+     sym <- newExprBuilder FloatIEEERepr State globalNonceGenerator
+
+     --extendConfig Z3.z3Options (getConfiguration sym)
+     --proc <- Online.startSolverProcess @(SMT2.Writer Z3.Z3) Z3.z3Features Nothing sym
+
+     extendConfig CVC4.cvc4Options (getConfiguration sym)
+     proc <- Online.startSolverProcess @(SMT2.Writer CVC4.CVC4) CVC4.cvc4Features Nothing sym
+
+     -- h <- openFile "z3.out" WriteMode
+     let testnum = 500
+
+     tests <- sequence [ do p <- templateGroundEvalTest sym proc t testnum
+                            pure (fromString (show t), p)
+                       | Some t <- xs
+                       ]
+     _ <- checkSequential $ Group "Float tests" tests
      return ()
 
 data FUnOp
@@ -64,6 +100,28 @@ data FBinOp
   | FMax
  deriving (Show)
 
+data FTestOp
+  = FIsNaN
+  | FIsInf
+  | FIsZero
+  | FIsPos
+  | FIsNeg
+  | FIsSubnorm
+  | FIsNorm
+ deriving Show
+
+data FRelOp
+  = FLogicEq
+  | FLogicNeq
+  | FEq
+  | FApart
+  | FUnordered
+  | FLe
+  | FLt
+  | FGe
+  | FGt
+ deriving Show
+
 roundingModes :: [RoundingMode]
 roundingModes = [ RNE, RNA, RTP, RTN, RTZ ]
 
@@ -80,6 +138,12 @@ fUnOps rs =
   [ FNeg, FAbs ] <>
   (FSqrt <$> rs) <>
   (FRound <$> rs)
+
+fTestOps :: [FTestOp]
+fTestOps = [ FIsNaN, FIsInf, FIsZero, FIsPos, FIsNeg, FIsSubnorm, FIsNorm ]
+
+fRelOps :: [FRelOp]
+fRelOps = [ FLogicEq, FLogicNeq, FEq, FApart, FUnordered, FLe, FLt, FGe, FGt ]
 
 -- | This datatype essentially mirrors the public API of the
 --   What4 interface.  There should (eventually) be one element
@@ -113,9 +177,68 @@ data TestTemplate tp where
     TestTemplate (BaseFloatType fpp) ->
     TestTemplate (BaseFloatType fpp)
 
+  TFloatTest ::
+    FTestOp ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate BaseBoolType
+
+  TFloatRel ::
+    FRelOp ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate BaseBoolType
+
+  TFloatFromBits :: (2 <= eb, 2 <= sb) =>
+    FloatPrecisionRepr (FloatingPointPrecision eb sb) ->
+    TestTemplate (BaseBVType (eb + sb)) ->
+    TestTemplate (BaseFloatType (FloatingPointPrecision eb sb))
+
+  TFloatToBits :: (2 <= eb, 2 <= sb) =>
+    TestTemplate (BaseFloatType (FloatingPointPrecision eb sb)) ->
+    TestTemplate (BaseBVType (eb + sb))
+
+  TBVToFloat :: (1 <= w) =>
+    FloatPrecisionRepr fpp ->
+    RoundingMode ->
+    Bool {- False = unsigned -} ->
+    TestTemplate (BaseBVType w) ->
+    TestTemplate (BaseFloatType fpp)
+
+  TFloatToBV :: (1 <= w) =>
+    NatRepr w ->
+    RoundingMode ->
+    Bool {- False = unsigned -} ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseBVType w)
+
+  TFloatCast ::
+    FloatPrecisionRepr fpp ->
+    RoundingMode ->
+    TestTemplate (BaseFloatType fpp') ->
+    TestTemplate (BaseFloatType fpp)
+
+  TFloatToReal ::
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate BaseRealType
+
+  TRealToFloat ::
+    FloatPrecisionRepr fpp ->
+    RoundingMode ->
+    TestTemplate BaseRealType ->
+    TestTemplate (BaseFloatType fpp)
+
+  TFloatFMA ::
+    RoundingMode ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp) ->
+    TestTemplate (BaseFloatType fpp)
+
+
+
 instance Show (TestTemplate tp) where
   showsPrec d tt = case tt of
-    TVar{}        -> showString "_"
+    TVar{}        -> showString "<var>"
     TFloatPZero{} -> showString "+0.0"
     TFloatNZero{} -> showString "-0.0"
     TFloatNaN{}   -> showString "NaN"
@@ -123,6 +246,33 @@ instance Show (TestTemplate tp) where
        shows op . showString " " . showsPrec 10 x
     TFloatBinOp op x y -> showParen (d > 0) $
        shows op . showString " " . showsPrec 10 x . showString " " . showsPrec 10 y
+    TFloatTest op x -> showParen (d > 0) $
+       shows op . showString " " . showsPrec 10 x
+    TFloatRel op x y ->  showParen (d > 0) $
+       shows op . showString " " . showsPrec 10 x . showString " " . showsPrec 10 y
+    TFloatFMA r x y z -> showParen (d > 0) $
+       showString "FMA" . showString " " . shows r . showString " " .
+       showsPrec 10 x . showString " " . showsPrec 10 y . showString " " . showsPrec 10 z
+    TFloatFromBits _fpp x -> showParen (d > 0) $
+       showString "FloatFromBits " . showsPrec 10 x
+    TFloatToBits x -> showParen (d > 0) $
+       showString "FloatToBits " . showsPrec 10 x
+    TFloatCast fpp r x -> showParen (d > 0) $
+       showString "FloatCast " . shows fpp . showString " " . shows r . showString " " . showsPrec 10 x
+    TFloatToReal x -> showParen (d > 0) $
+       showString "FloatToReal " . showsPrec 10 x
+    TRealToFloat fpp r x -> showParen (d > 0) $
+       showString "RealToFloat " . shows fpp . showString " " . shows r . showString " " . showsPrec 10 x
+    TBVToFloat fpp r sgn x ->
+       showString (if sgn then "SBVToFloat " else "BVToFloat ") .
+       shows fpp . showString " " .
+       shows r . showString " " .
+       showsPrec 10 x
+    TFloatToBV w r sgn x ->
+       showString (if sgn then "FloatToSBV" else "FloatToBV ") .
+       shows w . showString " " .
+       shows r . showString " " .
+       showsPrec 10 x
 
 templateDepth :: TestTemplate tp -> Integer
 templateDepth = f
@@ -137,16 +287,64 @@ templateDepth = f
 
           TFloatUnOp _op x    -> 1 + (f x)
           TFloatBinOp _op x y -> 1 + max (f x) (f y)
-
+          TFloatTest _op x    -> 1 + (f x)
+          TFloatRel _op x y   -> 1 + max (f x) (f y)
+          TFloatFMA _ x y z   -> 1 + max (f x) (max (f y) (f z))
+          TFloatFromBits _ x  -> 1 + f x
+          TFloatToBits x      -> 1 + f x
+          TFloatCast _ _ x    -> 1 + f x
+          TFloatToReal x      -> 1 + f x
+          TRealToFloat _ _ x  -> 1 + f x
+          TBVToFloat _ _ _ x  -> 1 + f x
+          TFloatToBV _ _ _ x  -> 1 + f x
 
 floatOps ::
+  FloatPrecisionRepr fpp ->
   [RoundingMode] ->
   [TestTemplate (BaseFloatType fpp)] ->
   [TestTemplate (BaseFloatType fpp)]
-floatOps rs subterms = uops <> bops
+floatOps fpp@(FloatingPointPrecisionRepr eb sb) rs subterms = casts <> uops <> bops <> fma
   where
-    uops = [ TFloatUnOp op x | op <- fUnOps rs, x <- subterms ]
-    bops = [ TFloatBinOp op x y | op <- fBinOps rs, x <- subterms, y <- subterms ]
+    uops  = [ TFloatUnOp op x | op <- fUnOps rs, x <- subterms ]
+    bops  = [ TFloatBinOp op x y | op <- fBinOps rs, x <- subterms, y <- subterms ]
+    fma   = [ TFloatFMA r x y z | r <- rs, x <- subterms, y <- subterms, z <- subterms ]
+    casts = [ case isPosNat (addNat eb sb) of
+                Just LeqProof -> TFloatFromBits fpp (TVar (BaseBVRepr (addNat eb sb)))
+                Nothing -> error $ unwords ["floatOps", "bad fpp", show fpp]
+            ]
+
+castTemplates :: RoundingMode -> [Some TestTemplate]
+castTemplates r =
+  [ Some (TFloatToBits (TVar (knownRepr :: BaseTypeRepr (BaseFloatType Prec32))))
+  , Some (TFloatCast (knownRepr :: FloatPrecisionRepr Prec32) r
+              (TVar (knownRepr :: BaseTypeRepr (BaseFloatType Prec64))))
+  , Some (TFloatCast (knownRepr :: FloatPrecisionRepr Prec64) r
+              (TVar (knownRepr :: BaseTypeRepr (BaseFloatType Prec32))))
+  , Some (TFloatToReal (TVar (knownRepr :: BaseTypeRepr (BaseFloatType Prec32))))
+  , Some (TRealToFloat (knownRepr :: FloatPrecisionRepr Prec32) r (TVar knownRepr))
+
+  , Some (TBVToFloat (knownRepr :: FloatPrecisionRepr Prec32) r False
+              (TVar (knownRepr :: BaseTypeRepr (BaseBVType 32))))
+  , Some (TBVToFloat (knownRepr :: FloatPrecisionRepr Prec32) r True
+              (TVar (knownRepr :: BaseTypeRepr (BaseBVType 32))))
+
+  , Some (TFloatToBV (knownNat :: NatRepr 32) r False
+              (TVar (knownRepr :: BaseTypeRepr (BaseFloatType Prec32))))
+  , Some (TFloatToBV (knownNat :: NatRepr 32) r True
+              (TVar (knownRepr :: BaseTypeRepr (BaseFloatType Prec32))))
+  ]
+
+
+floatTestTemplates ::
+  [RoundingMode] ->
+  Integer ->
+  FloatPrecisionRepr fpp ->
+  [TestTemplate BaseBoolType]
+floatTestTemplates rs n fpp = tops <> relops
+ where
+   subterms = floatTemplates rs n fpp
+   tops   = [ TFloatTest op x | op <- fTestOps, x <- subterms ]
+   relops = [ TFloatRel op x y | op <- fRelOps, x <- subterms, y <- subterms ]
 
 floatTemplates ::
   [RoundingMode] ->
@@ -155,127 +353,190 @@ floatTemplates ::
   [TestTemplate (BaseFloatType fpp)]
 floatTemplates rs n fpp
   | n <= 0 = base
-  | n == 1 = floatOps rs base
+  | n == 1 = base <> floatOps fpp rs base
   | otherwise = f n
 
   where
    base = [ TVar (BaseFloatRepr fpp), TFloatPZero fpp, TFloatNZero fpp, TFloatNaN fpp ]
 
    f d | d < 1 = [ TVar (BaseFloatRepr fpp) ]
-   f d = let xs = f (d-1) in xs <> floatOps rs xs
-
+   f d = [ TVar (BaseFloatRepr fpp) ] <> floatOps fpp rs (f (d-1))
 
 generateByType :: BaseTypeRepr tp -> Gen (GroundValue tp)
+generateByType BaseBoolRepr = Gen.bool
 generateByType (BaseFloatRepr fpp) = genFloat fpp
+generateByType (BaseBVRepr w) = genBV w
+generateByType BaseRealRepr  = genReal
 generateByType tp = error ("generateByType! TODO " ++ show tp)
+
+genReal :: Gen Rational
+genReal = Gen.realFrac_ (Gen.linearFracFrom 0 (negate mx) mx)
+  where mx = 1 ^^ (200::Integer)
+
+genBV :: (1 <= w) => NatRepr w -> Gen (BV.BV w)
+genBV w =
+  do val <- Gen.integral (Gen.linearFrom 0 (minSigned w) (maxSigned w))
+     pure (BV.mkBV w val)
 
 genFloat :: FloatPrecisionRepr fpp -> Gen BigFloat
 genFloat (FloatingPointPrecisionRepr eb sb) =
     Gen.frequency
-        [(1, pure bfPosZero)
-        ,(1, pure bfNegZero)
-        ,(1, pure bfPosInf)
-        ,(1, pure bfNegInf)
-        ,(1, pure bfNaN)
-        ,(95, genNormal)
+        [ ( 1, pure bfPosZero)
+        , ( 1, pure bfNegZero)
+        , ( 1, pure bfPosInf)
+        , ( 1, pure bfNegInf)
+        , ( 1, pure bfNaN)
+        , (95, genNormal)
         ]
  where
+  emax = bit (fromInteger (intValue eb - 1)) - 1
+  smax = bit (fromInteger (intValue sb)) - 1
+  opts = fpOpts (intValue eb) (intValue sb) Away
+
   genNormal =
-    do let emax = bit (fromInteger (intValue eb - 1)) - 1
-       let smax = bit (fromInteger (intValue sb)) - 1
-       let opts = fpOpts (intValue sb) (intValue sb) NearEven
-       sgn <- Gen.bool
+    do sgn <- Gen.bool
        ex  <- Gen.integral (Gen.linearFrom 0 (1-emax) emax)
-       mag <- Gen.integral (Gen.linear 0 smax)
-       let (x,Ok) = bfMul2Exp opts (bfFromInteger mag) ex
-       pure $ (if sgn then bfNeg x else x)
+       mag <- Gen.integral (Gen.linear 1 smax)
+       let (x0,st) = bfMul2Exp opts (bfFromInteger mag) (ex - fromIntegral (lgCeil mag))
+       let x = if sgn then bfNeg x0 else x0
+       let statusCheck =
+             case st of
+                MemError -> error ("genFloat: MemoryError!")
+                _ -> ()
 
+                -- Ok -> ()
+                -- _ -> trace (unwords [show st, show sgn, show ex, show mag, show x]) ()
+       statusCheck `seq` (pure x)
 
-mapGroundEval :: forall t. MapF (Expr t) GroundValueWrapper -> GroundEvalFn t
-mapGroundEval m = GroundEvalFn f
-  where
-    f :: forall tp. Expr t tp -> IO (GroundValue tp)
-    f x = case MapF.lookup x m of
-            Just v -> pure (unGVW v)
-            Nothing -> evalGroundExpr f x
+mapGroundEval :: MapF (Expr t) GroundValueWrapper -> Expr t tp -> MaybeT IO (GroundValue tp)
+mapGroundEval m x =
+  case MapF.lookup x m of
+    Just v -> pure (unGVW v)
+    Nothing -> tryEvalGroundExpr (mapGroundEval m) x
 
-solverEval :: forall t st fs tp.
-  ExprBuilder t st fs -> MapF (Expr t) GroundValueWrapper -> Expr t tp -> IO (GroundValue tp)
-solverEval sym gmap expr = Z3.withZ3 sym "z3" defaultLogData $ \s ->
-  do let f :: Pair (Expr t) GroundValueWrapper -> IO SMT2.Term
+solverEval :: forall t st fs solver tp.
+  OnlineSolver solver =>
+  ExprBuilder t st fs ->
+  SolverProcess t solver ->
+  MapF (Expr t) GroundValueWrapper ->
+  Expr t tp ->
+  IO (GroundValue tp)
+solverEval _sym proc gmap expr =
+  do let c = Online.solverConn proc
+     let f :: Pair (Expr t) GroundValueWrapper -> IO (SMT.Term solver)
          f (Pair e (GVW v)) =
             case exprType e of
               BaseFloatRepr fpp ->
-                do e' <- mkSMTTerm (SMT2.sessionWriter s) e
+                do e' <- mkSMTTerm c e
                    return (e' .== SMT.floatTerm fpp v)
+              BaseBVRepr w ->
+                do e' <- mkSMTTerm c e
+                   return (e' .== SMT.bvTerm w v)
+              BaseBoolRepr ->
+                do e' <- mkSMTTerm c e
+                   return (e' .== SMT.boolExpr v)
+              BaseRealRepr ->
+                do e' <- mkSMTTerm c e
+                   return (e' .== SMT.rationalTerm v)
+
               tp -> fail ("solverEval: TODO " ++ show tp)
 
-     mapM_ (SMT.assumeFormula (SMT2.sessionWriter s) <=< f) (MapF.toList gmap)
+     Online.inNewFrame proc do
+       mapM_ (SMT.assumeFormula c <=< f) (MapF.toList gmap)
+       e' <- mkSMTTerm c expr
+       res <- Online.check proc "eval"
+       case res of
+         Unsat _ -> fail "Expected SAT, but got UNSAT"
+         Unknown -> fail "Expected SAT, but got UNKNOWN"
+         Sat _ ->
+           case exprType expr of
+             BaseFloatRepr fpp ->
+               do bv <- SMT.smtEvalFloat (Online.solverEvalFuns proc) fpp e'
+                  return (bfFromBits (fppOpts fpp RNE) (BV.asUnsigned bv))
+             BaseBVRepr w ->
+               SMT.smtEvalBV (Online.solverEvalFuns proc) w e'
+             BaseRealRepr ->
+               SMT.smtEvalReal (Online.solverEvalFuns proc) e'
+             BaseBoolRepr ->
+               SMT.smtEvalBool (Online.solverEvalFuns proc) e'
 
-     e' <- mkSMTTerm (SMT2.sessionWriter s) expr
-     SMT2.writeGetValue (SMT2.sessionWriter s) [e']
-      
-     case exprType expr of
-       BaseFloatRepr fpp@(FloatingPointPrecisionRepr eb sb) ->
-          do bv <- SMT.smtEvalFloat (SMT2.smtLibEvalFuns s) fpp e'
-             return (floatFromBits (intValue eb) (intValue sb) (BV.asUnsigned bv))
-       tp -> fail ("solverEval: TODO2 " ++ show tp)
+             tp -> fail ("solverEval: TODO2 " ++ show tp)
 
 showMap :: MapF (Expr t) GroundValueWrapper -> String
 showMap gmap = unlines (map f (MapF.toList gmap))
   where
     f :: Pair (Expr t) (GroundValueWrapper) -> String
-    f (Pair e (GVW v)) =
-      case exprType e of
-        BaseFloatRepr _ -> show (printSymExpr e) <> " " <> show v
-        tp -> "showMap : TODO " <> show tp
+    f (Pair e (GVW v)) = show (printSymExpr e) <> " |-> " <> showGroundVal (exprType e) v
+
+showGroundVal :: BaseTypeRepr tp -> GroundValue tp -> String
+showGroundVal tp v =
+  case tp of
+    BaseFloatRepr fpp ->
+      show v <> " 0x" <> showHex (bfToBits (fppOpts fpp RNE) v) ""
+    BaseBVRepr w -> BV.ppHex w v
+    BaseRealRepr -> show v
+    BaseBoolRepr -> show v
+    _ -> "showGroundVal: TODO " <> show tp
 
 templateGroundEvalTest ::
+  OnlineSolver solver =>
   ExprBuilder t st fs ->
+  SolverProcess t solver ->
   TestTemplate tp ->
-  Property
-templateGroundEvalTest sym t = property $
-  do (gmapGen, expr) <- liftIO (templateGen sym t)
-     annotateShow (printSymExpr expr)
-     gmap <- forAllWith showMap gmapGen
-     v  <- liftIO (groundEval (mapGroundEval gmap) expr)
-     v' <- liftIO (solverEval sym gmap expr)
-     Just True === groundEq (exprType expr) v v'
+  Int ->
+  IO Property
+templateGroundEvalTest sym proc t numTests =
+  do (sz, gmapGen, expr) <- templateGen sym t
+     pure $ withTests (fromIntegral (max 1 (numTests * sz))) $ property $
+       do annotateShow (printSymExpr expr)
+          gmap <- forAllWith showMap gmapGen
+          v  <- liftIO (runMaybeT (mapGroundEval gmap expr))
+          annotate (maybe "Nothing" (showGroundVal (exprType expr)) v)
+          res <- liftIO (try (solverEval sym proc gmap expr))
+          case res of
+            Left (ex :: IOError) -> footnote (show ex) >> failure
+            Right v' ->
+              do annotate (showGroundVal (exprType expr) v')
+                 case v of
+                   Just v_ -> Just True === groundEq (exprType expr) v_ v'
+                   Nothing -> success
 
 -- | Use the template to create an expression, and a Hedgehog generator that
 --   builds a map from variables to concrete values for creating individual
 --   test cases.
-templateGen :: ExprBuilder t st fs -> TestTemplate tp -> IO (Gen (MapF (Expr t) GroundValueWrapper), Expr t tp)
+templateGen :: forall t st fs tp.
+  ExprBuilder t st fs -> TestTemplate tp -> IO (Int, Gen (MapF (Expr t) GroundValueWrapper), Expr t tp)
 templateGen sym = f
   where
+    f :: forall tp'. TestTemplate tp' -> IO (Int, Gen (MapF (Expr t) GroundValueWrapper), Expr t tp')
     f (TVar bt) =
        do v <- freshConstant sym emptySymbol bt
-          return (MapF.singleton v . GVW <$> generateByType bt, v)
+          return (1, MapF.singleton v . GVW <$> generateByType bt, v)
 
     f (TFloatPZero fpp) =
        do e <- floatPZero sym fpp
-          return (pure MapF.empty, e)
+          return (0, pure MapF.empty, e)
 
     f (TFloatNZero fpp) =
        do e <- floatNZero sym fpp
-          return (pure MapF.empty, e)
+          return (0, pure MapF.empty, e)
 
     f (TFloatNaN fpp) =
         do e <- floatNaN sym fpp
-           return (pure MapF.empty, e)
+           return (0, pure MapF.empty, e)
 
     f (TFloatUnOp op x) =
-        do (xg,xe) <- f x
+        do (xn,xg,xe) <- f x
            e <- case op of
                   FNeg     -> floatNeg sym xe
                   FAbs     -> floatAbs sym xe
                   FSqrt  r -> floatSqrt sym r xe
                   FRound r -> floatRound sym r xe
-           return (xg, e)
+           return (xn,xg, e)
 
     f (TFloatBinOp op x y) =
-        do (xg,xe) <- f x
-           (yg,ye) <- f y
+        do (xn,xg,xe) <- f x
+           (yn,yg,ye) <- f y
            e <- case op of
                   FAdd r -> floatAdd sym r xe ye
                   FSub r -> floatSub sym r xe ye
@@ -285,4 +546,78 @@ templateGen sym = f
                   FMin   -> floatMin sym xe ye
                   FMax   -> floatMax sym xe ye
 
-           return (MapF.union <$> xg <*> yg, e)
+           return (xn+yn, MapF.union <$> xg <*> yg, e)
+
+    f (TFloatTest op x) =
+        do (xn,xg,xe) <- f x
+           e <- case op of
+                  FIsNaN  -> floatIsNaN sym xe
+                  FIsInf  -> floatIsInf sym xe
+                  FIsZero -> floatIsZero sym xe
+                  FIsPos  -> floatIsPos sym xe
+                  FIsNeg  -> floatIsNeg sym xe
+                  FIsSubnorm -> floatIsSubnorm sym xe
+                  FIsNorm -> floatIsNorm sym xe
+           return (xn, xg, e)
+
+    f (TFloatRel op x y) =
+        do (xn,xg,xe) <- f x
+           (yn,yg,ye) <- f y
+           e <- case op of
+                  FLogicEq   -> floatEq sym xe ye
+                  FLogicNeq  -> floatNe sym xe ye
+                  FEq        -> floatFpEq sym xe ye
+                  FApart     -> floatFpApart sym xe ye
+                  FUnordered -> floatFpUnordered sym xe ye
+                  FLe        -> floatLe sym xe ye
+                  FLt        -> floatLt sym xe ye
+                  FGe        -> floatGe sym xe ye
+                  FGt        -> floatGt sym xe ye
+
+           return (xn+yn, MapF.union <$> xg <*> yg, e)
+
+    f (TFloatFMA r x y z) =
+        do (xn,xg,xe) <- f x
+           (yn,yg,ye) <- f y
+           (zn,zg,ze) <- f z
+           e <- floatFMA sym r xe ye ze
+           return (xn+yn+zn, foldr MapF.union MapF.empty <$> sequence [xg,yg,zg], e)
+
+    f (TFloatFromBits fpp x) =
+        do (xn,xg,xe) <- f x
+           e <- floatFromBinary sym fpp xe
+           return (xn,xg,e)
+
+    f (TFloatToBits x) =
+        do (xn,xg,xe) <- f x
+           e <- floatToBinary sym xe
+           return (xn,xg,e)
+
+    f (TFloatCast fpp r x) =
+        do (xn,xg,xe) <- f x
+           e <- floatCast sym fpp r xe
+           return (xn,xg,e)
+
+    f (TFloatToReal x) =
+        do (xn,xg,xe) <- f x
+           e <- floatToReal sym xe
+           return (xn,xg,e)
+
+    f (TRealToFloat fpp r x) =
+        do (xn,xg,xe) <- f x
+           e <- realToFloat sym fpp r xe
+           return (xn,xg,e)
+
+    f (TBVToFloat fpp r sgn x) =
+        do (xn,xg,xe) <- f x
+           e <- case sgn of
+                  False -> bvToFloat sym fpp r xe
+                  True  -> sbvToFloat sym fpp r xe
+           return (xn,xg,e)
+
+    f (TFloatToBV w r sgn x) =
+        do (xn,xg,xe) <- f x
+           e <- case sgn of
+                  False -> floatToBV sym w r xe
+                  True  -> floatToSBV sym w r xe
+           return (xn,xg,e)

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -119,6 +119,7 @@ library
     What4.WordMap
 
     What4.Expr
+    What4.Expr.App
     What4.Expr.ArrayUpdateMap
     What4.Expr.AppTheory
     What4.Expr.BoolMap
@@ -179,7 +180,6 @@ library
     Test.Verification
 
   other-modules:
-    What4.Expr.App
     Paths_what4
 
   ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -363,3 +363,22 @@ test-suite bvdomain_tests_hh
                , what4
 
   ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+
+test-suite template_tests
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+
+  hs-source-dirs: test
+  main-is : TestTemplate.hs
+
+  build-depends: base
+               , bv-sized
+               , libBF
+               , parameterized-utils
+               , tasty >= 0.10
+               , tasty-hedgehog
+               , hedgehog >= 1.0.2
+               , transformers
+               , what4
+
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -73,7 +73,7 @@ library
     hashtables >= 1.2.3,
     io-streams >= 1.5,
     lens >= 4.18,
-    libBF >= 0.5.1 && < 0.6,
+    libBF >= 0.6 && < 0.7,
     mtl >= 2.2.1,
     panic >= 0.3,
     parameterized-utils >= 2.1 && < 2.2,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -274,6 +274,7 @@ test-suite expr-builder-smtlib2
     bytestring,
     containers,
     data-binary-ieee754,
+    libBF,
     parameterized-utils,
     tasty >= 0.10,
     tasty-hunit >= 0.9,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -73,6 +73,7 @@ library
     hashtables >= 1.2.3,
     io-streams >= 1.5,
     lens >= 4.18,
+    libBF >= 0.5.1 && < 0.6,
     mtl >= 2.2.1,
     panic >= 0.3,
     parameterized-utils >= 2.1 && < 2.2,
@@ -165,6 +166,7 @@ library
     What4.Utils.Environment
     What4.Utils.HandleReader
     What4.Utils.IncrHash
+    What4.Utils.FloatHelpers
     What4.Utils.LeqMap
     What4.Utils.MonadST
     What4.Utils.OnlyNatRepr

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -115,6 +115,7 @@ library
     What4.SatResult
     What4.SemiRing
     What4.Symbol
+    What4.SFloat
     What4.SWord
     What4.WordMap
 


### PR DESCRIPTION
Use the `libBF` library to implement concrete floating-point ground evaluation and constant folding.

This is especially a tricky area to get right, so I've implemented a new testing technique using "expression templates."   These are fragments of syntax containing variables at base types.  We can enumerate an interesting collection of these templates and use them to generate test cases.  For each test case, we will chose random concrete values for the variables and evaluate the syntax in a variety of ways and test that they agree.  In particular, we can ask solvers to act as computational oracles and verify that our ground evaluation agrees with their theory.