### PR TITLE
Include test/responses in hackage tarball

### DIFF
--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -23,6 +23,10 @@ Description:
 
 data-files: solverBounds.config
 
+Extra-source-files:
+  test/responses/*.exp
+  test/responses/*.rsp
+
 Extra-doc-files:
   README.md
   CHANGES.md


### PR DESCRIPTION
Fixes test failure when running with the hackage tarball:

```
Test suite solver_parsing_tests: RUNNING...
solver_parsing_tests: test/responses: getDirectoryContents:openDirStream: does not exist (No such file or directory)
Test suite solver_parsing_tests: FAIL
```