### PR TITLE
Fix compile with versions >= 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,12 @@ jobs:
         # LD_LIBRARY_PATH manipulation may be removed for all steps.
         run: |
           cd what4
-          nix-shell -p cabal-install $GHC gmp zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure -fSTPTestDisable -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
+          nix-shell -p cabal-install $GHC gmp zlib happy --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure -fSTPTestDisable -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
       - name: Build
         shell: bash
         run: |
           cd what4
-          nix-shell -p cabal-install $GHC gmp zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal build --extra-lib-dirs="$ZLIB_LOC"'
+          nix-shell -p cabal-install $GHC gmp zlib happy --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal build --extra-lib-dirs="$ZLIB_LOC"'
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         ghc: [8.10.3, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,4 +84,4 @@ jobs:
         shell: bash
         run: |
           cd what4
-          nix-shell -p cabal-install $GHC --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal haddock what4 --extra-lib-dirs="$ZLIB_LOC"'
+          nix-shell -p cabal-install $GHC zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal haddock what4 --extra-lib-dirs="$ZLIB_LOC"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,16 @@ name: What4 CI
 on:
   - push
   - pull_request
+
+# The CACHE_VERSION can be updated to force the use of a new cache if
+# the current cache contents become corrupted/invalid.  This can
+# sometimes happen when (for example) the OS version is changed but
+# older .so files are cached, which can have various effects
+# (e.g. cabal complains it can't find a valid version of the "happy"
+# tool).
+env:
+  CACHE_VERSION: 1
+
 jobs:
   linux:
     name: Testing ${{ matrix.os }} GHC-${{ matrix.ghc }}
@@ -9,7 +19,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         ghc: [8.10.3, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
@@ -29,9 +39,9 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: |
-            cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-${{ github.ref }}
+            ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-${{ github.ref }}
           restore-keys: |
-            cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-
+            ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-
       - name: Cabal update
         shell: bash
         run: nix-shell -p cabal-install --run 'cabal update'
@@ -40,10 +50,13 @@ jobs:
         run: |
           cd what4
           nix-shell -p cabal-install --run 'cabal check'
-      - name: GHC Version
+      - name: Setup Environment Vars
         run: |
-          echo GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g) >> $GITHUB_ENV
+          GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
+          echo GHC=$GHC >> $GITHUB_ENV
+          echo GHCPKGS=haskell.packages.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g) >> $GITHUB_ENV
           echo ZLIB_LOC="$(nix eval --raw nixpkgs.zlib)/lib" >> $GITHUB_ENV
+          echo NS="nix-shell -p cabal-install $GHC gmp zlib --run" >> $GITHUB_ENV
       - name: Cabal configure
         shell: bash
         # Note: the explicit LD_LIBRARY_PATH is needed for GHC 8.6.5
@@ -52,20 +65,21 @@ jobs:
         # LD_LIBRARY_PATH manipulation may be removed for all steps.
         run: |
           cd what4
-          nix-shell -p cabal-install $GHC gmp zlib happy --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure -fSTPTestDisable -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
+          $NS 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure -fSTPTestDisable -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
       - name: Build
         shell: bash
         run: |
           cd what4
-          nix-shell -p cabal-install $GHC gmp zlib happy --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal build --extra-lib-dirs="$ZLIB_LOC"'
+          $NS 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal build --extra-lib-dirs="$ZLIB_LOC"'
       - name: Test
         shell: bash
         run: |
+          cd what4
           echo Boolector version $(nix eval nixpkgs.boolector.version)
           echo CVC4 version $(nix eval nixpkgs.cvc4.version)
           echo Yices version $(nix eval nixpkgs.yices.version)
           echo Z3 version $(nix eval nixpkgs.z3.version)
-          nix-shell -p cabal-install $GHC abc-verifier boolector cvc4 yices z3 --run 'cabal test what4'
+          nix-shell -p cabal-install $GHC abc-verifier boolector cvc4 yices z3 zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal test --extra-lib-dirs="$ZLIB_LOC"'
       - name: Documentation
         shell: bash
         run: |

--- a/what4/README.md
+++ b/what4/README.md
@@ -271,7 +271,7 @@ for the more experimental logics that have not been standardized. If you
 encounter such a situation, please open a ticket, as our goal is to work correctly
 on as wide a collection of solvers as is reasonable.
 
-- Z3 versions 4.8.7 and 4.8.8
+- Z3 versions 4.8.7, 4.8.8, and 4.8.9
 - Yices 2.6.1 and 2.6.2
 - CVC4 1.7 and 1.8
 - Boolector 3.2.1

--- a/what4/solverBounds.config
+++ b/what4/solverBounds.config
@@ -1,0 +1,25 @@
+-- This file defines upper and lower bounds for solvers
+-- that are expected to work with What4.  Lower bounds
+-- are inclusive, but upper bounds are exclusive bounds.
+-- Thus, we expect versions v to be compatible with
+-- What4 when where lower <= v < upper.  A recommended
+-- version may also be specified, which is purely
+-- informational.
+
+solvers:
+  Z3:
+    lower : "4.8.7"
+    recommended : "4.8.9"
+    upper : "4.9"
+  Yices:
+    lower : "2.6.1"
+    recommended : "2.6.2"
+    upper : "2.7"
+  CVC4:
+    lower : "1.7"
+    recommended : "1.8"
+    upper : "1.9"
+  STP:
+    lower : "3.2.1"
+    recommended : "3.2.1"
+    upper : "3.3"

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -93,6 +93,7 @@ import qualified Data.Bits as Bits
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.Char (digitToInt, isPrint, isAscii)
+import           Data.List.NonEmpty ( NonEmpty(..) )
 import           Data.IORef
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Lazy
@@ -1150,8 +1151,8 @@ shutdownSolver _solver p = do
 -----------------------------------------------------------------
 -- Checking solver version bounds
 
-mkChunks :: [Word] -> [Versions.VChunk]
-mkChunks = map ((:[]) . Versions.Digits)
+mkChunks :: Word -> [Word] -> NonEmpty Versions.VChunk
+mkChunks maj vs = fmap ( (:| []) . Versions.Digits) (maj :| vs)
 
 -- | The minimum (inclusive) version bound for a given solver.
 --
@@ -1161,7 +1162,7 @@ solverMinVersions :: Map String Version
 solverMinVersions =
   [ -- TODO: Why is this verion required?
     ( "Yices"
-    , Version { _vEpoch = Nothing, _vChunks = mkChunks [2, 6, 1], _vRel = []}
+    , Version { _vEpoch = Nothing, _vChunks = mkChunks 2 [6, 1], _vRel = [], _vMeta = [] }
     )
   ]
 

--- a/what4/src/What4/Utils/Versions.hs
+++ b/what4/src/What4/Utils/Versions.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module What4.Utils.Versions where
+
+import           Control.Exception (throw)
+import           Data.Text (Text)
+import           Data.Versions (Version(..))
+import qualified Data.Versions as Versions
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Lift
+
+deriving instance Lift Versions.VUnit
+deriving instance Lift Versions.Version
+
+ver :: Text -> Q Exp
+ver nm =
+  case Versions.version nm of
+    Left err -> throw err
+    Right v  -> lift v
+

--- a/what4/src/What4/Utils/Versions.hs
+++ b/what4/src/What4/Utils/Versions.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -6,14 +7,22 @@
 
 module What4.Utils.Versions where
 
-import           Control.Exception (throw)
+import qualified Config as Config
+import           Control.Monad.IO.Class
+import           Control.Exception (throw, throwIO)
+import           Control.Monad (foldM)
+import           Data.List (find)
 import           Data.Text (Text)
+import qualified Data.Text.IO as Text
 import           Data.Versions (Version(..))
 import qualified Data.Versions as Versions
+
+import Paths_what4( getDataFileName )
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Lift
 
+-- NB, orphan instances :-(
 deriving instance Lift Versions.VUnit
 deriving instance Lift Versions.Version
 
@@ -23,3 +32,55 @@ ver nm =
     Left err -> throw err
     Right v  -> lift v
 
+data SolverBounds =
+  SolverBounds
+  { lower :: Maybe Version
+  , upper :: Maybe Version
+  , recommended :: Maybe Version
+  }
+
+deriving instance Lift SolverBounds
+
+emptySolverBounds :: SolverBounds
+emptySolverBounds = SolverBounds Nothing Nothing Nothing
+
+-- | This method parses configuration files describing the
+--   upper and lower bounds of solver versions we expect to
+--   work correctly with What4.  See the file \"solverBounds.config\"
+--   for examples of how such bounds are specified.
+parseSolverBounds :: FilePath -> IO [(Text,SolverBounds)]
+parseSolverBounds fname =
+  do cf <- Config.parse <$> Text.readFile fname
+     case cf of
+       Left err -> throwIO err
+       Right (Config.Sections _ ss)
+         | Just Config.Section{ Config.sectionValue = Config.Sections _ vs } <-
+                   find (\s -> Config.sectionName s == "solvers") ss
+         -> mapM getSolverBound vs
+
+       Right _ -> fail ("could not parse solver bounds from " ++ fname)
+
+ where
+   getSolverBound :: Config.Section Config.Position -> IO (Text, SolverBounds)
+   getSolverBound Config.Section{ Config.sectionName = nm, Config.sectionValue = Config.Sections _ vs } =
+     do b <- foldM updateBound emptySolverBounds vs
+        pure (nm, b)
+   getSolverBound v = fail ("could not parse solver bounds " ++ show v)
+
+
+   updateBound :: SolverBounds -> Config.Section Config.Position -> IO SolverBounds
+   updateBound bnd Config.Section{ Config.sectionName = nm, Config.sectionValue = Config.Text _ val} =
+     case Versions.version val of
+       Left err -> throwIO err
+       Right v
+         | nm == "lower"       -> pure bnd { lower = Just v }
+         | nm == "upper"       -> pure bnd { upper = Just v }
+         | nm == "recommended" -> pure bnd { recommended = Just v }
+         | otherwise -> fail ("unrecognized solver bound name" ++ show nm)
+
+   updateBound _ v = fail ("could not parse solver bound " ++ show v)
+
+
+computeDefaultSolverBounds :: Q Exp
+computeDefaultSolverBounds =
+  lift =<< (liftIO (parseSolverBounds =<< getDataFileName "solverBounds.config"))

--- a/what4/src/What4/Utils/Versions.hs
+++ b/what4/src/What4/Utils/Versions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -21,6 +22,11 @@ import Paths_what4( getDataFileName )
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Lift
+
+#if !MIN_VERSION_template_haskell(2,15,0)
+import Data.List.NonEmpty as NEL
+deriving instance Lift a => Lift (NEL.NonEmpty a)
+#endif
 
 -- NB, orphan instances :-(
 deriving instance Lift Versions.VUnit

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
 import Test.Tasty
@@ -22,8 +23,6 @@ import qualified Data.ByteString as BS
 import qualified Data.Binary.IEEE754 as IEEE754
 import           Data.Foldable
 import qualified Data.Map as Map (empty, singleton)
-import           Data.Versions (Version(Version))
-import qualified Data.Versions as Versions
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Nonce
@@ -43,6 +42,7 @@ import qualified What4.Solver.CVC4 as CVC4
 import qualified What4.Solver.Z3 as Z3
 import qualified What4.Solver.Yices as Yices
 import What4.Utils.StringLiteral
+import What4.Utils.Versions (ver)
 
 data State t = State
 data SomePred = forall t . SomePred (BoolExpr t)
@@ -900,9 +900,7 @@ testSolverInfo = testGroup "solver info queries" $
 testSolverVersion :: TestTree
 testSolverVersion = testCase "test solver version bounds" $
   withOnlineZ3 $ \_ proc -> do
-    let v = Version { _vEpoch = Nothing
-                    , _vChunks = [[Versions.Digits 0]]
-                    , _vRel = [] }
+    let v = $(ver "0")
     checkSolverVersion' (Map.singleton "Z3" v) Map.empty proc >> return ()
 
 testBVDomainArithScale :: TestTree

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -21,6 +21,7 @@ import           Control.Monad (void)
 import qualified Data.BitVector.Sized as BV
 import qualified Data.ByteString as BS
 import qualified Data.Binary.IEEE754 as IEEE754
+import qualified Data.Map as Map
 import           Data.Foldable
 
 import qualified Data.Parameterized.Context as Ctx

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -22,7 +22,6 @@ import qualified Data.BitVector.Sized as BV
 import qualified Data.ByteString as BS
 import qualified Data.Binary.IEEE754 as IEEE754
 import           Data.Foldable
-import qualified Data.Map as Map (empty, singleton)
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Nonce
@@ -42,7 +41,7 @@ import qualified What4.Solver.CVC4 as CVC4
 import qualified What4.Solver.Z3 as Z3
 import qualified What4.Solver.Yices as Yices
 import What4.Utils.StringLiteral
-import What4.Utils.Versions (ver)
+import What4.Utils.Versions (ver, SolverBounds(..), emptySolverBounds)
 
 data State t = State
 data SomePred = forall t . SomePred (BoolExpr t)
@@ -900,8 +899,8 @@ testSolverInfo = testGroup "solver info queries" $
 testSolverVersion :: TestTree
 testSolverVersion = testCase "test solver version bounds" $
   withOnlineZ3 $ \_ proc -> do
-    let v = $(ver "0")
-    checkSolverVersion' (Map.singleton "Z3" v) Map.empty proc >> return ()
+    let bnd = emptySolverBounds{ lower = Just $(ver "0") }
+    checkSolverVersion' (Map.singleton "Z3" bnd) proc >> return ()
 
 testBVDomainArithScale :: TestTree
 testBVDomainArithScale = testCase "bv domain arith scale" $

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -81,7 +81,7 @@ library
     scientific >= 0.3.6,
     temporary >= 1.2,
     template-haskell,
-    text >= 1.1,
+    text >= 1.2.4.0 && < 1.3,
     th-abstraction >=0.1 && <0.5,
     th-lift >= 0.8.2 && < 0.9,
     transformers >= 0.4,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -79,6 +79,7 @@ library
     template-haskell,
     text >= 1.1,
     th-abstraction >=0.1 && <0.5,
+    th-lift >= 0.8.2 && < 0.9,
     transformers >= 0.4,
     unordered-containers >= 0.2.10,
     utf8-string >= 1.0.1,
@@ -167,6 +168,7 @@ library
     What4.Utils.Streams
     What4.Utils.StringLiteral
     What4.Utils.Word16String
+    What4.Utils.Versions
 
     Test.Verification
 

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -20,6 +20,9 @@ Description:
 
   The data representation types make heavy use of GADT-style type indices
   to ensure type-correct manipulation of symbolic values.
+
+data-files: solverBounds.config
+
 Extra-doc-files:
   README.md
   CHANGES.md
@@ -57,6 +60,7 @@ library
     bv-sized >= 1.0.0,
     bytestring >= 0.10,
     deriving-compat >= 0.5,
+    config-value >= 0.8 && < 0.9,
     containers >= 0.5.0.0,
     data-binary-ieee754,
     deepseq >= 1.3,
@@ -174,6 +178,7 @@ library
 
   other-modules:
     What4.Expr.App
+    Paths_what4
 
   ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
   -- ghc-prof-options: -fprof-auto-top

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -83,7 +83,7 @@ library
     unordered-containers >= 0.2.10,
     utf8-string >= 1.0.1,
     vector >= 0.12.1,
-    versions >= 3.5.2 && < 4.0,
+    versions >= 4.0 && < 5.0,
     zenc >= 0.1.0 && < 0.2.0,
     ghc-prim >= 0.5.2
 


### PR DESCRIPTION
This might be a good time to add realistic version bounds to this part of the code.  Do we have more up-to-date expected versions than are currently in the What4 readme @kquick? Maybe we could put those someplace machine-readable and use TH to automatically import them into this module.