### PR TITLE
Support Verilog modules with multiple outputs

### DIFF
--- a/what4/src/What4/Protocol/VerilogWriter.hs
+++ b/what4/src/What4/Protocol/VerilogWriter.hs
@@ -16,6 +16,7 @@ module What4.Protocol.VerilogWriter
   ) where
 
 import Control.Monad.Except
+import Data.Parameterized.Some (Some(..), traverseSome)
 import Prettyprinter
 import What4.Expr.Builder (Expr, SymExpr)
 import What4.Interface (IsExprBuilder)
@@ -30,7 +31,7 @@ import What4.Protocol.VerilogWriter.Backend
 exprsVerilog ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>
   sym ->
-  [Expr n tp] ->
+  [Some (Expr n)] ->
   Doc () ->
   ExceptT String IO (Doc ())
 exprsVerilog sym es name = fmap (\m -> moduleDoc m name) (exprsToModule sym es)
@@ -40,6 +41,6 @@ exprsVerilog sym es name = fmap (\m -> moduleDoc m name) (exprsToModule sym es)
 exprsToModule ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>
   sym ->
-  [Expr n tp] ->
+  [Some (Expr n)] ->
   ExceptT String IO (Module sym n)
-exprsToModule sym es = mkModule sym $ map exprToVerilogExpr es
+exprsToModule sym es = mkModule sym $ map (traverseSome exprToVerilogExpr) es

--- a/what4/src/What4/Protocol/VerilogWriter.hs
+++ b/what4/src/What4/Protocol/VerilogWriter.hs
@@ -11,8 +11,8 @@ ABC.
 
 module What4.Protocol.VerilogWriter
   ( Module
-  , exprVerilog
-  , exprToModule
+  , exprsVerilog
+  , exprsToModule
   ) where
 
 import Control.Monad.Except
@@ -24,21 +24,22 @@ import What4.Protocol.VerilogWriter.AST
 import What4.Protocol.VerilogWriter.ABCVerilog
 import What4.Protocol.VerilogWriter.Backend
 
--- | Convert the given What4 expression into a textual representation of
--- a Verilog module of the given name.
-exprVerilog ::
+-- | Convert the given What4 expressions, representing the outputs of a
+-- circuit, into a textual representation of a Verilog module of the
+-- given name.
+exprsVerilog ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>
   sym ->
-  Expr n tp ->
+  [Expr n tp] ->
   Doc () ->
   ExceptT String IO (Doc ())
-exprVerilog sym e name = fmap (\m -> moduleDoc m name) (exprToModule sym e)
+exprsVerilog sym es name = fmap (\m -> moduleDoc m name) (exprsToModule sym es)
 
--- | Convert the given What4 expression into a Verilog module of the
--- given name.
-exprToModule ::
+-- | Convert the given What4 expressions, representing the outputs of a
+-- circuit, into a Verilog module of the given name.
+exprsToModule ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>
   sym ->
-  Expr n tp ->
+  [Expr n tp] ->
   ExceptT String IO (Module sym n)
-exprToModule sym e = mkModule sym $ exprToVerilogExpr e
+exprsToModule sym es = mkModule sym $ map exprToVerilogExpr es

--- a/what4/src/What4/Protocol/VerilogWriter/AST.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/AST.hs
@@ -20,7 +20,7 @@ import           Control.Monad.State (MonadState(), StateT(..), get, put, modify
 import qualified What4.BaseTypes as WT
 import           What4.Expr.Builder
 import           Data.Parameterized.Classes (OrderingF(..), compareF)
-import           Data.Parameterized.Some (Some(..))
+import           Data.Parameterized.Some (Some(..), viewSome)
 import           Data.Parameterized.Pair
 import           GHC.TypeNats ( type (<=) )
 
@@ -304,13 +304,13 @@ newtype Module sym n = Module (ModuleState sym n)
 -- that corresponds to the module's output.
 mkModule ::
   sym ->
-  [VerilogM sym n (IExp tp)] ->
+  [VerilogM sym n (Some IExp)] ->
   ExceptT String IO (Module sym n)
 mkModule sym ops = fmap Module $ execVerilogM sym $ do
     es <- sequence ops
-    forM_ es $ \e ->
+    forM_ es $ \se ->
       do out <- freshIdentifier "out"
-         addOutput (iexpType e) out (IExp e)
+         viewSome (\e -> addOutput (iexpType e) out (IExp e)) se
 
 initModuleState :: sym -> IO (ModuleState sym n)
 initModuleState sym = do

--- a/what4/src/What4/Protocol/VerilogWriter/AST.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/AST.hs
@@ -304,12 +304,13 @@ newtype Module sym n = Module (ModuleState sym n)
 -- that corresponds to the module's output.
 mkModule ::
   sym ->
-  VerilogM sym n (IExp tp) ->
+  [VerilogM sym n (IExp tp)] ->
   ExceptT String IO (Module sym n)
-mkModule sym op = fmap Module $ execVerilogM sym $ do
-    e <- op
-    out <- freshIdentifier "out"
-    addOutput (iexpType e) out (IExp e)
+mkModule sym ops = fmap Module $ execVerilogM sym $ do
+    es <- sequence ops
+    forM_ es $ \e ->
+      do out <- freshIdentifier "out"
+         addOutput (iexpType e) out (IExp e)
 
 initModuleState :: sym -> IO (ModuleState sym n)
 initModuleState sym = do

--- a/what4/test/AdapterTest.hs
+++ b/what4/test/AdapterTest.hs
@@ -25,6 +25,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Data.Parameterized.Nonce
+import Data.Parameterized.Some
 
 import What4.Config
 import What4.Interface
@@ -165,7 +166,7 @@ verilogTest = testCase "verilogTest" $ withIONonceGenerator $ \gen ->
      one <- bvLit sym w (mkBV w 1)
      add <- bvAdd sym x one
      r <- notPred sym =<< bvEq sym x add
-     edoc <- runExceptT (exprVerilog sym r "f")
+     edoc <- runExceptT (exprsVerilog sym [Some r] "f")
      case edoc of
        Left err -> fail $ "Failed to translate to Verilog: " ++ err
        Right doc ->


### PR DESCRIPTION
This adds support for generating Verilog modules wiht multiple outputs by allowing the user to pass multiple What4 expressions into the Verilog generation functions.