### PR TITLE
Adapt what4-{abc,blt} to SolverEndSATQuery changes

### DIFF
--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -79,7 +79,8 @@ import           What4.BaseTypes
 import           What4.Concrete
 import           What4.Config
 import           What4.Interface
-                   (getConfiguration, IsExprBuilder, logSolverEvent, SolverEvent(..), andAllOf)
+                   ( getConfiguration, IsExprBuilder, logSolverEvent
+                   , SolverEvent(..), SolverStartSATQuery(..), SolverEndSATQuery(..), andAllOf )
 import           What4.Expr
 import           What4.Expr.Builder
 import qualified What4.Expr.BoolMap as BM
@@ -743,10 +744,10 @@ checkSat sym logData e = do
   checkSupportedByAbc vars
   checkNoLatches vars
   logSolverEvent sym
-    SolverStartSATQuery
+    (SolverStartSATQuery $ SolverStartSATQueryRec
     { satQuerySolverName = "ABC"
     , satQueryReason = logReason logData
-    }
+    })
   withNetwork $ \ntk -> do
     -- Get network
     let g = gia ntk
@@ -790,10 +791,10 @@ checkSat sym logData e = do
              logCallbackVerbose logData 2 "Calling ABC's QBF solver"
              runQBF ntk exist_cnt p max_qbf_iter
     logSolverEvent sym
-      SolverEndSATQuery
+      (SolverEndSATQuery $ SolverEndSATQueryRec
       { satQueryResult = forgetModelAndCore res
       , satQueryError  = Nothing
-      }
+      })
     return res
 
 -- | Associate an element in a binding with the term.

--- a/what4-blt/src/What4/Solver/BLT.hs
+++ b/what4-blt/src/What4/Solver/BLT.hs
@@ -132,18 +132,18 @@ runBLTInOverride sym logData ps contFn = do
   epar <- parseBLTParams . T.unpack <$> (getOpt =<< getOptionSetting bltParams cfg)
   par  <- either fail return epar
   logSolverEvent sym
-    SolverStartSATQuery
+    (SolverStartSATQuery $ SolverStartSATQueryRec
     { satQuerySolverName = "BLT"
     , satQueryReason = logReason logData
-    }
+    })
   withHandle par $ \h -> do
     forM_ ps (assume h)
     result <- checkSat h
     logSolverEvent sym
-      SolverEndSATQuery
+      (SolverEndSATQuery $ SolverEndSATQueryRec
       { satQueryResult = forgetModelAndCore result
       , satQueryError  = Nothing
-      }
+      })
     contFn result
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
This updates `what4-{abc,blt}` to use the new `SolverStartSATQueryRec` and `SolverEndSATQueryRec` data types introduced in #111.

Fixes #119.