### PR TITLE
Add arrayCopy, arraySet, and arrayRangeEqual primitives.

### DIFF
--- a/what4/src/What4/Expr/App.hs
+++ b/what4/src/What4/Expr/App.hs
@@ -529,6 +529,43 @@ data App (e :: BaseType -> Type) (tp :: BaseType) where
               -> !(Ctx.Assignment e (i::>tp))
               -> App e b
 
+  CopyArray ::
+    (1 <= w) =>
+    !(NatRepr w) ->
+    !(BaseTypeRepr a) ->
+    !(e (BaseArrayType (SingleCtx (BaseBVType w)) a)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseArrayType (SingleCtx (BaseBVType w)) a)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    App e (BaseArrayType (SingleCtx (BaseBVType w)) a)
+
+  SetArray ::
+    (1 <= w) =>
+    !(NatRepr w) ->
+    !(BaseTypeRepr a) ->
+    !(e (BaseArrayType (SingleCtx (BaseBVType w)) a)) ->
+    !(e (BaseBVType w)) ->
+    !(e a) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    App e (BaseArrayType (SingleCtx (BaseBVType w)) a)
+
+  EqualArrayRange ::
+    (1 <= w) =>
+    !(NatRepr w) ->
+    !(BaseTypeRepr a) ->
+    !(e (BaseArrayType (SingleCtx (BaseBVType w)) a)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseArrayType (SingleCtx (BaseBVType w)) a)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    !(e (BaseBVType w)) ->
+    App e BaseBoolType
+
   ------------------------------------------------------------------------
   -- Conversions.
 
@@ -1819,6 +1856,9 @@ appType a =
     ConstantArray idx b _   -> BaseArrayRepr idx b
     SelectArray b _ _       -> b
     UpdateArray b itp _ _ _     -> BaseArrayRepr itp b
+    CopyArray w a_repr _ _ _ _ _ _ _ -> BaseArrayRepr (singleton (BaseBVRepr w)) a_repr
+    SetArray w a_repr _ _ _ _ _ -> BaseArrayRepr (singleton (BaseBVRepr w)) a_repr
+    EqualArrayRange _ _ _ _ _ _ _ _ _ -> knownRepr
 
     IntegerToReal{} -> knownRepr
     BVToInteger{} -> knownRepr
@@ -1973,6 +2013,11 @@ abstractEval f a0 = do
 
     SelectArray _bRepr a _i -> f a  -- FIXME?
     UpdateArray bRepr _ a _i v -> withAbstractable bRepr $ avJoin bRepr (f a) (f v)
+    CopyArray _ a_repr dest_arr _dest_idx src_arr _src_idx _len _dest_end_idx _src_end_idx ->
+      withAbstractable a_repr $ avJoin a_repr (f dest_arr) (f src_arr)
+    SetArray _ a_repr arr _idx val _len _end_idx ->
+      withAbstractable a_repr $ avJoin a_repr (f arr) (f val)
+    EqualArrayRange{} -> Nothing
 
     IntegerToReal x -> RAV (mapRange toRational (f x)) (Just True)
     BVToInteger x -> valueRange (Inclusive lx) (Inclusive ux)
@@ -2139,6 +2184,9 @@ reduceApp sym unary a0 = do
     ConstantArray idx_tp _ e -> constantArray sym idx_tp e
     SelectArray _ a i     -> arrayLookup sym a i
     UpdateArray _ _ a i v -> arrayUpdate sym a i v
+    CopyArray _ _ dest_arr dest_idx src_arr src_idx len _ _ -> arrayCopy sym dest_arr dest_idx src_arr src_idx len
+    SetArray _ _ arr idx val len _ -> arraySet sym arr idx val len
+    EqualArrayRange _ _ x_arr x_idx y_arr y_idx len _ _ -> arrayRangeEq sym x_arr x_idx y_arr y_idx len
 
     IntegerToReal x -> integerToReal sym x
     RealToInteger x -> realToInteger sym x
@@ -2430,6 +2478,28 @@ ppApp' a0 = do
       prettyApp "select" (exprPrettyArg a : exprPrettyIndices i)
     UpdateArray _ _ a i v ->
       prettyApp "update" ([exprPrettyArg a] ++ exprPrettyIndices i ++ [exprPrettyArg v])
+    CopyArray _ _ dest_arr dest_idx src_arr src_idx len _ _ ->
+      prettyApp
+        "arrayCopy"
+        [ exprPrettyArg dest_arr
+        , exprPrettyArg dest_idx
+        , exprPrettyArg src_arr
+        , exprPrettyArg src_idx
+        , exprPrettyArg len
+        ]
+    SetArray _ _ arr idx val len _ ->
+      prettyApp
+        "arraySet"
+        [exprPrettyArg arr, exprPrettyArg idx, exprPrettyArg val, exprPrettyArg len]
+    EqualArrayRange _ _ x_arr x_idx y_arr y_idx len _ _ ->
+      prettyApp
+        "arrayRangeEq"
+        [ exprPrettyArg x_arr
+        , exprPrettyArg x_idx
+        , exprPrettyArg y_arr
+        , exprPrettyArg y_idx
+        , exprPrettyArg len
+        ]
 
     ------------------------------------------------------------------------
     -- Conversions.

--- a/what4/src/What4/Expr/App.hs
+++ b/what4/src/What4/Expr/App.hs
@@ -2184,9 +2184,11 @@ reduceApp sym unary a0 = do
     ConstantArray idx_tp _ e -> constantArray sym idx_tp e
     SelectArray _ a i     -> arrayLookup sym a i
     UpdateArray _ _ a i v -> arrayUpdate sym a i v
-    CopyArray _ _ dest_arr dest_idx src_arr src_idx len _ _ -> arrayCopy sym dest_arr dest_idx src_arr src_idx len
+    CopyArray _ _ dest_arr dest_idx src_arr src_idx len _ _ ->
+      arrayCopy sym dest_arr dest_idx src_arr src_idx len
     SetArray _ _ arr idx val len _ -> arraySet sym arr idx val len
-    EqualArrayRange _ _ x_arr x_idx y_arr y_idx len _ _ -> arrayRangeEq sym x_arr x_idx y_arr y_idx len
+    EqualArrayRange _ _ x_arr x_idx y_arr y_idx len _ _ ->
+      arrayRangeEq sym x_arr x_idx y_arr y_idx len
 
     IntegerToReal x -> integerToReal sym x
     RealToInteger x -> realToInteger sym x

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -201,6 +201,9 @@ appTheory a0 =
     ConstantArray{} -> ArrayTheory
     SelectArray{} -> ArrayTheory
     UpdateArray{} -> ArrayTheory
+    CopyArray{} -> ArrayTheory
+    SetArray{} -> ArrayTheory
+    EqualArrayRange{} -> ArrayTheory
 
     ---------------------
     -- String operations

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -1152,6 +1152,10 @@ sbConcreteLookup sym arr0 mcidx idx
         (sliced_arr, sliced_idx) <- sliceArrayLookupUpdate sym arr0 idx
         sbMakeExpr sym (SelectArray range sliced_arr sliced_idx)
 
+-- | Simplify an array lookup expression by slicing the array w.r.t. the index.
+--
+-- Remove array update, copy and set operations at indices that are different
+-- from the lookup index.
 sliceArrayLookupUpdate ::
   ExprBuilder t st fs ->
   Expr t (BaseArrayType (d::>tp) range) ->

--- a/what4/src/What4/Expr/GroundEval.hs
+++ b/what4/src/What4/Expr/GroundEval.hs
@@ -498,6 +498,10 @@ evalGroundApp f a0 = do
                     BaseBVRepr _    -> xj == yj
                     _ -> error $ "We do not yet support UpdateArray on " ++ show tp ++ " indices."
 
+    CopyArray{} -> error "CopyArray: unsupported."
+    SetArray{} -> error "SetArray: unsupported."
+    EqualArrayRange{} -> error "EqualArrayRange: unsupported."
+
     ------------------------------------------------------------------------
     -- Conversions
 

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -1382,6 +1382,38 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
               -> Ctx.Assignment (SymExpr sym) (idx::>tp)
               -> IO (SymExpr sym b)
 
+  -- | Return element in array.
+  arrayCopy ::
+    (1 <= w) =>
+    sym ->
+    SymArray sym (SingleCtx (BaseBVType w)) a ->
+    SymBV sym w ->
+    SymArray sym (SingleCtx (BaseBVType w)) a ->
+    SymBV sym w ->
+    SymBV sym w ->
+    IO (SymArray sym (SingleCtx (BaseBVType w)) a)
+
+  -- | Return element in array.
+  arraySet ::
+    (1 <= w) =>
+    sym ->
+    SymArray sym (SingleCtx (BaseBVType w)) a ->
+    SymBV sym w ->
+    SymExpr sym a ->
+    SymBV sym w ->
+    IO (SymArray sym (SingleCtx (BaseBVType w)) a)
+
+  -- | Return element in array.
+  arrayRangeEq ::
+    (1 <= w) =>
+    sym ->
+    SymArray sym (SingleCtx (BaseBVType w)) a ->
+    SymBV sym w ->
+    SymArray sym (SingleCtx (BaseBVType w)) a ->
+    SymBV sym w ->
+    SymBV sym w ->
+    IO (Pred sym)
+
   -- | Create an array from a map of concrete indices to values.
   --
   -- This is implemented, but designed to be overridden for efficiency.

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -1382,7 +1382,14 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
               -> Ctx.Assignment (SymExpr sym) (idx::>tp)
               -> IO (SymExpr sym b)
 
-  -- | Return element in array.
+  -- | Copy elements from the source array to the destination array.
+  --
+  -- @'arrayCopy' sym dest_arr dest_idx src_arr src_idx len@ copies the
+  -- elements from @src_arr@ at indices @[src_idx .. (src_idx + len)]@ into
+  -- @dest_arr@ at indices @[dest_idx .. (dest_idx + len)]@.
+  --
+  -- The result is undefined if either @dest_idx + len@ or @src_idx + len@
+  -- wraps around.
   arrayCopy ::
     (1 <= w) =>
     sym ->
@@ -1393,7 +1400,12 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
     SymBV sym w ->
     IO (SymArray sym (SingleCtx (BaseBVType w)) a)
 
-  -- | Return element in array.
+  -- | Set elements of the given array.
+  --
+  -- @'arraySet' sym arr idx val len@ sets the elements of @arr@ at indices
+  -- @[idx .. (idx + len)]@ to @val@.
+  --
+  -- The result is undefined if @idx + len@ wraps around.
   arraySet ::
     (1 <= w) =>
     sym ->
@@ -1403,7 +1415,16 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
     SymBV sym w ->
     IO (SymArray sym (SingleCtx (BaseBVType w)) a)
 
-  -- | Return element in array.
+  -- | Check whether the lhs array and rhs array are equal at a range of
+  --   indices.
+  --
+  -- @'arrayRangeEq' sym lhs_arr lhs_idx rhs_arr rhs_idx len@ checks whether
+  -- the elements of @lhs_arr@ at indices @[lhs_idx .. (lhs_idx + len)]@ and
+  -- the elements of @rhs_arr@ at indices @[rhs_idx .. (rhs_idx + len)]@ are
+  -- equal.
+  --
+  -- The result is undefined if either @lhs_idx + len@ or @rhs_idx + len@
+  -- wraps around.
   arrayRangeEq ::
     (1 <= w) =>
     sym ->

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -2630,7 +2630,10 @@ appSMTExpr ae = do
 
       cr <- liftIO $ withConnEntryStack conn $ runInSandbox conn $ do
         i_expr <- asBase <$> freshConstant "i" idx_type
-        return $ asBase (smt_array_select res [i_expr]) .== ite ((bvULe dest_idx_expr i_expr) .&& (bvULt i_expr (bvAdd dest_idx_expr len_expr))) (asBase (smt_array_select src_arr_typed_expr [bvAdd src_idx_expr (bvSub i_expr dest_idx_expr)])) (asBase (smt_array_select dest_arr_typed_expr [i_expr]))
+        return $ asBase (smt_array_select res [i_expr]) .==
+          ite ((bvULe dest_idx_expr i_expr) .&& (bvULt i_expr (bvAdd dest_idx_expr len_expr)))
+            (asBase (smt_array_select src_arr_typed_expr [bvAdd src_idx_expr (bvSub i_expr dest_idx_expr)]))
+            (asBase (smt_array_select dest_arr_typed_expr [i_expr]))
       addSideCondition "array copy" $ forallResult cr
       addSideCondition "array copy" $ bvULt dest_idx_expr (bvAdd dest_idx_expr len_expr)
       addSideCondition "array copy" $ bvULt src_idx_expr (bvAdd src_idx_expr len_expr)
@@ -2649,7 +2652,10 @@ appSMTExpr ae = do
       res <- freshConstant "array_set" arr_type
       cr <- liftIO $ withConnEntryStack conn $ runInSandbox conn $ do
         i_expr <- asBase <$> freshConstant "i" idx_type
-        return $ asBase (smt_array_select res [i_expr]) .== ite ((bvULe idx_expr i_expr) .&& (bvULt i_expr (bvAdd idx_expr len_expr))) val_expr (asBase (smt_array_select arr_typed_expr [i_expr]))
+        return $ asBase (smt_array_select res [i_expr]) .==
+          ite ((bvULe idx_expr i_expr) .&& (bvULt i_expr (bvAdd idx_expr len_expr)))
+            val_expr
+            (asBase (smt_array_select arr_typed_expr [i_expr]))
       addSideCondition "array set" $ forallResult cr
       addSideCondition "array set" $ bvULt idx_expr (bvAdd idx_expr len_expr)
 
@@ -2666,7 +2672,9 @@ appSMTExpr ae = do
 
       cr <- liftIO $ withConnEntryStack conn $ runInSandbox conn $ do
         i_expr <- asBase <$> freshConstant "i" idx_type
-        return $ impliesExpr ((bvULe x_idx_expr i_expr) .&& (bvULt i_expr (bvAdd x_idx_expr len_expr))) ((asBase (smt_array_select x_arr_typed_expr [i_expr])) .== (asBase (smt_array_select y_arr_typed_expr [bvAdd y_idx_expr (bvSub i_expr x_idx_expr)])))
+        return $ impliesExpr ((bvULe x_idx_expr i_expr) .&& (bvULt i_expr (bvAdd x_idx_expr len_expr)))
+          ((asBase (smt_array_select x_arr_typed_expr [i_expr])) .==
+            (asBase (smt_array_select y_arr_typed_expr [bvAdd y_idx_expr (bvSub i_expr x_idx_expr)])))
       addSideCondition "array range equal" $ bvULt x_idx_expr (bvAdd x_idx_expr len_expr)
       addSideCondition "array range equal" $ bvULt y_idx_expr (bvAdd y_idx_expr len_expr)
 

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -2616,6 +2616,62 @@ appSMTExpr ae = do
               let expr = ite cond value base_array_value
               SMTName array_type <$> freshBoundFn args resType expr
 
+    CopyArray _w_repr _a_repr dest_arr dest_idx src_arr src_idx len _dest_end_idx _src_end_idx -> do
+      dest_arr_typed_expr <- mkExpr dest_arr
+      let arr_type = smtExprType dest_arr_typed_expr
+      dest_idx_typed_expr <- mkExpr dest_idx
+      let dest_idx_expr = asBase dest_idx_typed_expr
+      let idx_type = smtExprType dest_idx_typed_expr
+      src_arr_typed_expr <- mkExpr src_arr
+      src_idx_expr <- mkBaseExpr src_idx
+      len_expr <- mkBaseExpr len
+
+      res <- freshConstant "array_copy" arr_type
+
+      cr <- liftIO $ withConnEntryStack conn $ runInSandbox conn $ do
+        i_expr <- asBase <$> freshConstant "i" idx_type
+        return $ asBase (smt_array_select res [i_expr]) .== ite ((bvULe dest_idx_expr i_expr) .&& (bvULt i_expr (bvAdd dest_idx_expr len_expr))) (asBase (smt_array_select src_arr_typed_expr [bvAdd src_idx_expr (bvSub i_expr dest_idx_expr)])) (asBase (smt_array_select dest_arr_typed_expr [i_expr]))
+      addSideCondition "array copy" $ forallResult cr
+      addSideCondition "array copy" $ bvULt dest_idx_expr (bvAdd dest_idx_expr len_expr)
+      addSideCondition "array copy" $ bvULt src_idx_expr (bvAdd src_idx_expr len_expr)
+
+      return res
+
+    SetArray _w_repr _a_repr arr idx val len _end_idx -> do
+      arr_typed_expr <- mkExpr arr
+      let arr_type = smtExprType arr_typed_expr
+      idx_typed_expr <- mkExpr idx
+      let idx_expr = asBase idx_typed_expr
+      let idx_type = smtExprType idx_typed_expr
+      val_expr <- mkBaseExpr val
+      len_expr <- mkBaseExpr len
+
+      res <- freshConstant "array_set" arr_type
+      cr <- liftIO $ withConnEntryStack conn $ runInSandbox conn $ do
+        i_expr <- asBase <$> freshConstant "i" idx_type
+        return $ asBase (smt_array_select res [i_expr]) .== ite ((bvULe idx_expr i_expr) .&& (bvULt i_expr (bvAdd idx_expr len_expr))) val_expr (asBase (smt_array_select arr_typed_expr [i_expr]))
+      addSideCondition "array set" $ forallResult cr
+      addSideCondition "array set" $ bvULt idx_expr (bvAdd idx_expr len_expr)
+
+      return res
+
+    EqualArrayRange _w_repr _a_repr x_arr x_idx y_arr y_idx len _x_end_idx _y_end_idx -> do
+      x_arr_typed_expr <- mkExpr x_arr
+      x_idx_typed_expr <- mkExpr x_idx
+      let x_idx_expr = asBase x_idx_typed_expr
+      let idx_type = smtExprType x_idx_typed_expr
+      y_arr_typed_expr <- mkExpr y_arr
+      y_idx_expr <- mkBaseExpr y_idx
+      len_expr <- mkBaseExpr len
+
+      cr <- liftIO $ withConnEntryStack conn $ runInSandbox conn $ do
+        i_expr <- asBase <$> freshConstant "i" idx_type
+        return $ impliesExpr ((bvULe x_idx_expr i_expr) .&& (bvULt i_expr (bvAdd x_idx_expr len_expr))) ((asBase (smt_array_select x_arr_typed_expr [i_expr])) .== (asBase (smt_array_select y_arr_typed_expr [bvAdd y_idx_expr (bvSub i_expr x_idx_expr)])))
+      addSideCondition "array range equal" $ bvULt x_idx_expr (bvAdd x_idx_expr len_expr)
+      addSideCondition "array range equal" $ bvULt y_idx_expr (bvAdd y_idx_expr len_expr)
+
+      freshBoundTerm BoolTypeMap $ forallResult cr
+
     ------------------------------------------------------------------------
     -- Conversions.
 

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -341,6 +341,9 @@ appVerilogExpr app =
     ConstantArray _ _ _ -> doNotSupportError "arrays"
     UpdateArray _ _ _ _ _ -> doNotSupportError "arrays"
     SelectArray _ _ _ -> doNotSupportError "arrays"
+    CopyArray _ _ _ _ _ _ _ _ _ -> doNotSupportError "arrays"
+    SetArray _ _ _ _ _ _ _ -> doNotSupportError "arrays"
+    EqualArrayRange _ _ _ _ _ _ _ _ _ -> doNotSupportError "arrays"
 
     -- Conversions
     IntegerToReal _ -> doNotSupportError "integers"


### PR DESCRIPTION
The implementation supports single-dimensional arrays with bitvector indices. The encoding in SMTLib uses universal quantification, with Z3 the recommended solver. The operations are undefined if any of the index ranges wraps around.