### PR TITLE
Support client-provided Verilog input lists

### DIFF
--- a/what4/src/What4/Protocol/VerilogWriter.hs
+++ b/what4/src/What4/Protocol/VerilogWriter.hs
@@ -16,12 +16,11 @@ module What4.Protocol.VerilogWriter
   ) where
 
 import Control.Monad.Except
-import Data.Parameterized.Nonce (Nonce(..))
 import Data.Parameterized.Some (Some(..), traverseSome)
 import Data.Text (Text)
 import Prettyprinter
 import What4.Expr.Builder (Expr, SymExpr)
-import What4.Interface (IsExprBuilder, BaseTypeRepr)
+import What4.Interface (IsExprBuilder)
 
 import What4.Protocol.VerilogWriter.AST
 import What4.Protocol.VerilogWriter.ABCVerilog

--- a/what4/src/What4/Protocol/VerilogWriter.hs
+++ b/what4/src/What4/Protocol/VerilogWriter.hs
@@ -16,10 +16,12 @@ module What4.Protocol.VerilogWriter
   ) where
 
 import Control.Monad.Except
+import Data.Parameterized.Nonce (Nonce(..))
 import Data.Parameterized.Some (Some(..), traverseSome)
+import Data.Text (Text)
 import Prettyprinter
 import What4.Expr.Builder (Expr, SymExpr)
-import What4.Interface (IsExprBuilder)
+import What4.Interface (IsExprBuilder, BaseTypeRepr)
 
 import What4.Protocol.VerilogWriter.AST
 import What4.Protocol.VerilogWriter.ABCVerilog
@@ -31,16 +33,18 @@ import What4.Protocol.VerilogWriter.Backend
 exprsVerilog ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>
   sym ->
+  [(Some (Expr n), Text)] ->
   [Some (Expr n)] ->
   Doc () ->
   ExceptT String IO (Doc ())
-exprsVerilog sym es name = fmap (\m -> moduleDoc m name) (exprsToModule sym es)
+exprsVerilog sym ins es name = fmap (\m -> moduleDoc m name) (exprsToModule sym ins es)
 
 -- | Convert the given What4 expressions, representing the outputs of a
 -- circuit, into a Verilog module of the given name.
 exprsToModule ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>
   sym ->
+  [(Some (Expr n), Text)] ->
   [Some (Expr n)] ->
   ExceptT String IO (Module sym n)
-exprsToModule sym es = mkModule sym $ map (traverseSome exprToVerilogExpr) es
+exprsToModule sym ins es = mkModule sym ins $ map (traverseSome exprToVerilogExpr) es

--- a/what4/src/What4/Protocol/VerilogWriter/ABCVerilog.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/ABCVerilog.hs
@@ -16,6 +16,7 @@ import Data.BitVector.Sized
 import Data.Parameterized.NatRepr
 import Data.Parameterized.Some
 import Data.String
+import Data.Word
 import Prettyprinter
 import What4.BaseTypes
 import What4.Protocol.VerilogWriter.AST
@@ -34,7 +35,7 @@ moduleDoc (Module ms) name =
     , "endmodule"
     ]
   where
-    inputNames = map (identDoc . snd) (vsInputs ms)
+    inputNames = map (identDoc . (\(_, _, n) -> n)) (vsInputs ms)
     outputNames = map (identDoc . (\(_, _, n, _) -> n)) (vsOutputs ms)
     params = reverse inputNames ++ reverse outputNames
 
@@ -54,8 +55,8 @@ lhsDoc (LHS name) = identDoc name
 lhsDoc (LHSBit name idx) =
   identDoc name <> brackets (pretty idx)
 
-inputDoc :: (Some BaseTypeRepr, Identifier) -> Doc ()
-inputDoc (tp, name) =
+inputDoc :: (Word64, Some BaseTypeRepr, Identifier) -> Doc ()
+inputDoc (_, tp, name) =
   viewSome (typeDoc "input" False) tp <+> identDoc name <> semi
 
 wireDoc :: Doc () -> (Some BaseTypeRepr, Bool, Identifier, Some Exp) -> Doc ()

--- a/what4/src/What4/Protocol/VerilogWriter/AST.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/AST.hs
@@ -284,9 +284,13 @@ data ModuleState sym n =
                 -- ^ All internal wires, in reverse order. Includes the
                 -- type, signedness, name, and initializer of each.
                 , vsSeenNonces :: Map.Map Word64 Identifier
-                -- ^ A map from the identifier nonces seen so far to their identifier names.
+                -- ^ A map from the identifier nonces seen so far to
+                -- their identifier names. These nonces exist for
+                -- identifiers from the original term, but not
+                -- intermediate Verilog variables.
                 , vsUsedIdentifiers :: Set.Set Identifier
-                -- ^ A set of all the identifiers used so far
+                -- ^ A set of all the identifiers used so far, including
+                -- intermediate Verilog variables.
                 , vsExpCache :: IdxCache n IExp
                 -- ^ An expression cache to preserve sharing present in
                 -- the What4 representation.

--- a/what4/src/What4/Protocol/VerilogWriter/AST.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/AST.hs
@@ -7,24 +7,30 @@ License          : BSD3
 An intermediate AST to use for generating Verilog modules from What4 expressions.
 -}
 {-# LANGUAGE GADTs, GeneralizedNewtypeDeriving, ScopedTypeVariables,
-  TypeApplications, PolyKinds, DataKinds, ExplicitNamespaces, TypeOperators #-}
+  TypeApplications, PolyKinds, DataKinds, ExplicitNamespaces, TypeOperators,
+  OverloadedStrings #-}
 
 module What4.Protocol.VerilogWriter.AST
   where
 
 import qualified Data.BitVector.Sized as BV
 import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Data.Set as Set
+import           Data.String
+import           Data.Word
 import           Control.Monad.Except
-import           Control.Monad.State (MonadState(), StateT(..), get, put, modify)
+import           Control.Monad.State (MonadState(), StateT(..), get, put, modify, gets)
 
 import qualified What4.BaseTypes as WT
 import           What4.Expr.Builder
 import           Data.Parameterized.Classes (OrderingF(..), compareF)
+import           Data.Parameterized.Nonce (Nonce, indexValue)
 import           Data.Parameterized.Some (Some(..), viewSome)
 import           Data.Parameterized.Pair
 import           GHC.TypeNats ( type (<=) )
 
-type Identifier = String
+type Identifier = T.Text
 
 -- | A type for Verilog binary operators that enforces well-typedness,
 -- including bitvector size constraints.
@@ -136,7 +142,7 @@ mkLet :: Exp tp -> VerilogM sym n (IExp tp)
 mkLet (IExp x) = return x
 mkLet e = do
     let tp = expType e
-    x <- addFreshWire tp False "x" e
+    x <- addFreshWire tp False "wr" e
     return (Ident tp x)
 
 -- | Indicate than an expression name is signed. This causes arithmetic
@@ -145,7 +151,7 @@ mkLet e = do
 signed :: IExp tp -> VerilogM sym n (IExp tp)
 signed e = do
     let tp = iexpType e
-    x <- addFreshWire tp True "x" (IExp e)
+    x <- addFreshWire tp True "wr" (IExp e)
     return (Ident tp x)
 
 -- | Apply a binary operation to two expressions and bind the result to
@@ -265,8 +271,8 @@ data Item where
 -- | Necessary monadic operations
 
 data ModuleState sym n =
-    ModuleState { vsInputs :: [(Some WT.BaseTypeRepr, Identifier)]
-                -- ^ All module inputs, in reverse order.
+    ModuleState { vsInputs :: [(Word64, Some WT.BaseTypeRepr, Identifier)]
+                -- ^ All module inputs, in reverse order. We use Word64 for Nonces to avoid GHC bugs.
                 , vsOutputs :: [(Some WT.BaseTypeRepr, Bool, Identifier, Some Exp)]
                 -- ^ All module outputs, in reverse order. Includes the
                 -- type, signedness, name, and initializer of each.
@@ -275,6 +281,10 @@ data ModuleState sym n =
                 -- type, signedness, name, and initializer of each.
                 , vsFreshIdent :: Int
                 -- ^ A counter for generating fresh names.
+                , vsSeenNonces :: Map.Map Word64 Identifier
+                -- ^ A map from the identifier nonces seen so far to their identifier names.
+                , vsUsedIdentifiers :: Set.Set Identifier
+                -- ^ A set of all the identifiers used so far
                 , vsExpCache :: IdxCache n IExp
                 -- ^ An expression cache to preserve sharing present in
                 -- the What4 representation.
@@ -304,9 +314,15 @@ newtype Module sym n = Module (ModuleState sym n)
 -- that corresponds to the module's output.
 mkModule ::
   sym ->
+  [(Some (Expr n), T.Text)] ->
   [VerilogM sym n (Some IExp)] ->
   ExceptT String IO (Module sym n)
-mkModule sym ops = fmap Module $ execVerilogM sym $ do
+mkModule sym ins ops = fmap Module $ execVerilogM sym $ do
+    let addExprInput e ident =
+          case e of
+            Some (BoundVarExpr x) -> addBoundInput x ident
+            _ -> throwError "Input provided to mkModule isn't an input"
+    mapM_ (uncurry addExprInput) ins
     es <- sequence ops
     forM_ es $ \se ->
       do out <- freshIdentifier "out"
@@ -315,7 +331,18 @@ mkModule sym ops = fmap Module $ execVerilogM sym $ do
 initModuleState :: sym -> IO (ModuleState sym n)
 initModuleState sym = do
   cache <- newIdxCache
-  return $ ModuleState [] [] [] 0 cache Map.empty Map.empty sym
+  return $ ModuleState
+           { vsInputs = []
+           , vsOutputs = []
+           , vsWires = []
+           , vsFreshIdent = 0
+           , vsSeenNonces = Map.empty
+           , vsUsedIdentifiers = Set.empty
+           , vsExpCache = cache
+           , vsBVCache = Map.empty
+           , vsBoolCache = Map.empty
+           , vsSym = sym
+           }
 
 runVerilogM ::
   VerilogM sym n a ->
@@ -332,16 +359,34 @@ execVerilogM sym op =
      (_a,m) <- runVerilogM op s
      return m
 
+addBoundInput ::
+  ExprBoundVar n tp ->
+  Identifier ->
+  VerilogM sym n Identifier
+addBoundInput x ident =
+  addFreshInput (Some idx) (Some tp) ident
+    where
+      tp = bvarType x
+      idx = bvarId x
+
 -- | Returns and records a fresh input with the given type and with a
 -- name constructed from the given base.
 addFreshInput ::
-  WT.BaseTypeRepr tp ->
+  Some (Nonce n) ->
+  Some WT.BaseTypeRepr ->
   Identifier ->
   VerilogM sym n Identifier
-addFreshInput tp base = do
-  name <- freshIdentifier base
-  modify $ \st -> st { vsInputs = (Some tp, name) : vsInputs st }
-  return name
+addFreshInput n tp base = do
+  seenNonces <- gets vsSeenNonces
+  let idx = viewSome indexValue n
+  case Map.lookup idx seenNonces of
+    Just ident -> return ident
+    Nothing ->
+      do name <- freshIdentifier base
+         modify $ \st -> st { vsInputs = (idx, tp, name) : vsInputs st
+                            , vsSeenNonces = Map.insert idx name seenNonces
+                            }
+         return name
 
 -- | Add an output to the current Verilog module state, given a type, a
 -- name, and an initializer expression.
@@ -366,13 +411,21 @@ addWire tp isSigned name e =
 
 -- | Create a fresh identifier by concatenating the given base with the
 -- current fresh identifier counter.
-freshIdentifier :: String -> VerilogM sym n Identifier
+freshIdentifier :: T.Text -> VerilogM sym n Identifier
 freshIdentifier basename = do
   st <- get
-  let x = vsFreshIdent st
-  put $ st { vsFreshIdent = x+1 }
-  return $ basename ++ "_" ++ show x
-
+  let used = vsUsedIdentifiers st
+  case basename `Set.member` used of
+    True ->
+      do let x = vsFreshIdent st
+             freshName = T.concat [basename, "_", fromString (show x)]
+         put $ st { vsFreshIdent = x+1
+                  , vsUsedIdentifiers = Set.insert freshName used
+                  }
+         return freshName
+    False ->
+      do put $ st { vsUsedIdentifiers = Set.insert basename used }
+         return basename
 
 -- | Add a new wire to the current Verilog module state, given a type, a
 -- signedness flag, the prefix of a name, and an initializer expression.
@@ -381,7 +434,7 @@ freshIdentifier basename = do
 addFreshWire ::
   WT.BaseTypeRepr tp ->
   Bool ->
-  String ->
+  T.Text ->
   Exp tp ->
   VerilogM sym n Identifier
 addFreshWire repr isSigned basename e = do

--- a/what4/test/AdapterTest.hs
+++ b/what4/test/AdapterTest.hs
@@ -166,7 +166,7 @@ verilogTest = testCase "verilogTest" $ withIONonceGenerator $ \gen ->
      one <- bvLit sym w (mkBV w 1)
      add <- bvAdd sym x one
      r <- notPred sym =<< bvEq sym x add
-     edoc <- runExceptT (exprsVerilog sym [Some r] "f")
+     edoc <- runExceptT (exprsVerilog sym [] [Some r] "f")
      case edoc of
        Left err -> fail $ "Failed to translate to Verilog: " ++ err
        Right doc ->
@@ -178,17 +178,16 @@ verilogTest = testCase "verilogTest" $ withIONonceGenerator $ \gen ->
                     , refDoc
                     ]
   where
-    refDoc = unlines [
-               "module f(x_1, out_6);"
-             , "  input [7:0] x_1;"
-             , "  wire [7:0] x_0 = 8'h1;"
-             , "  wire [7:0] x_2 = x_0 * x_1;"
-             , "  wire [7:0] x_3 = x_0 + x_2;"
-             , "  wire x_4 = x_3 == x_1;"
-             , "  wire x_5 = ! x_4;"
-             , "  output out_6 = x_5;"
-             , "endmodule"
-             ]
+    refDoc = unlines [ "module f(x, out);"
+                     , "  input [7:0] x;"
+                     , "  wire [7:0] wr = 8'h1;"
+                     , "  wire [7:0] wr_0 = wr * x;"
+                     , "  wire [7:0] wr_1 = wr + wr_0;"
+                     , "  wire wr_2 = wr_1 == x;"
+                     , "  wire wr_3 = ! wr_2;"
+                     , "  output out = wr_3;"
+                     , "endmodule"
+                     ]
 
 getSolverVersion :: String -> IO String
 getSolverVersion solver = do

--- a/what4/test/AdapterTest.hs
+++ b/what4/test/AdapterTest.hs
@@ -181,11 +181,11 @@ verilogTest = testCase "verilogTest" $ withIONonceGenerator $ \gen ->
     refDoc = unlines [ "module f(x, out);"
                      , "  input [7:0] x;"
                      , "  wire [7:0] wr = 8'h1;"
-                     , "  wire [7:0] wr_0 = wr * x;"
-                     , "  wire [7:0] wr_1 = wr + wr_0;"
-                     , "  wire wr_2 = wr_1 == x;"
-                     , "  wire wr_3 = ! wr_2;"
-                     , "  output out = wr_3;"
+                     , "  wire [7:0] wr_2 = wr * x;"
+                     , "  wire [7:0] wr_3 = wr + wr_2;"
+                     , "  wire wr_4 = wr_3 == x;"
+                     , "  wire wr_5 = ! wr_4;"
+                     , "  output out = wr_5;"
                      , "endmodule"
                      ]
 


### PR DESCRIPTION
This makes it possible for the client of the Verilog writer to specify that a specific set of variables should appear in the module input list in a specific order. This makes it so that the order agrees with what the counterexample processor in SAW expects, and makes Verilog modules intended for use elsewhere able to have inputs that appear in the same order as in a Cryptol or SAWCore function. Previously, inputs were ordered according to their occurrence in the term being exported.

Makes progress in moving away from String along the way.