### PR TITLE
Fixes bug involving structs that contain nats

### DIFF
--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -1221,6 +1221,18 @@ addPartialSideCond ::
 addPartialSideCond _ t NatTypeMap Nothing =
   do addSideCondition "nat_range" $ t .>= 0
 
+-- NB, structs also (might) have a side condition even if there is no abstract
+-- domain (due to the possibility of containing nats)
+addPartialSideCond conn t (StructTypeMap ctx) Nothing =
+     Ctx.forIndex (Ctx.size ctx)
+        (\start i ->
+            do start
+               addPartialSideCond conn
+                 (structProj @h ctx i t)
+                 (ctx Ctx.! i)
+                 Nothing)
+        (return ())
+
 -- in all other cases, no abstract domain information means unconstrained values
 addPartialSideCond _ _ _ Nothing = return ()
 


### PR DESCRIPTION
This adds the case where we have a struct with no abstract domain, because we
actually need to make a recursive call in that scenario (in case any of the
fields are nats).

This fixes https://github.com/GaloisInc/what4/issues/91

However, it does not address the problem of arrays of nats; I'm not sure how to handle that situation.