### PR TITLE
Enhance timeout handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     name: Testing ${{ matrix.os }} GHC-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
+    env:
+      CI_TEST_LEVEL: "1"
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         # LD_LIBRARY_PATH manipulation may be removed for all steps.
         run: |
           cd what4
-          $NS 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure --enable-tests -fSTPTestDisable -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
+          $NS 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure --enable-tests -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
       - name: Build
         shell: bash
         run: |
@@ -108,7 +108,8 @@ jobs:
           echo CVC4 version $(nix eval nixpkgs.cvc4.version)
           echo Yices version $(nix eval nixpkgs.yices.version)
           echo Z3 version $(nix eval nixpkgs.z3.version)
-          nix-shell -p cabal-install $GHC abc-verifier boolector cvc4 yices z3 zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal test --extra-lib-dirs="$ZLIB_LOC"'
+          echo STP version $(nix eval nixpkgs.z3.version)
+          nix-shell -p cabal-install $GHC abc-verifier boolector cvc4 stp yices z3 zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal test --extra-lib-dirs="$ZLIB_LOC"'
       - name: Documentation
         shell: bash
         run: |

--- a/what4/doc/implementation.md
+++ b/what4/doc/implementation.md
@@ -123,3 +123,28 @@ reasons:
 
 A future version of Yices may provide the ability to specify normal
 keyboard interrupt handling via command-line parameters.
+
+## Configuration
+
+What4 configuration utilizes a configuration management that allows
+different modules to locally define their configuration options.
+Configuration options are identified by a name which contains
+period-separated strings to differentiate different configuration
+namespaces.
+
+The overall configuration is stored in the `sym` parameter, and can be
+retrieved by the `getConfiguration` function and extended via the
+`extendConfig` function.  Each configuration has an `OptionStyle` that
+associates a validation function with the configuration; setting a
+configuration value returns an indication of whether an error
+occurred, along with zero or more warnings for the configuration.
+
+Each module can define its own set of configuration options, and must
+contrive to extend the global configuration with its options at
+startup time.
+
+This configuration mechanism is designed to allow client libraries and
+executables to extend the configuration with their own configuration
+parameters.
+
+For more information, see src/What4/Config.hs.

--- a/what4/src/What4/Config.hs
+++ b/what4/src/What4/Config.hs
@@ -47,7 +47,7 @@
 -- to install.  A configuration may be later extended with additional
 -- options by using the `extendConfig` operation.
 --
--- Example use (assuming the you wanted to use the z3 solver):
+-- Example use (assuming you wanted to use the z3 solver):
 --
 -- > import What4.Solver
 -- >
@@ -959,7 +959,7 @@ class Opt (tp :: BaseType) (a :: Type) | tp -> a where
   getOpt x = maybe (throwM $ OptGetFailure (OSet $ Some x) "not set") return
              =<< getMaybeOpt x
 
--- | Throw an exception if the given @OptionSetResult@ indidcates
+-- | Throw an exception if the given @OptionSetResult@ indicates
 --   an error.  Otherwise, return any generated warnings.
 checkOptSetResult :: OptionSetting tp -> OptionSetResult -> IO [Doc Void]
 checkOptSetResult optset res =
@@ -1111,7 +1111,7 @@ instance Pretty ConfigValue where
 
 
 -- | Given the name of a subtree, return all
---   the currently-set configurtion values in that subtree.
+--   the currently-set configuration values in that subtree.
 --
 --   If the subtree name is empty, the entire tree will be traversed.
 getConfigValues ::

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -183,11 +183,15 @@ data SolverProcess scope solver = SolverProcess
     -- ^ The amount of time (in seconds) that a solver should spend
     -- trying to satisfy any particular goal before giving up.  A
     -- value of zero indicates no time limit.
-
-    -- THIS IS INFORMATIONAL ONLY AND *NOT* USED TO ACTUALLY SET THE
-    -- SOLVER TIMEOUT!  To set the solver timeout, see the
-    -- solver-specific configuration (e.g. 'z3Timeout', 'cvc4Timeout',
-    -- etc.)
+    --
+    -- Note that it is not sufficient to set just this value to
+    -- control timeouts; this value is used as a reference for common
+    -- code (e.g. SMTLIB2) to determine the timeout for the associated
+    -- timer.  When initialized, this field of the SolverProcess is
+    -- initialized from a solver-specific timeout configuration
+    -- (e.g. z3Timeout); the latter is the definitive reference for
+    -- the timeout, and solver-specific code will likely use the the
+    -- latter rather than this common field.
   }
 
 

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -47,9 +47,9 @@ import           Control.Monad ( unless )
 import           Control.Monad (void, forM, forM_)
 import           Control.Monad.Catch ( MonadMask, bracket_, onException )
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
+import           Data.IORef
 import           Data.Parameterized.Some
 import           Data.Proxy
-import           Data.IORef
 import           Data.Text (Text)
 import qualified Data.Text.Lazy as LazyText
 import           Prettyprinter

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -169,6 +169,11 @@ data SolverProcess scope solver = SolverProcess
     -- ^ The amount of time (in seconds) that a solver should spend
     -- trying to satisfy any particular goal before giving up.  A
     -- value of zero indicates no time limit.
+
+    -- THIS IS INFORMATIONAL ONLY AND *NOT* USED TO ACTUALLY SET THE
+    -- SOLVER TIMEOUT!  To set the solver timeout, see the
+    -- solver-specific configuration (e.g. 'z3Timeout', 'cvc4Timeout',
+    -- etc.)
   }
 
 

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -416,7 +416,7 @@ checkAndGetModel yp rsn = do
     Unknown -> return Unknown
     Sat () -> Sat <$> getModel yp
 
--- | Following a successful check-sat command, build a ground evaulation function
+-- | Following a successful check-sat command, build a ground evaluation function
 --   that will evaluate terms in the context of the current model.
 getModel :: SMTReadWriter solver => SolverProcess scope solver -> IO (GroundEvalFn scope)
 getModel p = smtExprGroundEvalFn (solverConn p)

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -53,7 +53,10 @@ import           Control.Monad.Catch ( Exception, MonadMask, bracket_, catchIf
                                      , onException, throwM, fromException  )
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import           Data.IORef
+#if MIN_VERSION_base(4,14,0)
+#else
 import qualified Data.List as L
+#endif
 import           Data.Parameterized.Some
 import           Data.Proxy
 import           Data.Text (Text)

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -117,6 +117,11 @@ getGoalTimeoutInSeconds sgt =
       -- a full second.
   in if msecs > 0 && secs == 0 then 1 else secs
 
+instance Pretty SolverGoalTimeout where
+  pretty (SolverGoalTimeout ms) = pretty ms <> pretty "msec"
+
+instance Show SolverGoalTimeout where
+  show = show . pretty
 
 -- | A live connection to a running solver process.
 --

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -53,6 +53,7 @@ import           Control.Monad.Catch ( Exception, MonadMask, bracket_, catchIf
                                      , onException, throwM, fromException  )
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import           Data.IORef
+import qualified Data.List as L
 import           Data.Parameterized.Some
 import           Data.Proxy
 import           Data.Text (Text)
@@ -299,7 +300,7 @@ tryPop p =
 #if MIN_VERSION_base(4,14,0)
       solverGone = IOE.isResourceVanishedError
 #else
-      solverGone = isInfixOf "resource vanished" . IOE.ioeGetErrorString
+      solverGone = L.isInfixOf "resource vanished" . IOE.ioeGetErrorString
 #endif
   in readIORef (solverEarlyUnsat p) >>= \case
     Nothing -> do let c = solverConn p

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -197,7 +197,11 @@ solverResponse = connInputHandle . solverConn
 killSolver :: SolverProcess t solver -> IO ()
 killSolver p =
   do catchJust filterAsync
-           (terminateProcess (solverHandle p))
+           (terminateProcess (solverHandle p)
+            -- some solvers emit stderr messages on SIGTERM
+            >> readAllLines (solverStderr p)
+            >> return ()
+           )
            (\(ex :: SomeException) -> hPutStrLn stderr $ displayException ex)
      void $ waitForProcess (solverHandle p)
 

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -1049,13 +1049,14 @@ startSolver
   -> AcknowledgementAction t (Writer a)
         -- ^ Action for acknowledging command responses
   -> (WriterConn t (Writer a) -> IO ()) -- ^ Action for setting start-up-time options and logic
+  -> SolverGoalTimeout
   -> ProblemFeatures
   -> Maybe (CFG.ConfigOption I.BaseBoolType)
   -- ^ strictness override configuration
   -> Maybe IO.Handle
   -> B.ExprBuilder t st fs
   -> IO (SolverProcess t (Writer a))
-startSolver solver ack setup feats strictOpt auxOutput sym = do
+startSolver solver ack setup tmout feats strictOpt auxOutput sym = do
   path <- defaultSolverPath solver sym
   args <- defaultSolverArgs solver sym
   hdls@(in_h, out_h, err_h, ph) <- startProcess path args Nothing
@@ -1089,7 +1090,7 @@ startSolver solver ack setup feats strictOpt auxOutput sym = do
             , solverName     = show solver
             , solverEarlyUnsat = earlyUnsatRef
             , solverSupportsResetAssertions = supportsResetAssertions solver
-            , solverGoalTimeout = SolverGoalTimeout 0 -- no timeout by default
+            , solverGoalTimeout = tmout
             }
 
 shutdownSolver

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -97,8 +97,6 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.Char (digitToInt, isPrint, isAscii)
 import           Data.IORef
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as Lazy
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Monoid
@@ -112,6 +110,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.String
 import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as Lazy
 import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -1043,6 +1043,8 @@ writeDefaultSMT2 a nm feat strictOpt sym h ps = do
   writeCheckSat c
   writeExit c
 
+-- n.b. commonly used for the startSolverProcess method of the
+-- OnlineSolver class, so it's helpful for the type suffixes to align
 startSolver
   :: SMTLib2GenericSolver a
   => a

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -101,7 +101,7 @@ module What4.Protocol.SMTWriter
   ) where
 
 #if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail( MonadFail )
+import           Control.Monad.Fail ( MonadFail )
 #endif
 
 import           Control.Exception
@@ -112,8 +112,8 @@ import           Control.Monad.Reader
 import           Control.Monad.ST
 import           Control.Monad.State.Strict
 import           Control.Monad.Trans.Maybe
-import qualified Data.Bits as Bits
 import qualified Data.BitVector.Sized as BV
+import qualified Data.Bits as Bits
 import           Data.ByteString (ByteString)
 import           Data.IORef
 import           Data.Kind
@@ -128,10 +128,10 @@ import           Data.Parameterized.TraversableFC
 import           Data.Ratio
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as Lazy
 import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder (decimal)
-import qualified Data.Text.Lazy as Lazy
 import           Data.Word
 import           LibBF (BigFloat, bfFromBits)
 

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -2868,7 +2868,8 @@ newtype SMTEvalBVArrayWrapper h =
 data SMTEvalFunctions h
    = SMTEvalFunctions { smtEvalBool :: Term h -> IO Bool
                         -- ^ Given a SMT term for a Boolean value, this should
-                        -- whether the term is assigned true or false.
+                        -- return an indication of whether the term is assigned
+                        -- true or false.
                       , smtEvalBV   :: forall w . NatRepr w -> Term h -> IO (BV.BV w)
                         -- ^ Given a bitwidth, and a SMT term for a bitvector
                         -- with that bitwidth, this should return an unsigned

--- a/what4/src/What4/Solver.hs
+++ b/what4/src/What4/Solver.hs
@@ -36,6 +36,7 @@ module What4.Solver
   , Boolector(..)
   , boolectorAdapter
   , boolectorPath
+  , boolectorTimeout
   , runBoolectorInOverride
   , withBoolector
   , boolectorOptions
@@ -50,7 +51,6 @@ module What4.Solver
   , writeCVC4SMT2File
   , withCVC4
   , cvc4Options
-  , cvc4Timeout
   , cvc4Features
 
     -- * DReal
@@ -65,6 +65,7 @@ module What4.Solver
   , STP(..)
   , stpAdapter
   , stpPath
+  , stpTimeout
   , runSTPInOverride
   , withSTP
   , stpOptions
@@ -79,7 +80,6 @@ module What4.Solver
   , runYicesInOverride
   , writeYicesFile
   , yicesOptions
-  , yicesGoalTimeout
   , yicesDefaultFeatures
 
     -- * Z3
@@ -90,7 +90,6 @@ module What4.Solver
   , runZ3InOverride
   , withZ3
   , z3Options
-  , z3Timeout
   , z3Features
   ) where
 

--- a/what4/src/What4/Solver.hs
+++ b/what4/src/What4/Solver.hs
@@ -50,6 +50,7 @@ module What4.Solver
   , writeCVC4SMT2File
   , withCVC4
   , cvc4Options
+  , cvc4Timeout
   , cvc4Features
 
     -- * DReal
@@ -78,6 +79,7 @@ module What4.Solver
   , runYicesInOverride
   , writeYicesFile
   , yicesOptions
+  , yicesGoalTimeout
   , yicesDefaultFeatures
 
     -- * Z3
@@ -88,6 +90,7 @@ module What4.Solver
   , runZ3InOverride
   , withZ3
   , z3Options
+  , z3Timeout
   , z3Features
   ) where
 

--- a/what4/src/What4/Solver/CVC4.hs
+++ b/what4/src/What4/Solver/CVC4.hs
@@ -227,7 +227,7 @@ setInteractiveLogicAndOptions writer = do
     SMT2.setOption writer "print-success"  "true"
     -- Tell CVC4 to produce models
     SMT2.setOption writer "produce-models" "true"
-    -- Tell CVC4 to make declaraions global, so they are not removed by 'pop' commands
+    -- Tell CVC4 to make declarations global, so they are not removed by 'pop' commands
     SMT2.setOption writer "global-declarations" "true"
     -- Tell CVC4 to compute UNSAT cores, if that feature is enabled
     when (supportedFeatures writer `hasProblemFeature` useUnsatCores) $ do

--- a/what4/src/What4/Solver/CVC4.hs
+++ b/what4/src/What4/Solver/CVC4.hs
@@ -237,10 +237,9 @@ setInteractiveLogicAndOptions writer = do
 
 instance OnlineSolver (SMT2.Writer CVC4) where
   startSolverProcess feat mbIOh sym = do
-    sp <- SMT2.startSolver CVC4 SMT2.smtAckResult setInteractiveLogicAndOptions
-          feat (Just cvc4StrictParsing) mbIOh sym
     timeout <- SolverGoalTimeout <$>
                (getOpt =<< getOptionSetting cvc4Timeout (getConfiguration sym))
-    return $ sp { solverGoalTimeout = timeout }
+    SMT2.startSolver CVC4 SMT2.smtAckResult setInteractiveLogicAndOptions
+          timeout feat (Just cvc4StrictParsing) mbIOh sym
 
   shutdownSolverProcess = SMT2.shutdownSolver CVC4

--- a/what4/src/What4/Solver/STP.hs
+++ b/what4/src/What4/Solver/STP.hs
@@ -146,7 +146,7 @@ setInteractiveLogicAndOptions writer = do
     -- Tell STP to produce models
     SMT2.setOption writer "produce-models" "true"
 
-    -- Tell STP to make declaraions global, so they are not removed by 'pop' commands
+    -- Tell STP to make declarations global, so they are not removed by 'pop' commands
 -- TODO, add this command once https://github.com/stp/stp/issues/365 is closed
 --    SMT2.setOption writer "global-declarations" "true"
 

--- a/what4/src/What4/Solver/Z3.hs
+++ b/what4/src/What4/Solver/Z3.hs
@@ -63,7 +63,6 @@ z3Timeout = configOption knownRepr "solver.z3.timeout"
 
 z3TimeoutOLD :: ConfigOption BaseIntegerType
 z3TimeoutOLD = configOption knownRepr "z3_timeout"
-
 -- | Strict parsing specifically for Z3 interaction?  If set,
 -- overrides solver.strict_parsing, otherwise defaults to
 -- solver.strict_parsing.
@@ -214,11 +213,11 @@ setInteractiveLogicAndOptions writer = do
       SMT2.setOption writer "produce-unsat-cores" "true"
 
 instance OnlineSolver (SMT2.Writer Z3) where
+
   startSolverProcess feat mbIOh sym = do
-    sp <- SMT2.startSolver Z3 SMT2.smtAckResult setInteractiveLogicAndOptions feat
-          (Just z3StrictParsing) mbIOh sym
     timeout <- SolverGoalTimeout <$>
                (getOpt =<< getOptionSetting z3Timeout (getConfiguration sym))
-    return $ sp { solverGoalTimeout = timeout }
+    SMT2.startSolver Z3 SMT2.smtAckResult setInteractiveLogicAndOptions
+      timeout feat (Just z3StrictParsing) mbIOh sym
 
   shutdownSolverProcess = SMT2.shutdownSolver Z3

--- a/what4/src/What4/Utils/Process.hs
+++ b/what4/src/What4/Utils/Process.hs
@@ -93,6 +93,7 @@ startProcess path args mcwd =
               , std_err = CreatePipe
               , create_group = False
               , cwd = mcwd
+              , delegate_ctlc = True
               }
      createProcess create_proc >>= \case
        (Just in_h, Just out_h, Just err_h, ph) -> return (in_h, out_h, err_h, ph)

--- a/what4/src/What4/Utils/Process.hs
+++ b/what4/src/What4/Utils/Process.hs
@@ -103,7 +103,7 @@ startProcess path args mcwd =
                ] ++ args
 
 -- | Filtering function for use with `catchJust` or `tryJust`
---   that filters out asynch exceptions so they are rethrown
+--   that filters out async exceptions so they are rethrown
 --   instead of captured
 filterAsync :: SomeException -> Maybe SomeException
 filterAsync e

--- a/what4/test/AdapterTest.hs
+++ b/what4/test/AdapterTest.hs
@@ -681,6 +681,8 @@ reportSolverVersions = do testLevel <- fromMaybe "0" <$> lookupEnv "CI_TEST_LEVE
                           catMaybes <$> mapM (rep testLevel) allAdapters
   where rep lvl a = let s = solver_adapter_name a in disp lvl a s =<< getSolverVersion s
         disp lvl adptr s = \case
+          Right v -> do putStrLn $ "  Solver " <> s <> " == " <> v
+                        return $ Just adptr
           Left e ->
             if and [ "does not exist" `L.isInfixOf` e
                    , lvl == "0"
@@ -689,8 +691,6 @@ reportSolverVersions = do testLevel <- fromMaybe "0" <$> lookupEnv "CI_TEST_LEVE
                     return Nothing
             else do putStrLn $ "  Solver " <> s <> " error: " <> e
                     return $ Just adptr
-          Right v -> do putStrLn $ "  Solver " <> s <> " == " <> v
-                        return $ Just adptr
 
 
 main :: IO ()

--- a/what4/test/AdapterTest.hs
+++ b/what4/test/AdapterTest.hs
@@ -24,6 +24,7 @@ import           System.Exit ( ExitCode(..) )
 import           System.Process ( readProcessWithExitCode )
 
 import           Test.Tasty
+import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.HUnit
 
 import           Data.Parameterized.Nonce
@@ -565,7 +566,12 @@ nonlinearRealTest adpt = testCase (solver_adapter_name adpt) $
 
 
 mkQuickstartTest :: SolverAdapter State -> TestTree
-mkQuickstartTest adpt = testCase (solver_adapter_name adpt) $
+mkQuickstartTest adpt =
+  let wrap = if solver_adapter_name adpt == "stp"
+             then ignoreTestBecause "STP cannot generate the model"
+             else id
+  in wrap $
+  testCase (solver_adapter_name adpt) $
   withSym adpt $ \sym ->
     do -- Let's determine if the following formula is satisfiable:
        -- f(p, q, r) = (p | !q) & (q | r) & (!p | !r) & (!p | !q | r)

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -192,8 +192,7 @@ quickstartTest useFrames (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts,
           case res of
             Unsat _ -> fail "Unsatisfiable"
             Unknown -> fail "Solver returned UNKNOWN"
-            Sat _ ->
-              checkFormula1Model sym p q r =<< getModel proc
+            Sat _ -> checkFormula1Model sym p q r =<< getModel proc
 
      -- Now check that the formula is unsatisfiable when the blocking
      -- predicate is added.  Re-use the existing solver connection
@@ -256,6 +255,7 @@ longTimeTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, mb'timeoutO
   do sym <- newExprBuilder FloatUninterpretedRepr State gen
      extendConfig opts (getConfiguration sym)
 
+     -- Configure a solver timeout in What4 if specified for this test.
      case goal_tmo of
        Nothing -> return ()
        Just t -> case mb'timeoutOpt of
@@ -321,7 +321,6 @@ main :: IO ()
 main = do
   solvers <- reportSolverVersions
   defaultMain $
-    -- localOption (mkTimeout (10 * 1000 * 1000)) $
     testGroup "OnlineSolverTests"
     [
       testGroup "SmokeTest" $ map mkSmokeTest solvers

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -424,7 +424,7 @@ timeoutTests solvers =
       -- negative affect on the actual timing tests, but it does
       -- decrease sensitivity in test timing changes.
       --
-      acceptableTimeDelta = 55.0 -- percent variance from expected
+      acceptableTimeDelta = 63.0 -- percent variance allowed from expected
 
       --------------------------------------------------
       -- end of expected developer-adjustments above  --

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -157,6 +157,10 @@ checkFormula1Model sym p q r eval =
 -- resetting the solver between cases
 quickstartTest :: Bool -> SolverTestData -> TestTree
 quickstartTest useFrames (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _timeoutOpt) =
+  let wrap = if nm == "STP"
+             then ignoreTestBecause "STP cannot generate the model"
+             else id
+  in wrap $
   testCaseSteps nm $ \step ->
   withIONonceGenerator $ \gen ->
   do sym <- newExprBuilder FloatUninterpretedRepr State gen

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -12,15 +13,29 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 
+import           Control.Concurrent ( threadDelay )
+import           Control.Concurrent.Async ( race )
 import           Control.Exception ( try, SomeException )
 import           Control.Lens (folded)
 import           Control.Monad ( forM, void )
+import           Control.Monad.Catch ( MonadMask )
+import           Control.Monad.IO.Class ( MonadIO )
 import           Data.Char ( toLower )
+import           Data.Either ( isLeft, isRight )
+import qualified Data.List as L
+import           Data.Maybe ( fromMaybe )
+import           Data.Metrology ( (%), (#), (|<=|), (|*), (|<|), qApprox )
+import           Data.Metrology.SI ( Time, milli, micro, nano, Second(..) )
+import           Data.Metrology.Show ()
 import           Data.Proxy
+import qualified Prettyprinter as PP
+import           System.Clock
 import           System.Exit ( ExitCode(..) )
 import           System.Process ( readProcessWithExitCode )
 
 import           Test.Tasty
+import qualified Test.Tasty.Checklist as TCL
+import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.HUnit
 
 import qualified Data.BitVector.Sized as BV
@@ -38,19 +53,30 @@ import qualified What4.Solver.Yices as Yices
 
 data State t = State
 
-allOnlineSolvers :: [(String, AnOnlineSolver, ProblemFeatures, [ConfigDesc])]
+type SolverTestData = (String, AnOnlineSolver, ProblemFeatures, [ConfigDesc], Maybe (ConfigOption BaseIntegerType))
+
+allOnlineSolvers :: [SolverTestData]
 allOnlineSolvers =
-  [ ("Z3", AnOnlineSolver @(SMT2.Writer Z3) Proxy, z3Features, z3Options)
-  , ("CVC4",  AnOnlineSolver @(SMT2.Writer CVC4) Proxy, cvc4Features, cvc4Options)
-  , ("Yices", AnOnlineSolver @Yices.Connection Proxy, yicesDefaultFeatures, yicesOptions)
-  , ("Boolector", AnOnlineSolver @(SMT2.Writer Boolector) Proxy, boolectorFeatures, boolectorOptions)
+  [ ("Z3", AnOnlineSolver @(SMT2.Writer Z3) Proxy, z3Features, z3Options, Just z3Timeout)
+  , ("CVC4",  AnOnlineSolver @(SMT2.Writer CVC4) Proxy, cvc4Features, cvc4Options, Just cvc4Timeout)
+  , ("Yices", AnOnlineSolver @Yices.Connection Proxy, yicesDefaultFeatures, yicesOptions, Just yicesGoalTimeout)
+  , ("Boolector", AnOnlineSolver @(SMT2.Writer Boolector) Proxy, boolectorFeatures, boolectorOptions, Nothing)
 #ifdef TEST_STP
-  , ("STP", AnOnlineSolver @(SMT2.Writer STP) Proxy, stpFeatures, stpOptions)
+  , ("STP", AnOnlineSolver @(SMT2.Writer STP) Proxy, stpFeatures, stpOptions, Nothing)
 #endif
   ]
 
-mkSmokeTest :: (String, AnOnlineSolver, ProblemFeatures, [ConfigDesc]) -> TestTree
-mkSmokeTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts) = testCase nm $
+testSolverName (nm,_,_,_,_) = nm
+
+instance TCL.TestShow [PP.Doc ann] where
+  testShow = L.intercalate ", " . fmap show
+
+-- The smoke test is a simple test to ensure that the solver can be
+-- queried for a computable result and that the result can be obtained
+-- in a reasonably quick amount of time with no cancel or timeouts
+-- considerations.
+mkSmokeTest :: SolverTestData -> TestTree
+mkSmokeTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, timeoutOpt) = testCase nm $
   withIONonceGenerator $ \gen ->
   do sym <- newExprBuilder FloatUninterpretedRepr State gen
      extendConfig opts (getConfiguration sym)
@@ -126,10 +152,12 @@ checkFormula1Model sym p q r eval =
      return block
 
 
--- Solve Formula1 using a frame (push/pop) for each of the good and
--- bad cases
-quickstartTest :: (String, AnOnlineSolver, ProblemFeatures, [ConfigDesc]) -> TestTree
-quickstartTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts) = testCaseSteps nm $ \step ->
+-- Solve (the relatively simple) Formula1 using either frames
+-- (push/pop) for each of the good and bad cases or else no frames and
+-- resetting the solver between cases
+quickstartTest :: Bool -> SolverTestData -> TestTree
+quickstartTest useFrames (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _timeoutOpt) =
+  testCaseSteps nm $ \step ->
   withIONonceGenerator $ \gen ->
   do sym <- newExprBuilder FloatUninterpretedRepr State gen
      extendConfig opts (getConfiguration sym)
@@ -140,13 +168,22 @@ quickstartTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts) = testCas
      proc <- startSolverProcess @s features Nothing sym
      let conn = solverConn proc
 
+     -- helpers for operating framed v.s. non-framed testing
+
+     let startOnlineCheck :: (MonadMask m, MonadIO m, SMTReadWriter solver) => SolverProcess scope solver -> m b -> m b
+         startOnlineCheck = if useFrames then inNewFrame else passThru
+         resetOnlineCheck = if useFrames then doNothing  else reset
+         doNothing = const $ return ()
+         passThru _ op = op
+         checkType = if useFrames then "framed" else "direct"
+
      -- Check that formula f is satisfiable, and get the values from
      -- the model that satisifies it
 
      step "Check Satisfiability"
-     block <- inNewFrame proc $
+     block <- startOnlineCheck proc $
        do assume conn f
-          res <- check proc "framed formula1 satisfiable"
+          res <- check proc $ checkType <> " formula1 satisfiable"
           case res of
             Unsat _ -> fail "Unsatisfiable"
             Unknown -> fail "Solver returned UNKNOWN"
@@ -156,61 +193,95 @@ quickstartTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts) = testCas
      -- Now check that the formula is unsatisfiable when the blocking
      -- predicate is added.  Re-use the existing solver connection
 
+     resetOnlineCheck proc
+
      step "Check Unsatisfiable"
-     inNewFrame proc $
+     startOnlineCheck proc  $
        do assume conn f
           assume conn block
-          res <- check proc "framed formula1 unsatisfiable"
+          res <- check proc $ checkType <> " formula1 unsatisfiable"
           case res of
             Unsat _ -> return ()
             Unknown -> fail "Solver returned UNKNOWN"
             Sat _   -> fail "Should be a unique model!"
 
 
+----------------------------------------------------------------------
 
--- Solve Formula1 directly, with a solver reset between good and bad cases
-quickstartTestAlt :: (String, AnOnlineSolver, ProblemFeatures, [ConfigDesc]) -> TestTree
-quickstartTestAlt (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts) = testCaseSteps nm $ \step ->
+-- This constructs a What4 formula that takes the solvers a
+-- non-trivial amount of time to find a solution for.  This is used
+-- for running tests that are expected to be interrupted by a timeout,
+-- although this formula should run to completion if unrestricted.
+mkFormula2 :: IsSymExprBuilder sym => sym -> IO (Pred sym)
+mkFormula2 sym = do
+     p <- freshConstant sym (safeSymbol "p8") (BaseBVRepr (knownNat @8))
+     q <- freshConstant sym (safeSymbol "q8") (BaseBVRepr (knownNat @8))
+     r <- freshConstant sym (safeSymbol "q8") (BaseBVRepr (knownNat @8))
+     zeroBV <- bvLit sym (knownNat @8) (BV.zero (knownNat))
+
+     let bvGCD n a b = do
+           isZero <- bvEq sym zeroBV b
+           recurs <- if n == 0 then return a
+                     else bvGCD (n-1) b =<< (bvUrem sym a b)
+           bvIte sym isZero a recurs
+
+     -- String together some symbolic GCD calculations to make
+     -- something that the solver takes a while to check.  The goal
+     -- here is something long enough that we can test various
+     -- timeouts.
+     gcd1 <- bvGCD (256 :: Int) p r
+     gcd2 <- bvGCD (256 :: Int) q r
+     gcdRes <- bvGCD (256 :: Int) gcd1 gcd2
+
+     chk1 <- bvUle sym gcdRes p
+     chk2 <- bvUle sym gcdRes q
+     -- chk3 <- bvNe sym gcdRes zero
+     -- chk4 <- bvEq sym gcdRes zero
+     -- andPred sym chk1 =<< andPred sym chk2 chk3
+     andAllOf sym folded [chk1, chk2] -- , chk3, chk4]
+
+-- Attempt to solve an extensive formula (using frames: push/pop) that
+-- should exceed the solver goal-timeout.  This can be used to verify
+-- that the goal-timeout is realized and that the solver is useable
+-- for a goal _after_ the goal-timeout was reached.
+longTimeTest :: SolverTestData -> Maybe Time -> IO Bool
+longTimeTest (nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, mb'timeoutOpt) goal_tmo =
+  TCL.withChecklist "timer tests" $
   withIONonceGenerator $ \gen ->
   do sym <- newExprBuilder FloatUninterpretedRepr State gen
      extendConfig opts (getConfiguration sym)
 
-     (p,q,r,f) <- mkFormula1 sym
+     case goal_tmo of
+       Nothing -> return ()
+       Just t -> case mb'timeoutOpt of
+         Nothing -> error $ "No goal timeout option for backend solver " <> nm
+         Just timeoutOpt -> do
+           tmOpt <- getOptionSetting timeoutOpt $ getConfiguration sym
+           warnings <- setOpt tmOpt $ floor (t # milli Second)
+           TCL.check "timer option set" null warnings
 
-     step "Start Solver"
-     proc <- startSolverProcess @s features Nothing sym
+     f <- mkFormula2 sym
+
+     proc' <- startSolverProcess @s features Nothing sym
+     let proc = maybe proc'
+           (\t -> proc' {
+               solverGoalTimeout = SolverGoalTimeout $ floor (t # micro Second)
+               }
+           ) goal_tmo
      let conn = solverConn proc
 
      -- Check that formula f is satisfiable, and get the values from
      -- the model that satisifies it
 
-     step "Check Satisfiability"
-     block <-
-       do assume conn f
-          res <- check proc "direct formula1 satisfiable"
-          case res of
-            Unsat _ -> fail "Unsatisfiable"
-            Unknown -> fail "Solver returned UNKNOWN"
-            Sat _ ->
-              checkFormula1Model sym p q r =<< getModel proc
+     do assume conn f
+        check proc "direct formula2 satisfiable" >>= \case
+          Unsat _ -> fail "Unsatisfiable"
+          Unknown -> return False  -- how a solver indicates a timeout
+          Sat _ -> return True
+--            checkFormula1Model sym p q r =<< getModel proc
 
-     -- Now check that the formula is unsatisfiable when the blocking
-     -- predicate is added.  Re-use the existing solver connection
-
-     reset proc
-
-     step "Check Unsatisfiable"
-     assume conn f
-     assume conn block
-     res <- check proc "direct formula1 unsatisfiable"
-     case res of
-       Unsat _ -> return ()
-       Unknown -> fail "Solver returned UNKNOWN"
-       Sat _   -> fail "Should be a unique model!"
 
 ----------------------------------------------------------------------
-
-
 
 getSolverVersion :: String -> IO String
 getSolverVersion solver =
@@ -229,20 +300,161 @@ getSolverVersion solver =
 
 
 reportSolverVersions :: IO ()
-reportSolverVersions = do putStrLn "SOLVER VERSIONS::"
+reportSolverVersions = do putStrLn "SOLVER SELF-REPORTED VERSIONS::"
                           void $ mapM rep allOnlineSolvers
-  where rep (s,_,_,_) = disp s =<< getSolverVersion s
-        disp s v = putStrLn $ "  Solver " <> s <> " == " <> v
+  where rep testsolver = let s = testSolverName testsolver in disp s =<< getSolverVersion s
+        disp s v = putStrLn $ "  Solver " <> s <> " -> " <> v
 
 
 main :: IO ()
 main = do
   reportSolverVersions
   defaultMain $
-    localOption (mkTimeout (10 * 1000 * 1000)) $
+    -- localOption (mkTimeout (10 * 1000 * 1000)) $
     testGroup "OnlineSolverTests"
     [
       testGroup "SmokeTest" $ map mkSmokeTest allOnlineSolvers
-    , testGroup "QuickStart Framed" $ map quickstartTest allOnlineSolvers
-    , testGroup "QuickStart Direct" $ map quickstartTestAlt allOnlineSolvers
+    , testGroup "QuickStart Framed" $ map (quickstartTest True)  allOnlineSolvers
+    , testGroup "QuickStart Direct" $ map (quickstartTest False) allOnlineSolvers
+    , timeoutTests
     ]
+
+-- Test the effects of general timeouts on solver proofs
+--
+-- n.b. Approximate times obviously highly variant based on test
+-- machine, etc.  As long as they run consistently longer than the
+-- useable threshold the tests should perform as expected.
+
+timeoutTests :: TestTree
+timeoutTests =
+  let
+      -- Amount of time to use for timeouts in testing: can be edited
+      -- to adjust the timeout threshold needed.  This should be large
+      -- enough to allow the solver to engage on the task, but smaller
+      -- than the expected completion time by enough that the timeout
+      -- will halt the test before it completes.
+      --
+      -- If the timeout is too short there is the risk that it's not a
+      -- valid timeout test because of:
+      --
+      --   1. machine speed variance
+      --   2. scheduling and solver startup variance
+      --   3. timer resolution and timeout-driven scheduling
+      --
+      -- If the timeout value is too large, then the solver may
+      -- complete the proof more quickly than the timeout will fire.
+      -- Also, people get bored.
+      --
+      -- This value should also be <= 60% of useableTimeThreshold to
+      -- ensure that the solver runs for a siginificantly longer
+      -- period than the test timeout will be set to.
+      --
+      -- This value can be adjusted by the developer as needed to
+      -- reasonably validate timeout testing subject to the above
+      -- considerations.
+      testTimeout = 100 % milli Second
+
+      -- Solvers must run for at least this amount of time to be
+      -- useable for timeout tests.  The test timeout value is
+      -- determined by 'testTimeout', but if the solver does not run
+      -- for at least the 'useableTimeThreshold' then the test result
+      -- is likely to be indeterminate due to scheduling and timeout
+      -- handling variance.
+      --
+      -- This value is only used for validating individual tests and
+      -- does not control how long the actual tests run.
+      --
+      -- This value can be adjusted by the developer for cause.
+      useableTimeThreshold = 250 % milli Second :: Time
+      -- useableTimeThreshold = 4 % Second :: Time
+
+      -- This is empirical data from previous runs of the "Test itself
+      -- is valid and completes" test case; this data is used to guide
+      -- the current evaluation; times here will be compared to the
+      -- 'useableTimeThreshold' to verify that tests can be accurately
+      -- run.  This table may need to be updated periodically by the
+      -- developer as solvers, What4 formulation, and machine speeds
+      -- evolve.
+      approxTestTimes :: [ (String, Time) ]
+      approxTestTimes = [ ("Z3",         2.27 % Second)    -- Z3 4.8.10
+                        , ("CVC4",       6.37 % Second)    -- CVC4 1.8
+                        , ("Yices",      2.66 % Second)    -- Yices 2.6.1
+                        , ("Boolector",  6.56 % Second)    -- Boolector 3.2.1
+                        , ("STP",        0 % Second)       -- unknown yet
+                        ]
+
+      -- This is the acceptable delta variation in time between the
+      -- times in the approxTestTimes above and the actual test times.
+      -- If difference between the two exceeds this amount then it
+      -- represents a significant variation that should be attended
+      -- to; either the values in the approxTestTimes needs to be
+      -- ujpdated to account for evolved functionality or the test
+      -- formulas should be updated to ensure that reasonable timeout
+      -- testing can be performed (or there is a significant
+      -- performance regression or unexpected improvement in What4).
+      --
+      -- Note that when this test executable is run solo, a delta
+      -- value of ~ 0.5 Second is sufficient, but when *all* test
+      -- executables are run in parallel via `cabal test`, there seems
+      -- to be a much larger variation in testing times.  This may be
+      -- due to increased CPU load or scheduling variance due multiple
+      -- parallel running multiple tests.
+      --
+      acceptableTimeDelta = 800 % milli Second :: Time  -- solo
+      -- acceptableTimeDelta = 2.2 % Second :: Time   -- parallelized
+
+      --------------------------------------------------
+      -- end of expected developer-adjustments above  --
+      --------------------------------------------------
+
+      mkTimeoutTests s =
+        let historical = fromMaybe (0.0 % Second) $ lookup (testSolverName s) approxTestTimes
+        in testGroup (testSolverName s)
+           [
+             testCase ("Test itself is valid and completes (" <> show historical <> ")") $ do
+               -- Verify that the solver will run to completion for
+               -- this test if there is no time limit, and also that
+               -- the approxTestTimes historical time is reasonably
+               -- close to the actual time taken for this test.
+               start <- getTime Monotonic
+               longTimeTest s Nothing @? "valid test"
+               finish <- getTime Monotonic
+               let deltaT = (fromInteger $ toNanoSecs $ diffTimeSpec start finish) % nano Second :: Time
+               assertBool
+                 ("actual duration of " <> show deltaT <> " is significantly different than expected")
+                 $ qApprox acceptableTimeDelta deltaT historical
+
+           , let maybeRunTest = if useableTimeThreshold |<| historical
+                                then id
+                                else ignoreTestBecause $ unwords
+                                     [ "solver runs test faster than "
+                                     , "reasonable timing threshold;"
+                                     , "skipping"
+                                     ]
+             in maybeRunTest $ testCase "Test runs past timeout" $ do
+               rslt <- race
+                       (threadDelay (floor $ useableTimeThreshold # micro Second))
+                       (longTimeTest s Nothing)
+               isLeft rslt @? "solver is to fast for valid timeout testing"
+
+           -- Verify that specifying a goal-timeout will stop once
+           -- that timeout is reached (i.e. before the race timeout here).
+           , testCase "Test with goal timeout" $ do
+               rslt <- race
+                       (threadDelay (floor $ useableTimeThreshold # micro Second))
+                       (longTimeTest s (Just testTimeout))
+               isRight rslt @? "solver goal timeout didn't occur"
+               assertEqual "solver didn't timeout on goal" (Right False) rslt
+               -- TODO: ensure that the solver process is no longer using CPU time.
+           ]
+
+  in testGroup "Timeout Tests" $
+     [
+       testCase "valid test timeout" $
+       -- Verify that the user-defineable 'testTimeout' is a
+       -- reasonable value.  If this fails, ignore all other test
+       -- results and modify the 'testTimeout'.
+       testTimeout |<=| useableTimeThreshold |* 0.60 @?
+       "test timeout too large"
+
+     ] <> map mkTimeoutTests allOnlineSolvers

--- a/what4/test/TestTemplate.hs
+++ b/what4/test/TestTemplate.hs
@@ -12,8 +12,8 @@ module Main where
 
 import Control.Exception
 import Control.Monad ((<=<)) -- , when)
-import           Control.Monad.Trans.Maybe
 import Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Maybe
 import Data.Bits
 import Data.Parameterized.Map (MapF)
 import qualified Data.Parameterized.Map as MapF

--- a/what4/test/responses/err-behav-unrec.exp
+++ b/what4/test/responses/err-behav-unrec.exp
@@ -1,12 +1,4 @@
-Left Could not parse solver response:
-  Solver response parsing failure.
-*** Exception: Unrecognized response from solver:
+Left Unrecognized response from solver:
   bad :error-behavior value
 in response to command:
   (get-info :error-behavior)
-
-Attempting to parse input for test resp:
-Just "(:error-behavior freak-out)\n"
-
-in response to commands for test resp:
-test cmd

--- a/what4/test/responses/minisat_verbose_success.strict.exp
+++ b/what4/test/responses/minisat_verbose_success.strict.exp
@@ -1,8 +1,1 @@
-Left Could not parse solver response:
-  Solver response parsing failure.
-*** Exception: Parse exception: Failed reading: empty
-Attempting to parse input for test resp:
-Just "minisat: Incremental solving is forced on (to avoid variable elimination) unless using internal decision strategy.\nsuccess\n"
-
-in response to commands for test resp:
-test cmd
+Left Parse exception: Failed reading: empty

--- a/what4/test/responses/rsnunk-bad.exp
+++ b/what4/test/responses/rsnunk-bad.exp
@@ -1,12 +1,4 @@
-Left Could not parse solver response:
-  Solver response parsing failure.
-*** Exception: Unrecognized response from solver:
+Left Unrecognized response from solver:
   bad :reason-unknown value
 in response to command:
   reason?
-
-Attempting to parse input for test resp:
-Just "(:reason-unknown foo bar baz)\n"
-
-in response to commands for test resp:
-test cmd

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -273,7 +273,8 @@ test-suite online-solver-test
 
   main-is: OnlineSolverTest.hs
 
-  if flag(solverTests)
+  -- Disabled for 9.0 until units package is updated
+  if flag(solverTests) && impl(ghc < 9.0)
     buildable: True
     if ! flag(STPTestDisable)
       cpp-options: -DTEST_STP

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -253,6 +253,7 @@ test-suite adapter-test
     lens,
     mtl >= 2.2.1,
     process,
+    tasty-expected-failure >= 0.12 && < 0.13,
     text,
     versions
 

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -90,6 +90,7 @@ library
   import: bldflags
   build-depends:
     base >= 4.8 && < 5,
+    async,
     attoparsec >= 0.13,
     bimap >= 0.2,
     bifunctors >= 5,
@@ -279,13 +280,21 @@ test-suite online-solver-test
     buildable: False
 
   build-depends:
+    async,
     bv-sized,
     bytestring,
+    clock,
     containers,
     data-binary-ieee754,
+    exceptions,
     lens,
+    prettyprinter,
     process,
+    tasty-expected-failure >= 0.12 && < 0.13,
+    tasty-checklist >= 0.1 && < 0.2,
     text,
+    units,
+    units-defs,
     versions
 
 test-suite expr-builder-smtlib2

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -291,7 +291,7 @@ test-suite online-solver-test
     prettyprinter,
     process,
     tasty-expected-failure >= 0.12 && < 0.13,
-    tasty-checklist >= 0.1 && < 0.2,
+    tasty-checklist >= 1.0 && < 1.1,
     text,
     units,
     units-defs,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -310,6 +310,8 @@ test-suite expr-builder-smtlib2
     containers,
     data-binary-ieee754,
     libBF,
+    process,
+    tasty-expected-failure >= 0.12 && < 0.13,
     text,
     versions
 


### PR DESCRIPTION
Updates various solver tests and adds better timeout management.

* Running `cabal test` will only ignore tests for missing solvers unless `CI_TEST_LEVEL` is set and not `0`.  This allows easy development with whatever solver is available in the development environment, but ensures that solvers are present and all tests pass in the CI process.
* Some solvers do not provide the ability to add per-goal timeouts.  Other solvers have some difficulty in honoring that timeout even if it is supported.  This PR adds a "deadman timeout" in What4 itself that will interrupt the solver if it does not voluntarily abort at the designated goal timeout period.
* Modifications to solver error handling to pop frames if possible, but not fail if the solver is not functional enough to allow frame popping.
* Propagate Ctrl-C to solvers to allow solvers to abort processing on Ctrl-C and indicate an incomplete status.
* Adds test for timeouts for online solvers.
* Enables testing the STP solver in CI
* Adds `solver.boolector.timeout` and `solver.stp.timeout` configuration options.
* Internally differentiates between response parsing failures v.s. other failure conditions.
* Various cleanup and response handling fixes and improvements for the corner cases caused by interrupts, exceptions, and failures.
