### PR TITLE
[CI] use nixos-21.05 for GHC 9 tests for boolector 3.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: cachix/install-nix-action@v12
         name: Nix unstable base
         # if: matrix.ghc == '9.0.1'
-        if: false
+        if: false  # not currently needed, but may be in the future
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,14 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-20.09
       - uses: cachix/install-nix-action@v12
-        name: Nix unstable base
+        name: Nix 21.05 base
         if: matrix.ghc == '9.0.1'
+        with:
+          nix_path: nixpkgs=channel:nixos-21.05
+      - uses: cachix/install-nix-action@v12
+        name: Nix unstable base
+        # if: matrix.ghc == '9.0.1'
+        if: false
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: actions/cache@v2


### PR DESCRIPTION
The boolector 3.2.2 version causes test failures in the adapter tests
for what4.  This nixos version pin retains boolector 3.2.1 (at least
for now).