### PR TITLE
Fix syntax errors in Verilog variable names

### DIFF
--- a/what4/src/What4/Protocol/VerilogWriter/ABCVerilog.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/ABCVerilog.hs
@@ -16,6 +16,7 @@ import Data.BitVector.Sized
 import Data.Parameterized.NatRepr
 import Data.Parameterized.Some
 import Data.String
+import qualified Data.Text as T
 import Data.Word
 import Prettyprinter
 import What4.BaseTypes
@@ -48,7 +49,7 @@ typeDoc ty isSigned (BaseBVRepr w) =
 typeDoc _ _ _ = "<type error>"
 
 identDoc :: Identifier -> Doc ()
-identDoc = pretty
+identDoc = pretty . T.replace "!" "_"
 
 lhsDoc :: LHS -> Doc ()
 lhsDoc (LHS name) = identDoc name


### PR DESCRIPTION
Variable names generated by `safeSymbol` can include exclamation marks.
Otherwise, they're guaranteed to be safe variable names in most
languages. Here, we replace `!` with `_` in any names before generating
the final Verilog text.