### PR TITLE
Update cabal version, add some warnings, fix some warnings.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,24 +58,22 @@ jobs:
           echo ZLIB_LOC="$(nix eval --raw nixpkgs.zlib)/lib" >> $GITHUB_ENV
           echo NS="nix-shell -p cabal-install $GHC gmp zlib --run" >> $GITHUB_ENV
 
-      - name: Cabal/GHC compatibility
+      - name: Package's Cabal/GHC compatibility
         shell: bash
+        # Using setup will use the cabal library installed with GHC
+        # instead of the cabal library of the Cabal-install tool to
+        # verify the cabal file is compatible with the associated
+        # GHC cabal library version.  Cannot run configure or build,
+        # because dependencies aren't present, but a clean is
+        # sufficient to cause parsing/validation of the cabal file.
         run: |
-          cd what4
-          if [ ! -f Setup.hs ] ; then
-            echo import Distribution.Simple > DefaultSetup.hs
-            echo main = defaultMain >> DefaultSetup.hs
-            nix-shell -p $GHC --run 'ghc -o setup.${{ matrix.ghc }} DefaultSetup.hs'
-          else
-            nix-shell -p $GHC --run 'ghc -o setup.${{ matrix.ghc }} Setup.hs'
-          fi
-          # Using setup will use the cabal library installed with GHC
-          # instead of the cabal library of the Cabal-install tool to
-          # verify the cabal file is compatible with the associated
-          # GHC cabal library version.  Cannot run configure or build,
-          # because dependencies aren't present, but a clean is
-          # sufficient to cause parsing/validation of the cabal file.
-          ./setup.${{ matrix.ghc }} clean
+          defsetup()  { echo import Distribution.Simple; echo main = defaultMain; }
+          setup_src() { if [ ! -f Setup.hs ] ; then defsetup > DefSetup.hs; fi; ls *Setup.hs; }
+          setup_bin() { echo setup.${{ matrix.ghc }}; }
+          with_ghc()  { nix-shell -p $GHC --run "$(echo ${@})"; }
+          (cd what4;     with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
+          (cd what4-abc; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
+          (cd what4-blt; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
 
       - name: Cabal configure
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,13 @@ jobs:
           (cd what4-abc; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
           (cd what4-blt; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
 
+      - name: Cabal check
+        shell: bash
+        run: |
+          (cd what4;     $NS 'cabal check')
+          (cd what4-abc; $NS 'cabal check')
+          (cd what4-blt; $NS 'cabal check')
+
       - name: Cabal configure
         shell: bash
         # Note: the explicit LD_LIBRARY_PATH is needed for GHC 8.6.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: [8.10.3, 8.8.4, 8.6.5]
+        ghc: [8.10.4, 8.8.4, 8.6.5]
         allow-failure: [false]
       fail-fast: false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,26 @@ jobs:
           echo GHCPKGS=haskell.packages.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g) >> $GITHUB_ENV
           echo ZLIB_LOC="$(nix eval --raw nixpkgs.zlib)/lib" >> $GITHUB_ENV
           echo NS="nix-shell -p cabal-install $GHC gmp zlib --run" >> $GITHUB_ENV
+
+      - name: Cabal/GHC compatibility
+        shell: bash
+        run: |
+          cd what4
+          if [ ! -f Setup.hs ] ; then
+            echo import Distribution.Simple > DefaultSetup.hs
+            echo main = defaultMain >> DefaultSetup.hs
+            nix-shell -p $GHC --run 'ghc -o setup.${{ matrix.ghc }} DefaultSetup.hs'
+          else
+            nix-shell -p $GHC --run 'ghc -o setup.${{ matrix.ghc }} Setup.hs'
+          fi
+          # Using setup will use the cabal library installed with GHC
+          # instead of the cabal library of the Cabal-install tool to
+          # verify the cabal file is compatible with the associated
+          # GHC cabal library version.  Cannot run configure or build,
+          # because dependencies aren't present, but a clean is
+          # sufficient to cause parsing/validation of the cabal file.
+          ./setup.${{ matrix.ghc }} clean
+
       - name: Cabal configure
         shell: bash
         # Note: the explicit LD_LIBRARY_PATH is needed for GHC 8.6.5

--- a/what4-abc/what4-abc.cabal
+++ b/what4-abc/what4-abc.cabal
@@ -1,12 +1,12 @@
+Cabal-version: 2.2
 Name:          what4-abc
 Version:       0.1
 Author:        Galois Inc.
 Maintainer:    jhendrix@galois.com
-Copyright:     (c) Galois, Inc 2014-2020
-License:       BSD3
+Copyright:     (c) Galois, Inc 2014-2021
+License:       BSD-3-Clause
 License-file:  LICENSE
 Build-type:    Simple
-Cabal-version: >= 1.9.2
 Category:      Language
 Synopsis:      What4 bindings to ABC
 Description:
@@ -40,5 +40,10 @@ library
   exposed-modules:
     What4.Solver.ABC
 
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
-  ghc-prof-options: -fprof-auto-top
+  ghc-options: -Wall
+               -Werror=incomplete-patterns
+               -Werror=missing-methods
+               -Werror=overlapping-patterns
+  ghc-prof-options: -fprof-auto-export
+
+  default-language: Haskell2010

--- a/what4-blt/what4-blt.cabal
+++ b/what4-blt/what4-blt.cabal
@@ -1,12 +1,12 @@
+Cabal-version: 2.2
 Name:          what4-blt
 Version:       0.2
 Author:        Galois Inc.
 Maintainer:    rdockins@galois.com
-Copyright:     (c) Galois, Inc 2014-2020
-License:       BSD3
+Copyright:     (c) Galois, Inc 2014-2021
+License:       BSD-3-Clause
 License-file:  LICENSE
 Build-type:    Simple
-Cabal-version: >= 1.10
 Category:      Language
 Synopsis:      What4 bindings to BLT
 Description:
@@ -15,7 +15,16 @@ Description:
   provides support for lowering Crucible formulae to linear systems
   of the sort understood by BLT, and for executing the underlying solver.
 
+common bldflags
+  ghc-options: -Wall
+               -Werror=incomplete-patterns
+               -Werror=missing-methods
+               -Werror=overlapping-patterns
+  ghc-prof-options: -fprof-auto-export
+  default-language: Haskell2010
+
 library
+  import: bldflags
   build-depends:
     base >= 4.7 && < 4.15,
     blt >= 0.12.1,
@@ -32,27 +41,19 @@ library
   exposed-modules:
     What4.Solver.BLT
 
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
-  ghc-prof-options: -fprof-auto-top
-
-  default-language: Haskell2010
-
 test-suite test
+  import: bldflags
   type: exitcode-stdio-1.0
   hs-source-dirs: test
-
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
 
   main-is: Test.hs
 
   build-depends:
-    base             >= 4.7,
+    base,
     containers,
     what4-blt,
     QuickCheck,
     tasty            >= 0.10,
     tasty-hunit      >= 0.9,
     tasty-quickcheck >= 0.8,
-    blt              >= 0.12
-
-  default-language: Haskell2010
+    blt

--- a/what4/src/What4/Concrete.hs
+++ b/what4/src/What4/Concrete.hs
@@ -46,7 +46,7 @@ module What4.Concrete
   , fromConcreteComplex
   ) where
 
-import           Data.List
+import qualified Data.List as List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Numeric as N
@@ -154,14 +154,14 @@ ppConcrete = \case
   ConcreteString x -> PP.viaShow x
   ConcreteBV w x -> PP.pretty ("0x" ++ (N.showHex (BV.asUnsigned x) (":[" ++ show w ++ "]")))
   ConcreteComplex (r :+ i) -> PP.pretty "complex(" PP.<> ppRational r PP.<> PP.pretty ", " PP.<> ppRational i PP.<> PP.pretty ")"
-  ConcreteStruct xs -> PP.pretty "struct(" PP.<> PP.cat (intersperse PP.comma (toListFC ppConcrete xs)) PP.<> PP.pretty ")"
+  ConcreteStruct xs -> PP.pretty "struct(" PP.<> PP.cat (List.intersperse PP.comma (toListFC ppConcrete xs)) PP.<> PP.pretty ")"
   ConcreteArray _ def xs0 -> go (Map.toAscList xs0) (PP.pretty "constArray(" PP.<> ppConcrete def PP.<> PP.pretty ")")
     where
     go  [] doc = doc
     go ((i,x):xs) doc = ppUpd i x (go xs doc)
 
     ppUpd i x doc =
-       PP.pretty "update(" PP.<> PP.cat (intersperse PP.comma (toListFC ppConcrete i))
+       PP.pretty "update(" PP.<> PP.cat (List.intersperse PP.comma (toListFC ppConcrete i))
                          PP.<> PP.comma
                          PP.<> ppConcrete x
                          PP.<> PP.comma

--- a/what4/src/What4/Utils/AnnotatedMap.hs
+++ b/what4/src/What4/Utils/AnnotatedMap.hs
@@ -84,7 +84,6 @@ instance (Ord k, Semigroup v) => Semigroup (Tag k v) where
 
 instance (Ord k, Semigroup v) => Monoid (Tag k v) where
   mempty  = NoTag
-  mappend = unionTag
 
 unionTag :: (Ord k, Semigroup v) => Tag k v -> Tag k v -> Tag k v
 unionTag x NoTag = x

--- a/what4/src/What4/Utils/Word16String.hs
+++ b/what4/src/What4/Utils/Word16String.hs
@@ -53,7 +53,6 @@ instance Semigroup Word16String where
 
 instance Monoid Word16String where
   mempty = empty
-  mappend = append
 
 instance Eq Word16String where
   (Word16String xs) == (Word16String ys) = xs == ys

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -57,6 +57,7 @@ common bldflags
                -Werror=incomplete-patterns
                -Werror=missing-methods
                -Werror=overlapping-patterns
+               -Wcompat
 
 common testdefs
   hs-source-dirs: test

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -1,4 +1,4 @@
-Cabal-version: 3.0
+Cabal-version: 2.2
 Name:          what4
 Version:       1.1.0.0.99
 Author:        Galois Inc.

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -64,7 +64,7 @@ common testdefs
   build-depends: base
                , parameterized-utils
                , tasty >= 0.10
-               , what4:what4
+               , what4
 
 common testdefs-quickcheck
   import: testdefs

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -1,12 +1,12 @@
+Cabal-version: 3.0
 Name:          what4
 Version:       1.1.0.0.99
 Author:        Galois Inc.
 Maintainer:    jhendrix@galois.com, rdockins@galois.com
 Copyright:     (c) Galois, Inc 2014-2021
-License:       BSD3
+License:       BSD-3-Clause
 License-file:  LICENSE
 Build-type:    Simple
-Cabal-version: 1.18
 Homepage:      https://github.com/GaloisInc/what4
 Bug-reports:   https://github.com/GaloisInc/what4/issues
 Tested-with:   GHC==8.6.5, GHC==8.8.4, GHC==8.10.3
@@ -51,7 +51,36 @@ flag STPTestDisable
   manual: True
   default: False
 
+common bldflags
+  default-language: Haskell2010
+  ghc-options: -Wall
+               -Werror=incomplete-patterns
+               -Werror=missing-methods
+               -Werror=overlapping-patterns
+
+common testdefs
+  hs-source-dirs: test
+  build-depends: base
+               , parameterized-utils
+               , tasty >= 0.10
+               , what4:what4
+
+common testdefs-quickcheck
+  import: testdefs
+  build-depends: tasty-quickcheck >= 0.10
+               , QuickCheck >= 2.12
+
+common testdefs-hedgehog
+  import: testdefs
+  build-depends: hedgehog >= 1.0.2
+               , tasty-hedgehog
+
+common testdefs-hunit
+  import: testdefs
+  build-depends: tasty-hunit >= 0.9
+
 library
+  import: bldflags
   build-depends:
     base >= 4.8 && < 5,
     attoparsec >= 0.13,
@@ -94,7 +123,6 @@ library
     zenc >= 0.1.0 && < 0.2.0,
     ghc-prim >= 0.5.2
 
-  default-language: Haskell2010
   default-extensions:
      NondecreasingIndentation
 
@@ -181,8 +209,6 @@ library
 
     Test.Verification
 
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
-  -- ghc-prof-options: -fprof-auto-top
   if impl(ghc >= 8.6)
     default-extensions: NoStarIsType
 
@@ -196,10 +222,9 @@ executable quickstart
     what4
 
 test-suite adapter-test
+  import: bldflags, testdefs-hunit
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test
   main-is: AdapterTest.hs
 
   if flag(solverTests)
@@ -212,28 +237,20 @@ test-suite adapter-test
     buildable: False
 
   build-depends:
-    base,
     bv-sized,
     bytestring,
     containers,
     data-binary-ieee754,
     lens,
     mtl >= 2.2.1,
-    parameterized-utils,
     process,
-    tasty >= 0.10,
-    tasty-hunit >= 0.9,
     text,
-    versions,
-    what4
-
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+    versions
 
 test-suite online-solver-test
+  import: bldflags, testdefs-hunit
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test
   main-is: OnlineSolverTest.hs
 
   if flag(solverTests)
@@ -244,141 +261,84 @@ test-suite online-solver-test
     buildable: False
 
   build-depends:
-    base,
     bv-sized,
     bytestring,
     containers,
     data-binary-ieee754,
     lens,
-    parameterized-utils,
     process,
-    tasty >= 0.10,
-    tasty-hunit >= 0.9,
     text,
-    versions,
-    what4
-
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+    versions
 
 test-suite expr-builder-smtlib2
+  import: bldflags, testdefs-hunit
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test
   main-is: ExprBuilderSMTLib2.hs
 
   build-depends:
-    base,
     bv-sized,
     bytestring,
     containers,
     data-binary-ieee754,
     libBF,
-    parameterized-utils,
-    tasty >= 0.10,
-    tasty-hunit >= 0.9,
     text,
-    versions,
-    what4
+    versions
 
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
 
 test-suite exprs_tests
+  import: bldflags, testdefs-hedgehog, testdefs-hunit
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test
   main-is: ExprsTest.hs
 
   other-modules:
     GenWhat4Expr
 
-  build-depends: base
-               , bv-sized
-               , hedgehog >= 1.0.2
-               , parameterized-utils
-               , tasty >= 0.10
-               , tasty-hunit >= 0.9
-               , tasty-hedgehog
-               , what4
+  build-depends: bv-sized
 
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
 
 test-suite iteexprs_tests
+  import: bldflags, testdefs-hedgehog, testdefs-hunit
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test
   main-is: IteExprs.hs
 
   other-modules:
     GenWhat4Expr
 
-  build-depends: base
-               , bv-sized
-               , hedgehog >= 1.0.2
-               , parameterized-utils
-               , tasty >= 0.10
-               , tasty-hunit >= 0.9
-               , tasty-hedgehog
+  build-depends: bv-sized
                , containers >= 0.5.0.0
-               , what4
 
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
 
 test-suite bvdomain_tests
+  import: bldflags, testdefs-quickcheck
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test, test/QC
+  hs-source-dirs: test/QC
   main-is: BVDomTests.hs
 
   other-modules:  VerifyBindings
 
-  build-depends: base
-               , parameterized-utils
-               , tasty >= 0.10
-               , tasty-quickcheck >= 0.10
-               , QuickCheck >= 2.12
-               , transformers
-               , what4
+  build-depends: transformers
 
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
 
 test-suite bvdomain_tests_hh
+  import: bldflags, testdefs-hedgehog
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
 
-  hs-source-dirs: test, test/HH
+  hs-source-dirs: test/HH
   main-is: BVDomTests.hs
 
   other-modules:  VerifyBindings
 
-  build-depends: base
-               , parameterized-utils
-               , tasty >= 0.10
-               , tasty-hedgehog
-               , hedgehog >= 1.0.2
-               , transformers
-               , what4
+  build-depends: transformers
 
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
 
 test-suite template_tests
+  import: bldflags, testdefs-hedgehog
   type: exitcode-stdio-1.0
-  default-language: Haskell2010
-
-  hs-source-dirs: test
   main-is : TestTemplate.hs
-
-  build-depends: base
-               , bv-sized
+  build-depends: bv-sized
                , libBF
-               , parameterized-utils
-               , tasty >= 0.10
-               , tasty-hedgehog
-               , hedgehog >= 1.0.2
                , transformers
-               , what4
-
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns


### PR DESCRIPTION
Also uses common stanzas in the cabal file which reduces duplication and makes version updates (especially for test modules) easier.