### PR TITLE
Faithfully implement the semantics of some string operations

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -2782,8 +2782,6 @@ instance IsExprBuilder (ExprBuilder t st fs) where
     | Just x' <- asString x
     , Just off' <- asInteger off
     , Just len' <- asInteger len
-    , 0 <= off', 0 <= len'
-    , off' + len' <= stringLitLength x'
     = stringLit sym $! stringLitSubstring x' off' len'
 
     | otherwise

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -1662,27 +1662,50 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
   stringConcat :: sym -> SymString sym si -> SymString sym si -> IO (SymString sym si)
 
   -- | Test if the first string contains the second string as a substring
-  stringContains :: sym -> SymString sym si -> SymString sym si -> IO (Pred sym)
+  stringContains ::
+    sym ->
+    SymString sym si {- ^ string to test -} ->
+    SymString sym si {- ^ substring to look for -} ->
+    IO (Pred sym)
 
   -- | Test if the first string is a prefix of the second string
-  stringIsPrefixOf :: sym -> SymString sym si -> SymString sym si -> IO (Pred sym)
+  stringIsPrefixOf ::
+    sym ->
+    SymString sym si {- ^ prefix string -} ->
+    SymString sym si {- ^ string to test -} ->
+    IO (Pred sym)
 
   -- | Test if the first string is a suffix of the second string
-  stringIsSuffixOf :: sym -> SymString sym si -> SymString sym si -> IO (Pred sym)
+  stringIsSuffixOf ::
+    sym ->
+    SymString sym si {- ^ suffix string -} ->
+    SymString sym si {- ^ string to test -} ->
+    IO (Pred sym)
 
   -- | Return the first position at which the second string can be found as a substring
   --   in the first string, starting from the given index.
   --   If no such position exists, return a negative value.
-  stringIndexOf :: sym -> SymString sym si -> SymString sym si -> SymInteger sym -> IO (SymInteger sym)
+  --   If the given index is out of bounds for the string, return a negative value.
+  stringIndexOf ::
+    sym ->
+    SymString sym si {- ^ string to search in -} ->
+    SymString sym si {- ^ substring to search for -} ->
+    SymInteger sym   {- ^ starting index for search -} ->
+    IO (SymInteger sym)
 
   -- | Compute the length of a string
   stringLength :: sym -> SymString sym si -> IO (SymInteger sym)
 
-  -- | @stringSubstring s off len@ extracts the substring of @s@ starting at index @off@ and
-  --   having length @len@.  The result of this operation is undefined if @off@ and @len@
-  --   do not specify a valid substring of @s@; in particular, we must have
-  --   0 <= off@, @0 <= len@ and @off+len <= length(s)@.
-  stringSubstring :: sym -> SymString sym si -> SymInteger sym -> SymInteger sym -> IO (SymString sym si)
+  -- | @stringSubstring s off len@ evaluates to the longest substring
+  --   of @s@ of length at most @len@ starting at position @off@.
+  --   It evaluates to the empty string if @len@ is negative or @off@ is not in
+  --   the interval @[0,l-1]@ where @l@ is the length of @s@.
+  stringSubstring ::
+    sym ->
+    SymString sym si {- ^ string to select a substring from -} ->
+    SymInteger sym   {- ^ offset of the beginning of the substring -} ->
+    SymInteger sym   {- ^ length of the substring -} ->
+    IO (SymString sym si)
 
   ----------------------------------------------------------------------
   -- Real operations


### PR DESCRIPTION
Previously, the string index-of and substring functions were
underspecified, whereas the SMTLib theory for these functions
determines precicely their result on out-of-bounds inputs.

Here, we faithfully implement those semantics.

Fixes #103