### PR TITLE
Add "getAnnotation" to project SymAnnotations from SymExprs

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -1602,6 +1602,11 @@ instance IsExprBuilder (ExprBuilder t st fs) where
         e' <- sbNonceExpr sym (Annotation tpr n e)
         return (n, e')
 
+  getAnnotation _sym e =
+    case e of
+      NonceAppExpr (nonceExprApp -> Annotation _ n _) -> Just n
+      _ -> Nothing
+
   ----------------------------------------------------------------------
   -- Program location operations
 

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -496,6 +496,12 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
   --   returned.
   annotateTerm :: sym -> SymExpr sym tp -> IO (SymAnnotation sym tp, SymExpr sym tp)
 
+  -- | Project an annotation from an expression
+  --
+  -- It should be the case that using 'getAnnotation' on a term returned by
+  -- 'annotateTerm' returns the same annotation that 'annotateTerm' did.
+  getAnnotation :: sym -> SymExpr sym tp -> Maybe (SymAnnotation sym tp)
+
   ----------------------------------------------------------------------
   -- Boolean operations.
 


### PR DESCRIPTION
I think the only way to access a `SymAnnotation` embedded in a term is with a traversal. My hope is that the addition of this function makes the annotations API a bit more flexible.