### PR TITLE
Audit IORefs

### DIFF
--- a/what4/src/What4/Config.hs
+++ b/what4/src/What4/Config.hs
@@ -72,7 +72,7 @@
 -- in a properly synchronized way.  Of course, if one desires to isolate
 -- configuration changes in different threads from each other, separate
 -- configuration objects are required. As noted in the documentation for
--- @set_opt_onset@, the validation procedures for options should not
+-- 'opt_onset', the validation procedures for options should not
 -- look up the value of other options, or deadlock may occur.
 ------------------------------------------------------------------------------
 {-# LANGUAGE CPP #-}
@@ -204,7 +204,7 @@ import           What4.Utils.StringLiteral
 --   to statically-checkable failures (missing symbols and type-checking,
 --   respectively) by consistently using `ConfigOption` values.
 --
---   The following example indicates the suggested useage
+--   The following example indicates the suggested usage
 --
 -- @
 --   asdfFrob :: ConfigOption BaseRealType
@@ -219,7 +219,7 @@ data ConfigOption (tp :: BaseType) where
 instance Show (ConfigOption tp) where
   show = configOptionName
 
--- | Construct a `ConfigOption` from a string name.  Idomatic useage is
+-- | Construct a `ConfigOption` from a string name.  Idiomatic usage is
 --   to define a single top-level `ConfigOption` value in the module where the option
 --   is defined to consistently fix its name and type for all subsequent uses.
 configOption :: BaseTypeRepr tp -> String -> ConfigOption tp
@@ -260,7 +260,7 @@ configOptionType (ConfigOption tp _) = tp
 --   (as defined by the associated @OptionStyle@).  The result of the validation
 --   function is an @OptionSetResult@.  If the option value given is invalid
 --   for some reason, an error should be returned.  Additionally, warning messages
---   may be returned, which will be passed through to the eventuall call site
+--   may be returned, which will be passed through to the eventual call site
 --   attempting to alter the option setting.
 data OptionSetResult =
   OptionSetResult
@@ -520,7 +520,7 @@ executablePathOptSty = stringOptSty & set_opt_onset vf
 data ConfigDesc where
   ConfigDesc :: ConfigOption tp -> OptionStyle tp -> Maybe (Doc Void) -> ConfigDesc
 
--- | The most general method for construcing a normal `ConfigDesc`.
+-- | The most general method for constructing a normal `ConfigDesc`.
 mkOpt :: ConfigOption tp     -- ^ Fixes the name and the type of this option
       -> OptionStyle tp      -- ^ Define the style of this option
       -> Maybe (Doc Void)    -- ^ Help text
@@ -670,7 +670,7 @@ insertOption (ConfigDesc (ConfigOption _tp (p:|ps)) sty h) m = adjustConfigMap p
 -- Config
 
 -- | The main configuration datatype.  It consists of an MVar
---   continaing the actual configuration data.
+--   containing the actual configuration data.
 newtype Config = Config (MVar ConfigMap)
 
 -- | Construct a new configuration from the given configuration

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -14,9 +14,9 @@ a number of mutable storage locations.  These are designed so they
 may reasonably be used in a multithreaded context.  In particular,
 nonce values are generated atomically, and other IORefs used in this
 module are modified or written atomically, so modifications should
-propigate in the expected sequentually-consistent ways.  Of course,
+propagate in the expected sequentially-consistent ways.  Of course,
 threads may still clobber state others have set (e.g., the current 
-program location) so the potentialy for truly multithreaded us is
+program location) so the potential for truly multithreaded use is
 somewhat limited.
 -}
 {-# LANGUAGE CPP #-}

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -115,6 +115,12 @@ getGoalTimeoutInSeconds sgt =
 
 
 -- | A live connection to a running solver process.
+--
+--   This data structure should be used in a single-threaded
+--   manner or with external synchronization to ensure that
+--   only a single thread has access at a time. Unsynchronized
+--   multithreaded use will lead to race conditions and very
+--   strange results.
 data SolverProcess scope solver = SolverProcess
   { solverConn  :: !(WriterConn scope solver)
     -- ^ Writer for sending commands to the solver

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -591,6 +591,10 @@ data StackEntry t (h :: Type) = StackEntry
 -- It is responsible for knowing the capabilities of the solver; generating
 -- fresh names when needed; maintaining the stack of pushes and pops, and
 -- sending queries to the solver.
+--
+-- A WriterConn should be used in a single-threaded manner or using external
+-- synchronization to ensure that only one thread is accessing this connection
+-- at a time, otherwise race conditions and unpredictable results may occur.
 data WriterConn t (h :: Type) =
   WriterConn { smtWriterName :: !String
                -- ^ Name of writer for error reporting purposes.

--- a/what4/src/What4/Solver/Adapter.hs
+++ b/what4/src/What4/Solver/Adapter.hs
@@ -125,7 +125,7 @@ solverAdapterOptions xs@(def:_) =
      return (opts, readIORef ref)
 
  where
- f ref x = (T.pack (solver_adapter_name x), writeIORef ref x >> return optOK)
+ f ref x = (T.pack (solver_adapter_name x), atomicWriteIORef ref x >> return optOK)
  vals ref = Map.fromList (map (f ref) xs)
  sty ref = mkOpt defaultSolverAdapter
                  (listOptSty (vals ref))


### PR DESCRIPTION
Audit all uses of IORefs in What4 and replace with with atomic primitives where necessary, or document when they require external synchronization.