### PR TITLE
Avoid loss of sharing when pushing bitvector equality under conditional

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -2301,11 +2301,13 @@ instance IsExprBuilder (ExprBuilder t st fs) where
     -- Push some equalities under if/then/else
     | SemiRingLiteral _ _ _ <- x
     , Just (BaseIte _ _ c a b) <- asApp y
+    , isJust (asBV a) || isJust (asBV b) -- avoid loss of sharing
     = join (itePred sym c <$> bvEq sym x a <*> bvEq sym x b)
 
     -- Push some equalities under if/then/else
     | Just (BaseIte _ _ c a b) <- asApp x
     , SemiRingLiteral _ _ _ <- y
+    , isJust (asBV a) || isJust (asBV b) -- avoid loss of sharing
     = join (itePred sym c <$> bvEq sym a y <*> bvEq sym b y)
 
     | Just (Some flv) <- inSameBVSemiRing x y


### PR DESCRIPTION
I was encountering a case where this rule was exploding performance, so I added a check for constant branches in a manner similar to other rules. I'm unsure if this is the right thing to do in general - in the longer term, it might be neat to have some way of selectively enabling/disabling rules.