### PR TITLE
Special functions

### DIFF
--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -306,18 +306,7 @@ bitblastExpr h ae = do
     SemiRingLe  OrderedSemiRingRealRepr _ _ -> realFail
     RealDiv{} -> realFail
     RealSqrt{} -> realFail
-
-    --------------------------------------------------------------------
-    -- Operations that introduce irrational numbers.
-
-    Pi -> realFail
-    RealSin{} -> realFail
-    RealCos{} -> realFail
-    RealATan2{} -> realFail
-    RealSinh{} -> realFail
-    RealCosh{} -> realFail
-    RealExp{} -> realFail
-    RealLog{} -> realFail
+    RealSpecialFunction{} -> realFail
 
     --------------------------------------------------------------------
     -- Bitvector operations
@@ -487,6 +476,7 @@ bitblastExpr h ae = do
     FloatToSBV{} -> floatFail
     FloatToReal{} -> floatFail
     FloatToBinary{} -> floatFail
+    FloatSpecialFunction{} -> floatFail
 
     ------------------------------------------------------------------------
     -- Array operations
@@ -495,6 +485,9 @@ bitblastExpr h ae = do
     ConstantArray{} -> arrayFail
     SelectArray{} -> arrayFail
     UpdateArray{} -> arrayFail
+    CopyArray{} -> arrayFail
+    SetArray{} -> arrayFail
+    EqualArrayRange{} -> arrayFail
 
     ------------------------------------------------------------------------
     -- String operations

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -116,14 +116,7 @@ appTheory a0 =
 
     ----------------------------
     -- Computable number operations
-    Pi -> ComputableArithTheory
-    RealSin{}   -> ComputableArithTheory
-    RealCos{}   -> ComputableArithTheory
-    RealATan2{} -> ComputableArithTheory
-    RealSinh{}  -> ComputableArithTheory
-    RealCosh{}  -> ComputableArithTheory
-    RealExp{}   -> ComputableArithTheory
-    RealLog{}   -> ComputableArithTheory
+    RealSpecialFunction{} -> ComputableArithTheory
 
     ----------------------------
     -- Bitvector operations
@@ -178,6 +171,8 @@ appTheory a0 =
     FloatToBV{}       -> FloatingPointTheory
     FloatToSBV{}      -> FloatingPointTheory
     FloatToReal{}     -> FloatingPointTheory
+
+    FloatSpecialFunction{} -> ComputableArithTheory -- TODO? is this right?
 
     --------------------------------
     -- Conversions.

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -219,6 +219,7 @@ import           What4.IndexLit
 import           What4.ProgramLoc
 import           What4.Concrete
 import           What4.SatResult
+import           What4.SpecialFunctions
 import           What4.Symbol
 import           What4.Utils.AbstractDomains
 import           What4.Utils.Arithmetic
@@ -1857,52 +1858,44 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
   -- if @x@ is negative.
   realSqrt :: sym -> SymReal sym -> IO (SymReal sym)
 
-  -- | @realAtan2 sym y x@ returns the arctangent of @y/x@ with a range
-  -- of @-pi@ to @pi@; this corresponds to the angle between the positive
-  -- x-axis and the line from the origin @(x,y)@.
-  --
-  -- When @x@ is @0@ this returns @pi/2 * sgn y@.
-  --
-  -- When @x@ and @y@ are both zero, this function is undefined.
-  realAtan2 :: sym -> SymReal sym -> SymReal sym -> IO (SymReal sym)
-
   -- | Return value denoting pi.
   realPi :: sym -> IO (SymReal sym)
+  realPi sym = realSpecialFunction0 sym Pi
 
   -- | Natural logarithm.  @realLog x@ is undefined
   --   for @x <= 0@.
   realLog :: sym -> SymReal sym -> IO (SymReal sym)
+  realLog sym x = realSpecialFunction1 sym Log x
 
   -- | Natural exponentiation
   realExp :: sym -> SymReal sym -> IO (SymReal sym)
+  realExp sym x = realSpecialFunction1 sym Exp x
 
   -- | Sine trig function
   realSin :: sym -> SymReal sym -> IO (SymReal sym)
+  realSin sym x = realSpecialFunction1 sym Sin x
 
   -- | Cosine trig function
   realCos :: sym -> SymReal sym -> IO (SymReal sym)
+  realCos sym x = realSpecialFunction1 sym Cos x
 
   -- | Tangent trig function.  @realTan x@ is undefined
   --   when @cos x = 0@,  i.e., when @x = pi/2 + k*pi@ for
   --   some integer @k@.
   realTan :: sym -> SymReal sym -> IO (SymReal sym)
-  realTan sym x = do
-    sin_x <- realSin sym x
-    cos_x <- realCos sym x
-    realDiv sym sin_x cos_x
+  realTan sym x = realSpecialFunction1 sym Tan x
 
   -- | Hyperbolic sine
   realSinh :: sym -> SymReal sym -> IO (SymReal sym)
+  realSinh sym x = realSpecialFunction1 sym Sinh x
 
   -- | Hyperbolic cosine
   realCosh :: sym -> SymReal sym -> IO (SymReal sym)
+  realCosh sym x = realSpecialFunction1 sym Cosh x
 
   -- | Hyperbolic tangent
   realTanh :: sym -> SymReal sym -> IO (SymReal sym)
-  realTanh sym x = do
-    sinh_x <- realSinh sym x
-    cosh_x <- realCosh sym x
-    realDiv sym sinh_x cosh_x
+  realTanh sym x = realSpecialFunction1 sym Tanh x
 
   -- | Return absolute value of the real number.
   realAbs :: sym -> SymReal sym -> IO (SymReal sym)
@@ -1920,6 +1913,50 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
         x2 <- realSq sym x
         y2 <- realSq sym y
         realSqrt sym =<< realAdd sym x2 y2
+
+  -- | @realAtan2 sym y x@ returns the arctangent of @y/x@ with a range
+  -- of @-pi@ to @pi@; this corresponds to the angle between the positive
+  -- x-axis and the line from the origin @(x,y)@.
+  --
+  -- When @x@ is @0@ this returns @pi/2 * sgn y@.
+  --
+  -- When @x@ and @y@ are both zero, this function is undefined.
+  realAtan2 :: sym -> SymReal sym -> SymReal sym -> IO (SymReal sym)
+  realAtan2 sym y x = realSpecialFunction2 sym Arctan2 y x
+
+  -- | Apply a special function to real arguments
+  realSpecialFunction
+    :: sym
+    -> SpecialFunction args
+    -> Ctx.Assignment (SpecialFnArg (SymExpr sym) BaseRealType) args
+    -> IO (SymReal sym)
+
+  -- | Access a 0-arity special function constant
+  realSpecialFunction0
+    :: sym
+    -> SpecialFunction EmptyCtx
+    -> IO (SymReal sym)
+  realSpecialFunction0 sym fn =
+    realSpecialFunction sym fn Ctx.Empty
+
+  -- | Apply a 1-argument special function
+  realSpecialFunction1
+    :: sym
+    -> SpecialFunction (EmptyCtx ::> R)
+    -> SymReal sym
+    -> IO (SymReal sym)
+  realSpecialFunction1 sym fn x =
+    realSpecialFunction sym fn (Ctx.Empty Ctx.:> SpecialFnArg x)
+
+  -- | Apply a 2-argument special function
+  realSpecialFunction2
+    :: sym
+    -> SpecialFunction (EmptyCtx ::> R ::> R)
+    -> SymReal sym
+    -> SymReal sym
+    -> IO (SymReal sym)
+  realSpecialFunction2 sym fn x y =
+    realSpecialFunction sym fn (Ctx.Empty Ctx.:> SpecialFnArg x Ctx.:> SpecialFnArg y)
 
   ----------------------------------------------------------------------
   -- IEEE-754 floating-point operations
@@ -2256,6 +2293,14 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym)
     -> IO (SymBV sym w)
   -- | Convert a floating point number to a real number.
   floatToReal :: sym -> SymFloat sym fpp -> IO (SymReal sym)
+
+  -- | Apply a special function to floating-point arguments
+  floatSpecialFunction
+    :: sym
+    -> FloatPrecisionRepr fpp
+    -> SpecialFunction args
+    -> Ctx.Assignment (SpecialFnArg (SymExpr sym) (BaseFloatType fpp)) args
+    -> IO (SymFloat sym fpp)
 
   ----------------------------------------------------------------------
   -- Cplx operations

--- a/what4/src/What4/InterpretedFloatingPoint.hs
+++ b/what4/src/What4/InterpretedFloatingPoint.hs
@@ -46,6 +46,8 @@ import Data.Bits
 import Data.Hashable
 import Data.Kind
 import Data.Parameterized.Classes
+import Data.Parameterized.Context (Assignment, EmptyCtx, (::>))
+import qualified Data.Parameterized.Context as Ctx
 import Data.Parameterized.TH.GADT
 import Data.Ratio
 import Data.Word ( Word16, Word64 )
@@ -54,6 +56,7 @@ import Prettyprinter
 
 import What4.BaseTypes
 import What4.Interface
+import What4.SpecialFunctions
 
 -- | This data kind describes the types of floating-point formats.
 -- This consist of the standard IEEE 754-2008 binary floating point formats,
@@ -452,6 +455,44 @@ class IsExprBuilder sym => IsInterpretedFloatExprBuilder sym where
     -> IO (SymBV sym w)
   -- | Convert a floating point number to a real number.
   iFloatToReal :: sym -> SymInterpretedFloat sym fi -> IO (SymReal sym)
+
+  -- | Apply a special function to floating-point arguments
+  iFloatSpecialFunction
+    :: sym
+    -> FloatInfoRepr fi
+    -> SpecialFunction args
+    -> Assignment (SpecialFnArg (SymExpr sym) (SymInterpretedFloatType sym fi)) args
+    -> IO (SymInterpretedFloat sym fi)
+
+  -- | Access a 0-arity special function constant
+  iFloatSpecialFunction0
+    :: sym
+    -> FloatInfoRepr fi
+    -> SpecialFunction EmptyCtx
+    -> IO (SymInterpretedFloat sym fi)
+  iFloatSpecialFunction0 sym fi fn =
+    iFloatSpecialFunction sym fi fn Ctx.Empty
+
+  -- | Apply a 1-argument special function
+  iFloatSpecialFunction1
+    :: sym
+    -> FloatInfoRepr fi
+    -> SpecialFunction (EmptyCtx ::> R)
+    -> SymInterpretedFloat sym fi
+    -> IO (SymInterpretedFloat sym fi)
+  iFloatSpecialFunction1 sym fi fn x =
+    iFloatSpecialFunction sym fi fn (Ctx.Empty Ctx.:> SpecialFnArg x)
+
+  -- | Apply a 2-argument special function
+  iFloatSpecialFunction2
+    :: sym
+    -> FloatInfoRepr fi
+    -> SpecialFunction (EmptyCtx ::> R ::> R)
+    -> SymInterpretedFloat sym fi
+    -> SymInterpretedFloat sym fi
+    -> IO (SymInterpretedFloat sym fi)
+  iFloatSpecialFunction2 sym fi fn x y =
+    iFloatSpecialFunction sym fi fn (Ctx.Empty Ctx.:> SpecialFnArg x Ctx.:> SpecialFnArg y)
 
   -- | The associated BaseType representative of the floating point
   -- interpretation for each format.

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -549,9 +549,11 @@ instance SupportTermOps Term where
   realDiv x y = x SMT2../ [y]
   realSin = un_app "sin"
   realCos = un_app "cos"
+  realTan = un_app "tan"
   realATan2 = bin_app "atan2"
   realSinh = un_app "sinh"
   realCosh = un_app "cosh"
+  realTanh = un_app "tanh"
   realExp = un_app "exp"
   realLog = un_app "log"
 

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -429,17 +429,16 @@ class Num v => SupportTermOps v where
   realDiv :: v -> v -> v
 
   realSin :: v -> v
-
   realCos :: v -> v
+  realTan :: v -> v
 
   realATan2 :: v -> v -> v
 
   realSinh :: v -> v
-
   realCosh :: v -> v
+  realTanh :: v -> v
 
   realExp  :: v -> v
-
   realLog  :: v -> v
 
   -- | Apply the arguments to the given function.
@@ -2148,8 +2147,10 @@ appSMTExpr ae = do
       case fn of
         SFn.Sin  -> sf1 realSin  args
         SFn.Cos  -> sf1 realCos  args
+        SFn.Tan  -> sf1 realTan  args
         SFn.Sinh -> sf1 realSinh args
         SFn.Cosh -> sf1 realCosh args
+        SFn.Tanh -> sf1 realTanh args
         SFn.Exp  -> sf1 realExp  args
         SFn.Log  -> sf1 realLog  args
         SFn.Arctan2 ->

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -153,6 +153,7 @@ import           What4.ProblemFeatures
 import           What4.ProgramLoc
 import           What4.SatResult
 import qualified What4.SemiRing as SR
+import qualified What4.SpecialFunctions as SFn
 import           What4.Symbol
 import           What4.Utils.AbstractDomains
 import qualified What4.Utils.BVDomain as BVD
@@ -2136,37 +2137,28 @@ appSMTExpr ae = do
       addSideCondition "real sqrt" $ v .>= 0
       -- Return variable
       return nm
-    Pi -> do
-      unsupportedTerm i
-    RealSin xe -> do
+
+    RealSpecialFunction fn (SFn.SpecialFnArgs args) -> do
       checkComputableSupport i
-      x <- mkBaseExpr xe
-      freshBoundTerm RealTypeMap $ realSin x
-    RealCos xe -> do
-      checkComputableSupport i
-      x <- mkBaseExpr xe
-      freshBoundTerm RealTypeMap $ realCos x
-    RealATan2 xe ye -> do
-      checkComputableSupport i
-      x <- mkBaseExpr xe
-      y <- mkBaseExpr ye
-      freshBoundTerm RealTypeMap $ realATan2 x y
-    RealSinh xe -> do
-      checkComputableSupport i
-      x <- mkBaseExpr xe
-      freshBoundTerm RealTypeMap $ realSinh x
-    RealCosh xe -> do
-      checkComputableSupport i
-      x <- mkBaseExpr xe
-      freshBoundTerm RealTypeMap $ realCosh x
-    RealExp xe -> do
-      checkComputableSupport i
-      x <- mkBaseExpr xe
-      freshBoundTerm RealTypeMap $ realExp x
-    RealLog xe -> do
-      checkComputableSupport i
-      x <- mkBaseExpr xe
-      freshBoundTerm RealTypeMap $ realLog x
+      let sf1 :: (Term h -> Term h) ->
+                 Ctx.Assignment (SFn.SpecialFnArg (Expr t) BaseRealType) (Ctx.EmptyCtx Ctx.::> SFn.R) ->
+                 SMTCollector t h (SMTExpr h BaseRealType)
+          sf1 tmfn (Ctx.Empty Ctx.:> SFn.SpecialFnArg xe) =
+             freshBoundTerm RealTypeMap . tmfn =<< mkBaseExpr xe
+      case fn of
+        SFn.Sin  -> sf1 realSin  args
+        SFn.Cos  -> sf1 realCos  args
+        SFn.Sinh -> sf1 realSinh args
+        SFn.Cosh -> sf1 realCosh args
+        SFn.Exp  -> sf1 realExp  args
+        SFn.Log  -> sf1 realLog  args
+        SFn.Arctan2 ->
+          case args of
+            Ctx.Empty Ctx.:> SFn.SpecialFnArg ye Ctx.:> SFn.SpecialFnArg xe ->
+              do y <- mkBaseExpr ye
+                 x <- mkBaseExpr xe
+                 freshBoundTerm RealTypeMap $ realATan2 y x
+        _ -> unsupportedTerm i -- TODO? more functions?
 
     ------------------------------------------
     -- Bitvector operations
@@ -2510,6 +2502,7 @@ appSMTExpr ae = do
     FloatToReal x -> do
       xe <- mkBaseExpr x
       freshBoundTerm RealTypeMap $ floatToReal xe
+    FloatSpecialFunction{} -> unsupportedTerm i
 
     ------------------------------------------------------------------------
     -- Array Operations

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -192,16 +192,7 @@ appVerilogExpr app =
     RealSqrt _ -> doNotSupportError "real numbers"
 
     -- Irrational numbers
-    Pi -> doNotSupportError "real numbers"
-
-    RealSin _ -> doNotSupportError "real numbers"
-    RealCos _ -> doNotSupportError "real numbers"
-    RealATan2 _ _ -> doNotSupportError "real numbers"
-    RealSinh _ -> doNotSupportError "real numbers"
-    RealCosh _ -> doNotSupportError "real numbers"
-
-    RealExp _ -> doNotSupportError "real numbers"
-    RealLog _ -> doNotSupportError "real numbers"
+    RealSpecialFunction{} -> doNotSupportError "real numbers"
     RoundEvenReal _ -> doNotSupportError "real numbers"
 
     -- Bitvector operations
@@ -335,6 +326,7 @@ appVerilogExpr app =
     FloatToBV _ _ _ -> doNotSupportError "floats"
     FloatToSBV _ _ _ -> doNotSupportError "floats"
     FloatToReal _ -> doNotSupportError "floats"
+    FloatSpecialFunction _ _ _ -> doNotSupportError "floats"
 
     -- Array operations
     ArrayMap _ _ _ _ -> doNotSupportError "arrays"

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -279,9 +279,11 @@ instance SupportTermOps YicesTerm where
   realDiv x y = term_app "/" [x, y]
   realSin = errorComputableUnsupported
   realCos = errorComputableUnsupported
+  realTan = errorComputableUnsupported
   realATan2 = errorComputableUnsupported
   realSinh = errorComputableUnsupported
   realCosh = errorComputableUnsupported
+  realTanh = errorComputableUnsupported
   realExp = errorComputableUnsupported
   realLog = errorComputableUnsupported
 

--- a/what4/src/What4/SpecialFunctions.hs
+++ b/what4/src/What4/SpecialFunctions.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -30,15 +31,24 @@ Some popular constant values are also included.
 -}
 
 module What4.SpecialFunctions
-  ( SpecialFunction(..)
-  , specialFnArgs
+  ( R
+  , SpecialFunction(..)
+  , buildSpecialFnArgs
   , FunctionSymmetry(..)
   , specialFnSymmetry
+  , SpecialFnArg(..)
+  , traverseSpecialFnArg
+  , SpecialFnArgs(..)
+  , traverseSpecialFnArgs
   ) where
 
-import Data.Parameterized.Ctx
+import           Data.Kind (Type)
+import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
-import Data.Parameterized.Context ( pattern (:>) )
+import           Data.Parameterized.Context ( pattern (:>) )
+import           Data.Parameterized.Ctx
+import           Data.Parameterized.TH.GADT
+import           Data.Parameterized.TraversableFC
 
 data FunctionSymmetry r
   = NoSymmetry
@@ -46,187 +56,230 @@ data FunctionSymmetry r
   | OddFunction
  deriving (Show)
 
+data R
+
 -- | Data type for representing
-data SpecialFunction (r :: domain) (args :: Ctx domain) where
+data SpecialFunction (args :: Ctx Type) where
   -- constant values involving Pi
-  Pi       :: SpecialFunction r EmptyCtx -- pi
-  Pi_2     :: SpecialFunction r EmptyCtx -- pi/2
-  Pi_4     :: SpecialFunction r EmptyCtx -- pi/4
-  PiUnder1 :: SpecialFunction r EmptyCtx -- 1/pi
-  PiUnder2 :: SpecialFunction r EmptyCtx -- 2/pi
-  SqrtPiUnder2 :: SpecialFunction r EmptyCtx -- 2/sqrt(pi)
+  Pi             :: SpecialFunction EmptyCtx -- pi
+  HalfPi         :: SpecialFunction EmptyCtx -- pi/2
+  QuarterPi      :: SpecialFunction EmptyCtx -- pi/4
+  OneOverPi      :: SpecialFunction EmptyCtx -- 1/pi
+  TwoOverPi      :: SpecialFunction EmptyCtx -- 2/pi
+  TwoOverSqrt_Pi :: SpecialFunction EmptyCtx -- 2/sqrt(pi)
 
   -- constant root values
-  Sqrt2    :: SpecialFunction r EmptyCtx -- sqrt(2)
-  Sqrt1_2  :: SpecialFunction r EmptyCtx -- sqrt(1/2)
+  Sqrt_2         :: SpecialFunction EmptyCtx -- sqrt(2)
+  Sqrt_OneHalf   :: SpecialFunction EmptyCtx -- sqrt(1/2)
 
   -- constant values involving exponentials and logarithms
-  E       :: SpecialFunction r EmptyCtx  -- e = exp(1)
-  Log_2E  :: SpecialFunction r EmptyCtx  -- log_2(e)
-  Log_10E :: SpecialFunction r EmptyCtx  -- log_10(e)
-  Ln2     :: SpecialFunction r EmptyCtx  -- ln(2)
-  Ln10    :: SpecialFunction r EmptyCtx  -- ln(10)
+  E              :: SpecialFunction EmptyCtx  -- e = exp(1)
+  Log2_E         :: SpecialFunction EmptyCtx  -- log_2(e)
+  Log10_E        :: SpecialFunction EmptyCtx  -- log_10(e)
+  Ln_2           :: SpecialFunction EmptyCtx  -- ln(2)
+  Ln_10          :: SpecialFunction EmptyCtx  -- ln(10)
 
   -- circular trigonometry functions
-  Sin    :: SpecialFunction r (EmptyCtx ::> r) -- sin(x)
-  Cos    :: SpecialFunction r (EmptyCtx ::> r) -- cos(x)
-  Tan    :: SpecialFunction r (EmptyCtx ::> r) -- tan(x) = sin(x)/cos(x)
-  Arcsin :: SpecialFunction r (EmptyCtx ::> r) -- inverse sin
-  Arccos :: SpecialFunction r (EmptyCtx ::> r) -- inverse cos
-  Arctan :: SpecialFunction r (EmptyCtx ::> r) -- inverse tan
+  Sin    :: SpecialFunction (EmptyCtx ::> R) -- sin(x)
+  Cos    :: SpecialFunction (EmptyCtx ::> R) -- cos(x)
+  Tan    :: SpecialFunction (EmptyCtx ::> R) -- tan(x) = sin(x)/cos(x)
+  Arcsin :: SpecialFunction (EmptyCtx ::> R) -- inverse sin
+  Arccos :: SpecialFunction (EmptyCtx ::> R) -- inverse cos
+  Arctan :: SpecialFunction (EmptyCtx ::> R) -- inverse tan
 
   -- hyperbolic trigonometry functions
-  Sinh    :: SpecialFunction r (EmptyCtx ::> r) -- sinh(x) (hyperbolic sine)
-  Cosh    :: SpecialFunction r (EmptyCtx ::> r) -- cosh(x)
-  Tanh    :: SpecialFunction r (EmptyCtx ::> r) -- tanh(x)
-  Arcsinh :: SpecialFunction r (EmptyCtx ::> r) -- inverse sinh
-  Arccosh :: SpecialFunction r (EmptyCtx ::> r) -- inverse cosh
-  Arctanh :: SpecialFunction r (EmptyCtx ::> r) -- inverse tanh
+  Sinh    :: SpecialFunction (EmptyCtx ::> R) -- sinh(x) (hyperbolic sine)
+  Cosh    :: SpecialFunction (EmptyCtx ::> R) -- cosh(x)
+  Tanh    :: SpecialFunction (EmptyCtx ::> R) -- tanh(x)
+  Arcsinh :: SpecialFunction (EmptyCtx ::> R) -- inverse sinh
+  Arccosh :: SpecialFunction (EmptyCtx ::> R) -- inverse cosh
+  Arctanh :: SpecialFunction (EmptyCtx ::> R) -- inverse tanh
 
   -- rectangular to polar coordinate conversion
-  Hypot   :: SpecialFunction r (EmptyCtx ::> r ::> r) -- hypot(x,y) = sqrt(x^2 + y^2)
-  Arctan2 :: SpecialFunction r (EmptyCtx ::> r ::> r) -- atan2(y,x) = atan(y/x)
+  Hypot   :: SpecialFunction (EmptyCtx ::> R ::> R) -- hypot(x,y) = sqrt(x^2 + y^2)
+  Arctan2 :: SpecialFunction (EmptyCtx ::> R ::> R) -- atan2(y,x) = atan(y/x)
 
   -- natural exponential and logarithm
-  Exp     :: SpecialFunction r (EmptyCtx ::> r) -- exp(x)
-  Log     :: SpecialFunction r (EmptyCtx ::> r) -- ln(x)
-  Expm1   :: SpecialFunction r (EmptyCtx ::> r) -- exp(x) - 1
-  Log1p   :: SpecialFunction r (EmptyCtx ::> r) -- ln(1+x)
+  Exp     :: SpecialFunction (EmptyCtx ::> R) -- exp(x)
+  Log     :: SpecialFunction (EmptyCtx ::> R) -- ln(x)
+  Expm1   :: SpecialFunction (EmptyCtx ::> R) -- exp(x) - 1
+  Log1p   :: SpecialFunction (EmptyCtx ::> R) -- ln(1+x)
 
   -- base 2 exponential and logarithm
-  Exp_2   :: SpecialFunction r (EmptyCtx ::> r) -- 2^x
-  Log_2   :: SpecialFunction r (EmptyCtx ::> r) -- log_2(x)
+  Exp2    :: SpecialFunction (EmptyCtx ::> R) -- 2^x
+  Log2    :: SpecialFunction (EmptyCtx ::> R) -- log_2(x)
 
   -- base 10 exponential and logarithm
-  Exp_10  :: SpecialFunction r (EmptyCtx ::> r) -- 10^x
-  Log_10  :: SpecialFunction r (EmptyCtx ::> r) -- log_10(x)
+  Exp10   :: SpecialFunction (EmptyCtx ::> R) -- 10^x
+  Log10   :: SpecialFunction (EmptyCtx ::> R) -- log_10(x)
 
-instance Show (SpecialFunction r args) where
+instance Show (SpecialFunction args) where
   show fn = case fn of
-    Pi           -> "π"
-    Pi_2         -> "π/2"
-    Pi_4         -> "π/4"
-    PiUnder1     -> "1/π"
-    PiUnder2     -> "2/π"
-    SqrtPiUnder2 -> "2/sqrt(π)"
-    Sqrt2        -> "sqrt(2)"
-    Sqrt1_2      -> "sqrt(1/2)"
+    Pi             -> "pi"
+    HalfPi         -> "halfPi"
+    QuarterPi      -> "quaterPi"
+    OneOverPi      -> "oneOverPi"
+    TwoOverPi      -> "twoOverPi"
+    TwoOverSqrt_Pi -> "twoOverSqrt_Pi"
+    Sqrt_2         -> "sqrt_2"
+    Sqrt_OneHalf   -> "sqrt_oneHalf"
 
-    E            -> "e"
-    Log_2E       -> "log₂(e)"
-    Log_10E      -> "log₁₀(e)"
-    Ln2          -> "ln(2)"
-    Ln10         -> "ln(10)"
+    E              -> "e"
+    Log2_E         -> "log2_e"
+    Log10_E        -> "log10_e"
+    Ln_2           -> "ln_2"
+    Ln_10          -> "ln_10"
 
-    Sin          -> "sin"
-    Cos          -> "cos"
-    Tan          -> "tan"
-    Arcsin       -> "arcsin"
-    Arccos       -> "arccos"
-    Arctan       -> "arctan"
+    Sin            -> "sin"
+    Cos            -> "cos"
+    Tan            -> "tan"
+    Arcsin         -> "arcsin"
+    Arccos         -> "arccos"
+    Arctan         -> "arctan"
 
-    Sinh         -> "sinh"
-    Cosh         -> "cosh"
-    Tanh         -> "tanh"
-    Arcsinh      -> "arcsinh"
-    Arccosh      -> "arccosh"
-    Arctanh      -> "arctanh"
+    Sinh           -> "sinh"
+    Cosh           -> "cosh"
+    Tanh           -> "tanh"
+    Arcsinh        -> "arcsinh"
+    Arccosh        -> "arccosh"
+    Arctanh        -> "arctanh"
 
-    Hypot        -> "hypot"
-    Arctan2      -> "atan2"
+    Hypot          -> "hypot"
+    Arctan2        -> "atan2"
 
-    Exp          -> "exp"
-    Log          -> "ln"
-    Expm1        -> "expm1"
-    Log1p        -> "log1p"
-    Exp_2        -> "exp₂"
-    Log_2        -> "log₂"
-    Exp_10       -> "exp₁₀"
-    Log_10       -> "log₁₀"
+    Exp            -> "exp"
+    Log            -> "ln"
+    Expm1          -> "expm1"
+    Log1p          -> "log1p"
+    Exp2           -> "exp2"
+    Log2           -> "log2"
+    Exp10          -> "exp10"
+    Log10          -> "log10"
 
-specialFnSymmetry :: SpecialFunction r args -> Ctx.Assignment FunctionSymmetry args
+specialFnSymmetry :: SpecialFunction args -> Ctx.Assignment FunctionSymmetry args
 specialFnSymmetry fn = case fn of
-    Pi           -> Ctx.Empty
-    Pi_2         -> Ctx.Empty
-    Pi_4         -> Ctx.Empty
-    PiUnder1     -> Ctx.Empty
-    PiUnder2     -> Ctx.Empty
-    SqrtPiUnder2 -> Ctx.Empty
-    Sqrt2        -> Ctx.Empty
-    Sqrt1_2      -> Ctx.Empty
+    Pi             -> Ctx.Empty
+    HalfPi         -> Ctx.Empty
+    QuarterPi      -> Ctx.Empty
+    OneOverPi      -> Ctx.Empty
+    TwoOverPi      -> Ctx.Empty
+    TwoOverSqrt_Pi -> Ctx.Empty
+    Sqrt_2         -> Ctx.Empty
+    Sqrt_OneHalf   -> Ctx.Empty
+    E              -> Ctx.Empty
+    Log2_E         -> Ctx.Empty
+    Log10_E        -> Ctx.Empty
+    Ln_2           -> Ctx.Empty
+    Ln_10          -> Ctx.Empty
 
-    E            -> Ctx.Empty
-    Log_2E       -> Ctx.Empty
-    Log_10E      -> Ctx.Empty
-    Ln2          -> Ctx.Empty
-    Ln10         -> Ctx.Empty
+    Sin            -> Ctx.Empty :> OddFunction
+    Cos            -> Ctx.Empty :> EvenFunction
+    Tan            -> Ctx.Empty :> OddFunction
+    Arcsin         -> Ctx.Empty :> OddFunction
+    Arccos         -> Ctx.Empty :> NoSymmetry
+    Arctan         -> Ctx.Empty :> OddFunction
 
-    Sin          -> Ctx.Empty :> OddFunction
-    Cos          -> Ctx.Empty :> EvenFunction
-    Tan          -> Ctx.Empty :> OddFunction
-    Arcsin       -> Ctx.Empty :> OddFunction
-    Arccos       -> Ctx.Empty :> NoSymmetry
-    Arctan       -> Ctx.Empty :> OddFunction
+    Sinh           -> Ctx.Empty :> OddFunction
+    Cosh           -> Ctx.Empty :> EvenFunction
+    Tanh           -> Ctx.Empty :> OddFunction
+    Arcsinh        -> Ctx.Empty :> OddFunction
+    Arccosh        -> Ctx.Empty :> NoSymmetry -- TODO? is it actually even?
+    Arctanh        -> Ctx.Empty :> OddFunction
 
-    Sinh         -> Ctx.Empty :> OddFunction
-    Cosh         -> Ctx.Empty :> EvenFunction
-    Tanh         -> Ctx.Empty :> OddFunction
-    Arcsinh      -> Ctx.Empty :> OddFunction
-    Arccosh      -> Ctx.Empty :> NoSymmetry -- TODO? is it actually even?
-    Arctanh      -> Ctx.Empty :> OddFunction
+    Exp            -> Ctx.Empty :> NoSymmetry
+    Log            -> Ctx.Empty :> NoSymmetry
+    Expm1          -> Ctx.Empty :> NoSymmetry
+    Log1p          -> Ctx.Empty :> NoSymmetry
+    Exp2           -> Ctx.Empty :> NoSymmetry
+    Log2           -> Ctx.Empty :> NoSymmetry
+    Exp10          -> Ctx.Empty :> NoSymmetry
+    Log10          -> Ctx.Empty :> NoSymmetry
 
-    Exp          -> Ctx.Empty :> NoSymmetry
-    Log          -> Ctx.Empty :> NoSymmetry
-    Expm1        -> Ctx.Empty :> NoSymmetry
-    Log1p        -> Ctx.Empty :> NoSymmetry
-    Exp_2        -> Ctx.Empty :> NoSymmetry
-    Log_2        -> Ctx.Empty :> NoSymmetry
-    Exp_10       -> Ctx.Empty :> NoSymmetry
-    Log_10       -> Ctx.Empty :> NoSymmetry
-
-    Hypot        -> Ctx.Empty :> NoSymmetry :> NoSymmetry
-    Arctan2      -> Ctx.Empty :> NoSymmetry :> NoSymmetry -- TODO? is it actually odd in both arguments?
+    Hypot          -> Ctx.Empty :> NoSymmetry :> NoSymmetry
+    Arctan2        -> Ctx.Empty :> NoSymmetry :> NoSymmetry -- TODO? is it actually odd in both arguments?
 
 
-specialFnArgs :: f r -> SpecialFunction r args -> Ctx.Assignment f args
-specialFnArgs repr fn = case fn of
-    Pi           -> Ctx.Empty
-    Pi_2         -> Ctx.Empty
-    Pi_4         -> Ctx.Empty
-    PiUnder1     -> Ctx.Empty
-    PiUnder2     -> Ctx.Empty
-    SqrtPiUnder2 -> Ctx.Empty
-    Sqrt2        -> Ctx.Empty
-    Sqrt1_2      -> Ctx.Empty
+buildSpecialFnArgs :: f R -> SpecialFunction args -> Ctx.Assignment f args
+buildSpecialFnArgs repr fn = case fn of
+    Pi             -> Ctx.Empty
+    HalfPi         -> Ctx.Empty
+    QuarterPi      -> Ctx.Empty
+    OneOverPi      -> Ctx.Empty
+    TwoOverPi      -> Ctx.Empty
+    TwoOverSqrt_Pi -> Ctx.Empty
+    Sqrt_2         -> Ctx.Empty
+    Sqrt_OneHalf   -> Ctx.Empty
+    E              -> Ctx.Empty
+    Log2_E         -> Ctx.Empty
+    Log10_E        -> Ctx.Empty
+    Ln_2           -> Ctx.Empty
+    Ln_10          -> Ctx.Empty
 
-    E            -> Ctx.Empty
-    Log_2E       -> Ctx.Empty
-    Log_10E      -> Ctx.Empty
-    Ln2          -> Ctx.Empty
-    Ln10         -> Ctx.Empty
+    Sin            -> Ctx.Empty :> repr
+    Cos            -> Ctx.Empty :> repr
+    Tan            -> Ctx.Empty :> repr
+    Arcsin         -> Ctx.Empty :> repr
+    Arccos         -> Ctx.Empty :> repr
+    Arctan         -> Ctx.Empty :> repr
 
-    Sin          -> Ctx.Empty :> repr
-    Cos          -> Ctx.Empty :> repr
-    Tan          -> Ctx.Empty :> repr
-    Arcsin       -> Ctx.Empty :> repr
-    Arccos       -> Ctx.Empty :> repr
-    Arctan       -> Ctx.Empty :> repr
+    Sinh           -> Ctx.Empty :> repr
+    Cosh           -> Ctx.Empty :> repr
+    Tanh           -> Ctx.Empty :> repr
+    Arcsinh        -> Ctx.Empty :> repr
+    Arccosh        -> Ctx.Empty :> repr
+    Arctanh        -> Ctx.Empty :> repr
 
-    Sinh         -> Ctx.Empty :> repr
-    Cosh         -> Ctx.Empty :> repr
-    Tanh         -> Ctx.Empty :> repr
-    Arcsinh      -> Ctx.Empty :> repr
-    Arccosh      -> Ctx.Empty :> repr
-    Arctanh      -> Ctx.Empty :> repr
+    Exp            -> Ctx.Empty :> repr
+    Log            -> Ctx.Empty :> repr
+    Expm1          -> Ctx.Empty :> repr
+    Log1p          -> Ctx.Empty :> repr
+    Exp2           -> Ctx.Empty :> repr
+    Log2           -> Ctx.Empty :> repr
+    Exp10          -> Ctx.Empty :> repr
+    Log10          -> Ctx.Empty :> repr
 
-    Exp          -> Ctx.Empty :> repr
-    Log          -> Ctx.Empty :> repr
-    Expm1        -> Ctx.Empty :> repr
-    Log1p        -> Ctx.Empty :> repr
-    Exp_2        -> Ctx.Empty :> repr
-    Log_2        -> Ctx.Empty :> repr
-    Exp_10       -> Ctx.Empty :> repr
-    Log_10       -> Ctx.Empty :> repr
+    Hypot          -> Ctx.Empty :> repr :> repr
+    Arctan2        -> Ctx.Empty :> repr :> repr
 
-    Hypot        -> Ctx.Empty :> repr :> repr
-    Arctan2      -> Ctx.Empty :> repr :> repr
+
+data SpecialFnArg (e :: k -> Type) (tp::k) (r::Type) where
+  SpecialFnArg :: e tp -> SpecialFnArg e tp R
+
+newtype SpecialFnArgs (e :: k -> Type) (tp :: k) args =
+  SpecialFnArgs (Ctx.Assignment (SpecialFnArg e tp) args)
+
+$(return [])
+
+instance HashableF SpecialFunction where
+  hashWithSaltF = $(structuralHashWithSalt [t|SpecialFunction|] [])
+
+instance Hashable (SpecialFunction args) where
+  hashWithSalt = hashWithSaltF
+
+instance TestEquality SpecialFunction where
+  testEquality = $(structuralTypeEquality [t|SpecialFunction|] [])
+
+instance OrdF e => TestEquality (SpecialFnArg e tp) where
+  testEquality (SpecialFnArg x) (SpecialFnArg y) =
+    do Refl <- testEquality x y
+       return Refl
+
+instance HashableF e => HashableF (SpecialFnArg e tp) where
+  hashWithSaltF s (SpecialFnArg x) = hashWithSaltF s x
+
+traverseSpecialFnArg :: Applicative m =>
+  (e tp -> m (f tp)) ->
+  SpecialFnArg e tp r -> m (SpecialFnArg f tp r)
+traverseSpecialFnArg f (SpecialFnArg x) = SpecialFnArg <$> f x
+
+instance OrdF e => Eq (SpecialFnArgs e tp r) where
+  SpecialFnArgs xs == SpecialFnArgs ys = xs == ys
+
+instance HashableF e => Hashable (SpecialFnArgs e tp args) where
+  hashWithSalt s (SpecialFnArgs xs) = hashWithSaltF s xs
+
+traverseSpecialFnArgs :: Applicative m =>
+  (e tp -> m (f tp)) ->
+  SpecialFnArgs e tp r -> m (SpecialFnArgs f tp r)
+traverseSpecialFnArgs f (SpecialFnArgs xs) =
+  SpecialFnArgs <$> traverseFC (traverseSpecialFnArg f) xs

--- a/what4/src/What4/SpecialFunctions.hs
+++ b/what4/src/What4/SpecialFunctions.hs
@@ -31,15 +31,26 @@ Some popular constant values are also included.
 -}
 
 module What4.SpecialFunctions
-  ( R
+  ( -- * Representation of special functions
+    R
   , SpecialFunction(..)
-  , buildSpecialFnArgs
+
+    -- ** Symmetry properties of special functions
   , FunctionSymmetry(..)
   , specialFnSymmetry
+
+    -- ** Packaging arguments to special functions
   , SpecialFnArg(..)
   , traverseSpecialFnArg
   , SpecialFnArgs(..)
   , traverseSpecialFnArgs
+
+    -- ** Interval data for domain and range
+  , RealPoint(..)
+  , RealBound(..)
+  , RealInterval(..)
+  , specialFnDomain
+  , specialFnRange
   ) where
 
 import           Data.Kind (Type)
@@ -50,15 +61,36 @@ import           Data.Parameterized.Ctx
 import           Data.Parameterized.TH.GADT
 import           Data.Parameterized.TraversableFC
 
+-- | Some special functions exhibit useful symmetries in their arguments.
+--   A function @f@ is an odd function if @f(-x) = -f(x)@, and is even
+--   if @f(-x) = f(x)@.  We extend this notion to arguments of more than
+--   one function by saying that a function is even/odd in its @i@th
+--   argument if it is even/odd when the other arguments are fixed.
 data FunctionSymmetry r
   = NoSymmetry
   | EvenFunction
   | OddFunction
  deriving (Show)
 
+
+-- | Phantom data index representing the real number line.
+--   Used for specifying the arity of special functions.
 data R
 
--- | Data type for representing
+-- | Data type for representing \"special\" functions.
+--   These include functions from standard and hyperbolic
+--   trigonometry, exponential and logarithmic functions,
+--   as well as other well-known mathematical functions.
+--
+--   Generally, little solver support exists for such functions
+--   (although systems like dReal and Metatarski can prove some
+--   properties).  Nonetheless, we may have some information about
+--   specific values these functions take, the domains on which they
+--   are defined, or the range of values their outputs may take, or
+--   specific relationships that may exists between these functions
+--   (e.g., trig identities).  This information may, in some
+--   circumstances, be sufficent to prove properties of interest, even
+--   if the functions cannot be represented in their entirety.
 data SpecialFunction (args :: Ctx Type) where
   -- constant values involving Pi
   Pi             :: SpecialFunction EmptyCtx -- pi
@@ -156,6 +188,52 @@ instance Show (SpecialFunction args) where
     Exp10          -> "exp10"
     Log10          -> "log10"
 
+-- | Values that can appear in the definition of domain and
+--   range intervals for special functions.
+data RealPoint
+  = Zero
+  | NegOne
+  | PosOne
+  | NegInf
+  | PosInf
+  | NegPi
+  | PosPi
+  | NegHalfPi
+  | PosHalfPi
+
+instance Show RealPoint where
+  show Zero   = "0"
+  show NegOne = "-1"
+  show PosOne = "+1"
+  show NegInf = "-∞"
+  show PosInf = "+∞"
+  show NegPi  = "-π"
+  show PosPi  = "+π"
+  show NegHalfPi = "-π/2"
+  show PosHalfPi = "+π/2"
+
+-- | The endpoint of an interval, which may be inclusive or exclusive.
+data RealBound
+  = Incl RealPoint
+  | Excl RealPoint
+
+-- | An interval on real values, or a point.
+data RealInterval r where
+  RealPoint    :: SpecialFunction EmptyCtx -> RealInterval R
+  RealInterval :: RealBound -> RealBound -> RealInterval R
+
+instance Show (RealInterval r) where
+  show (RealPoint x) = show x
+  show (RealInterval lo hi) = lostr ++ ", " ++ histr
+    where
+      lostr = case lo of
+                Incl x -> "[" ++ show x
+                Excl x -> "(" ++ show x
+      histr = case hi of
+                Incl x -> show x ++ "]"
+                Excl x -> show x ++ ")"
+
+-- | Compute function symmetry information for the given special function.
 specialFnSymmetry :: SpecialFunction args -> Ctx.Assignment FunctionSymmetry args
 specialFnSymmetry fn = case fn of
     Pi             -> Ctx.Empty
@@ -183,7 +261,7 @@ specialFnSymmetry fn = case fn of
     Cosh           -> Ctx.Empty :> EvenFunction
     Tanh           -> Ctx.Empty :> OddFunction
     Arcsinh        -> Ctx.Empty :> OddFunction
-    Arccosh        -> Ctx.Empty :> NoSymmetry -- TODO? is it actually even?
+    Arccosh        -> Ctx.Empty :> NoSymmetry
     Arctanh        -> Ctx.Empty :> OddFunction
 
     Exp            -> Ctx.Empty :> NoSymmetry
@@ -195,12 +273,64 @@ specialFnSymmetry fn = case fn of
     Exp10          -> Ctx.Empty :> NoSymmetry
     Log10          -> Ctx.Empty :> NoSymmetry
 
-    Hypot          -> Ctx.Empty :> NoSymmetry :> NoSymmetry
-    Arctan2        -> Ctx.Empty :> NoSymmetry :> NoSymmetry -- TODO? is it actually odd in both arguments?
+    Hypot          -> Ctx.Empty :> EvenFunction :> EvenFunction
+    Arctan2        -> Ctx.Empty :> OddFunction :> NoSymmetry
 
 
-buildSpecialFnArgs :: f R -> SpecialFunction args -> Ctx.Assignment f args
-buildSpecialFnArgs repr fn = case fn of
+-- | Compute the range of values that may be returned by the given special function
+--   as its arguments take on the possible values of its domain.  This may include
+--   limiting values if the function's domain includes infinities; for example
+--   @exp(-inf) = 0@.
+specialFnRange :: SpecialFunction args -> RealInterval R
+specialFnRange fn = case fn of
+    Pi             -> RealPoint Pi
+    HalfPi         -> RealPoint HalfPi
+    QuarterPi      -> RealPoint QuarterPi
+    OneOverPi      -> RealPoint OneOverPi
+    TwoOverPi      -> RealPoint TwoOverPi
+    TwoOverSqrt_Pi -> RealPoint TwoOverSqrt_Pi
+    Sqrt_2         -> RealPoint Sqrt_2
+    Sqrt_OneHalf   -> RealPoint Sqrt_OneHalf
+    E              -> RealPoint E
+    Log2_E         -> RealPoint Log2_E
+    Log10_E        -> RealPoint Log10_E
+    Ln_2           -> RealPoint Ln_2
+    Ln_10          -> RealPoint Ln_10
+
+    Sin            -> RealInterval (Incl NegOne) (Incl PosOne)
+    Cos            -> RealInterval (Incl NegOne) (Incl PosOne)
+    Tan            -> RealInterval (Incl NegInf) (Incl PosInf)
+
+    Arcsin         -> RealInterval (Incl NegHalfPi) (Incl PosHalfPi)
+    Arccos         -> RealInterval (Incl Zero)      (Incl PosPi)
+    Arctan         -> RealInterval (Incl NegHalfPi) (Incl PosHalfPi)
+
+    Sinh           -> RealInterval (Incl NegInf) (Incl PosInf)
+    Cosh           -> RealInterval (Incl PosOne) (Incl PosInf)
+    Tanh           -> RealInterval (Incl NegOne) (Incl PosOne)
+    Arcsinh        -> RealInterval (Incl NegInf) (Incl PosInf)
+    Arccosh        -> RealInterval (Incl Zero)   (Incl PosInf)
+    Arctanh        -> RealInterval (Incl NegInf) (Incl PosInf)
+
+    Exp            -> RealInterval (Incl Zero)   (Incl PosInf)
+    Log            -> RealInterval (Incl NegInf) (Incl PosInf)
+    Expm1          -> RealInterval (Incl NegOne) (Incl PosInf)
+    Log1p          -> RealInterval (Incl NegInf) (Incl PosInf)
+    Exp2           -> RealInterval (Incl Zero)   (Incl PosInf)
+    Log2           -> RealInterval (Incl NegInf) (Incl PosInf)
+    Exp10          -> RealInterval (Incl Zero)   (Incl PosInf)
+    Log10          -> RealInterval (Incl NegInf) (Incl PosInf)
+
+    Hypot          -> RealInterval (Incl Zero) (Incl PosInf)
+    Arctan2        -> RealInterval (Incl NegPi) (Incl PosPi)
+
+
+-- | Compute the domain of the given special function.  As a mathematical
+--   entity, the value of the given function is not well-defined outside
+--   its domain. In floating-point terms, a special function will return
+--   a @NaN@ when evaluated on arguments outside its domain.
+specialFnDomain :: SpecialFunction args -> Ctx.Assignment RealInterval args
+specialFnDomain fn = case fn of
     Pi             -> Ctx.Empty
     HalfPi         -> Ctx.Empty
     QuarterPi      -> Ctx.Empty
@@ -215,36 +345,39 @@ buildSpecialFnArgs repr fn = case fn of
     Ln_2           -> Ctx.Empty
     Ln_10          -> Ctx.Empty
 
-    Sin            -> Ctx.Empty :> repr
-    Cos            -> Ctx.Empty :> repr
-    Tan            -> Ctx.Empty :> repr
-    Arcsin         -> Ctx.Empty :> repr
-    Arccos         -> Ctx.Empty :> repr
-    Arctan         -> Ctx.Empty :> repr
+    Sin            -> Ctx.Empty :> RealInterval (Excl NegInf) (Excl PosInf)
+    Cos            -> Ctx.Empty :> RealInterval (Excl NegInf) (Excl PosInf)
+    Tan            -> Ctx.Empty :> RealInterval (Excl NegInf) (Excl PosInf)
+    Arcsin         -> Ctx.Empty :> RealInterval (Incl NegOne) (Incl PosOne)
+    Arccos         -> Ctx.Empty :> RealInterval (Incl NegOne) (Incl PosOne)
+    Arctan         -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
 
-    Sinh           -> Ctx.Empty :> repr
-    Cosh           -> Ctx.Empty :> repr
-    Tanh           -> Ctx.Empty :> repr
-    Arcsinh        -> Ctx.Empty :> repr
-    Arccosh        -> Ctx.Empty :> repr
-    Arctanh        -> Ctx.Empty :> repr
+    Sinh           -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Cosh           -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Tanh           -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Arcsinh        -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Arccosh        -> Ctx.Empty :> RealInterval (Incl PosOne) (Incl PosInf)
+    Arctanh        -> Ctx.Empty :> RealInterval (Incl NegOne) (Incl PosOne)
 
-    Exp            -> Ctx.Empty :> repr
-    Log            -> Ctx.Empty :> repr
-    Expm1          -> Ctx.Empty :> repr
-    Log1p          -> Ctx.Empty :> repr
-    Exp2           -> Ctx.Empty :> repr
-    Log2           -> Ctx.Empty :> repr
-    Exp10          -> Ctx.Empty :> repr
-    Log10          -> Ctx.Empty :> repr
+    Exp            -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Log            -> Ctx.Empty :> RealInterval (Incl Zero)   (Incl PosInf)
+    Expm1          -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Log1p          -> Ctx.Empty :> RealInterval (Incl NegOne) (Incl PosInf)
+    Exp2           -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Log2           -> Ctx.Empty :> RealInterval (Incl Zero)   (Incl PosInf)
+    Exp10          -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+    Log10          -> Ctx.Empty :> RealInterval (Incl Zero)   (Incl PosInf)
 
-    Hypot          -> Ctx.Empty :> repr :> repr
-    Arctan2        -> Ctx.Empty :> repr :> repr
+    Hypot          -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+                                :> RealInterval (Incl NegInf) (Incl PosInf)
+    Arctan2        -> Ctx.Empty :> RealInterval (Incl NegInf) (Incl PosInf)
+                                :> RealInterval (Incl NegInf) (Incl PosInf)
 
-
+-- | Data type for wrapping the actual arguments to special functions.
 data SpecialFnArg (e :: k -> Type) (tp::k) (r::Type) where
   SpecialFnArg :: e tp -> SpecialFnArg e tp R
 
+-- | Data type for wrapping a collction of actual arguments to special functions.
 newtype SpecialFnArgs (e :: k -> Type) (tp :: k) args =
   SpecialFnArgs (Ctx.Assignment (SpecialFnArg e tp) args)
 
@@ -259,24 +392,40 @@ instance Hashable (SpecialFunction args) where
 instance TestEquality SpecialFunction where
   testEquality = $(structuralTypeEquality [t|SpecialFunction|] [])
 
+instance OrdF SpecialFunction where
+  compareF = $(structuralTypeOrd [t|SpecialFunction|] [])
+
+
 instance OrdF e => TestEquality (SpecialFnArg e tp) where
   testEquality (SpecialFnArg x) (SpecialFnArg y) =
     do Refl <- testEquality x y
        return Refl
 
+instance OrdF e => OrdF (SpecialFnArg e tp) where
+  compareF (SpecialFnArg x) (SpecialFnArg y) =
+    case compareF x y of
+      LTF -> LTF
+      EQF -> EQF
+      GTF -> GTF
+
 instance HashableF e => HashableF (SpecialFnArg e tp) where
   hashWithSaltF s (SpecialFnArg x) = hashWithSaltF s x
+
+
+instance OrdF e => Eq (SpecialFnArgs e tp r) where
+  SpecialFnArgs xs == SpecialFnArgs ys = xs == ys
+
+instance OrdF e => Ord (SpecialFnArgs e tp r) where
+  compare (SpecialFnArgs xs) (SpecialFnArgs ys) = compare xs ys
+
+instance HashableF e => Hashable (SpecialFnArgs e tp args) where
+  hashWithSalt s (SpecialFnArgs xs) = hashWithSaltF s xs
+
 
 traverseSpecialFnArg :: Applicative m =>
   (e tp -> m (f tp)) ->
   SpecialFnArg e tp r -> m (SpecialFnArg f tp r)
 traverseSpecialFnArg f (SpecialFnArg x) = SpecialFnArg <$> f x
-
-instance OrdF e => Eq (SpecialFnArgs e tp r) where
-  SpecialFnArgs xs == SpecialFnArgs ys = xs == ys
-
-instance HashableF e => Hashable (SpecialFnArgs e tp args) where
-  hashWithSalt s (SpecialFnArgs xs) = hashWithSaltF s xs
 
 traverseSpecialFnArgs :: Applicative m =>
   (e tp -> m (f tp)) ->

--- a/what4/src/What4/SpecialFunctions.hs
+++ b/what4/src/What4/SpecialFunctions.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-|
+Module           : What4.SpecialFunctions
+Description      : Utilities relating to special functions
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Rob Dockins <rdockins@galois.com>
+
+Utilties for representing and handling certain \"special\"
+functions arising from analysis. Although many of these
+functions are most properly understood as complex valued
+functions on complex arguments, here we are primarily interested
+in their restriction to real-valued functions or their
+floating-point approximations.
+
+The functions considered here include functions from
+standard and hyperbolic trigonometry, exponential
+and logarithmic functions, etc.  Some of these functions
+are defineable in terms of others (e.g. @tan(x) = sin(x)/cos(x)@
+or expm1(x) = exp(x) - 1@) but are commonly implemented
+separately in math libraries for increased precision.
+Some popular constant values are also included.
+-}
+
+module What4.SpecialFunctions
+  ( SpecialFunction(..)
+  , specialFnArgs
+  , FunctionSymmetry(..)
+  , specialFnSymmetry
+  ) where
+
+import Data.Parameterized.Ctx
+import qualified Data.Parameterized.Context as Ctx
+import Data.Parameterized.Context ( pattern (:>) )
+
+data FunctionSymmetry r
+  = NoSymmetry
+  | EvenFunction
+  | OddFunction
+ deriving (Show)
+
+-- | Data type for representing
+data SpecialFunction (r :: domain) (args :: Ctx domain) where
+  -- constant values involving Pi
+  Pi       :: SpecialFunction r EmptyCtx -- pi
+  Pi_2     :: SpecialFunction r EmptyCtx -- pi/2
+  Pi_4     :: SpecialFunction r EmptyCtx -- pi/4
+  PiUnder1 :: SpecialFunction r EmptyCtx -- 1/pi
+  PiUnder2 :: SpecialFunction r EmptyCtx -- 2/pi
+  SqrtPiUnder2 :: SpecialFunction r EmptyCtx -- 2/sqrt(pi)
+
+  -- constant root values
+  Sqrt2    :: SpecialFunction r EmptyCtx -- sqrt(2)
+  Sqrt1_2  :: SpecialFunction r EmptyCtx -- sqrt(1/2)
+
+  -- constant values involving exponentials and logarithms
+  E       :: SpecialFunction r EmptyCtx  -- e = exp(1)
+  Log_2E  :: SpecialFunction r EmptyCtx  -- log_2(e)
+  Log_10E :: SpecialFunction r EmptyCtx  -- log_10(e)
+  Ln2     :: SpecialFunction r EmptyCtx  -- ln(2)
+  Ln10    :: SpecialFunction r EmptyCtx  -- ln(10)
+
+  -- circular trigonometry functions
+  Sin    :: SpecialFunction r (EmptyCtx ::> r) -- sin(x)
+  Cos    :: SpecialFunction r (EmptyCtx ::> r) -- cos(x)
+  Tan    :: SpecialFunction r (EmptyCtx ::> r) -- tan(x) = sin(x)/cos(x)
+  Arcsin :: SpecialFunction r (EmptyCtx ::> r) -- inverse sin
+  Arccos :: SpecialFunction r (EmptyCtx ::> r) -- inverse cos
+  Arctan :: SpecialFunction r (EmptyCtx ::> r) -- inverse tan
+
+  -- hyperbolic trigonometry functions
+  Sinh    :: SpecialFunction r (EmptyCtx ::> r) -- sinh(x) (hyperbolic sine)
+  Cosh    :: SpecialFunction r (EmptyCtx ::> r) -- cosh(x)
+  Tanh    :: SpecialFunction r (EmptyCtx ::> r) -- tanh(x)
+  Arcsinh :: SpecialFunction r (EmptyCtx ::> r) -- inverse sinh
+  Arccosh :: SpecialFunction r (EmptyCtx ::> r) -- inverse cosh
+  Arctanh :: SpecialFunction r (EmptyCtx ::> r) -- inverse tanh
+
+  -- rectangular to polar coordinate conversion
+  Hypot   :: SpecialFunction r (EmptyCtx ::> r ::> r) -- hypot(x,y) = sqrt(x^2 + y^2)
+  Arctan2 :: SpecialFunction r (EmptyCtx ::> r ::> r) -- atan2(y,x) = atan(y/x)
+
+  -- natural exponential and logarithm
+  Exp     :: SpecialFunction r (EmptyCtx ::> r) -- exp(x)
+  Log     :: SpecialFunction r (EmptyCtx ::> r) -- ln(x)
+  Expm1   :: SpecialFunction r (EmptyCtx ::> r) -- exp(x) - 1
+  Log1p   :: SpecialFunction r (EmptyCtx ::> r) -- ln(1+x)
+
+  -- base 2 exponential and logarithm
+  Exp_2   :: SpecialFunction r (EmptyCtx ::> r) -- 2^x
+  Log_2   :: SpecialFunction r (EmptyCtx ::> r) -- log_2(x)
+
+  -- base 10 exponential and logarithm
+  Exp_10  :: SpecialFunction r (EmptyCtx ::> r) -- 10^x
+  Log_10  :: SpecialFunction r (EmptyCtx ::> r) -- log_10(x)
+
+instance Show (SpecialFunction r args) where
+  show fn = case fn of
+    Pi           -> "π"
+    Pi_2         -> "π/2"
+    Pi_4         -> "π/4"
+    PiUnder1     -> "1/π"
+    PiUnder2     -> "2/π"
+    SqrtPiUnder2 -> "2/sqrt(π)"
+    Sqrt2        -> "sqrt(2)"
+    Sqrt1_2      -> "sqrt(1/2)"
+
+    E            -> "e"
+    Log_2E       -> "log₂(e)"
+    Log_10E      -> "log₁₀(e)"
+    Ln2          -> "ln(2)"
+    Ln10         -> "ln(10)"
+
+    Sin          -> "sin"
+    Cos          -> "cos"
+    Tan          -> "tan"
+    Arcsin       -> "arcsin"
+    Arccos       -> "arccos"
+    Arctan       -> "arctan"
+
+    Sinh         -> "sinh"
+    Cosh         -> "cosh"
+    Tanh         -> "tanh"
+    Arcsinh      -> "arcsinh"
+    Arccosh      -> "arccosh"
+    Arctanh      -> "arctanh"
+
+    Hypot        -> "hypot"
+    Arctan2      -> "atan2"
+
+    Exp          -> "exp"
+    Log          -> "ln"
+    Expm1        -> "expm1"
+    Log1p        -> "log1p"
+    Exp_2        -> "exp₂"
+    Log_2        -> "log₂"
+    Exp_10       -> "exp₁₀"
+    Log_10       -> "log₁₀"
+
+specialFnSymmetry :: SpecialFunction r args -> Ctx.Assignment FunctionSymmetry args
+specialFnSymmetry fn = case fn of
+    Pi           -> Ctx.Empty
+    Pi_2         -> Ctx.Empty
+    Pi_4         -> Ctx.Empty
+    PiUnder1     -> Ctx.Empty
+    PiUnder2     -> Ctx.Empty
+    SqrtPiUnder2 -> Ctx.Empty
+    Sqrt2        -> Ctx.Empty
+    Sqrt1_2      -> Ctx.Empty
+
+    E            -> Ctx.Empty
+    Log_2E       -> Ctx.Empty
+    Log_10E      -> Ctx.Empty
+    Ln2          -> Ctx.Empty
+    Ln10         -> Ctx.Empty
+
+    Sin          -> Ctx.Empty :> OddFunction
+    Cos          -> Ctx.Empty :> EvenFunction
+    Tan          -> Ctx.Empty :> OddFunction
+    Arcsin       -> Ctx.Empty :> OddFunction
+    Arccos       -> Ctx.Empty :> NoSymmetry
+    Arctan       -> Ctx.Empty :> OddFunction
+
+    Sinh         -> Ctx.Empty :> OddFunction
+    Cosh         -> Ctx.Empty :> EvenFunction
+    Tanh         -> Ctx.Empty :> OddFunction
+    Arcsinh      -> Ctx.Empty :> OddFunction
+    Arccosh      -> Ctx.Empty :> NoSymmetry -- TODO? is it actually even?
+    Arctanh      -> Ctx.Empty :> OddFunction
+
+    Exp          -> Ctx.Empty :> NoSymmetry
+    Log          -> Ctx.Empty :> NoSymmetry
+    Expm1        -> Ctx.Empty :> NoSymmetry
+    Log1p        -> Ctx.Empty :> NoSymmetry
+    Exp_2        -> Ctx.Empty :> NoSymmetry
+    Log_2        -> Ctx.Empty :> NoSymmetry
+    Exp_10       -> Ctx.Empty :> NoSymmetry
+    Log_10       -> Ctx.Empty :> NoSymmetry
+
+    Hypot        -> Ctx.Empty :> NoSymmetry :> NoSymmetry
+    Arctan2      -> Ctx.Empty :> NoSymmetry :> NoSymmetry -- TODO? is it actually odd in both arguments?
+
+
+specialFnArgs :: f r -> SpecialFunction r args -> Ctx.Assignment f args
+specialFnArgs repr fn = case fn of
+    Pi           -> Ctx.Empty
+    Pi_2         -> Ctx.Empty
+    Pi_4         -> Ctx.Empty
+    PiUnder1     -> Ctx.Empty
+    PiUnder2     -> Ctx.Empty
+    SqrtPiUnder2 -> Ctx.Empty
+    Sqrt2        -> Ctx.Empty
+    Sqrt1_2      -> Ctx.Empty
+
+    E            -> Ctx.Empty
+    Log_2E       -> Ctx.Empty
+    Log_10E      -> Ctx.Empty
+    Ln2          -> Ctx.Empty
+    Ln10         -> Ctx.Empty
+
+    Sin          -> Ctx.Empty :> repr
+    Cos          -> Ctx.Empty :> repr
+    Tan          -> Ctx.Empty :> repr
+    Arcsin       -> Ctx.Empty :> repr
+    Arccos       -> Ctx.Empty :> repr
+    Arctan       -> Ctx.Empty :> repr
+
+    Sinh         -> Ctx.Empty :> repr
+    Cosh         -> Ctx.Empty :> repr
+    Tanh         -> Ctx.Empty :> repr
+    Arcsinh      -> Ctx.Empty :> repr
+    Arccosh      -> Ctx.Empty :> repr
+    Arctanh      -> Ctx.Empty :> repr
+
+    Exp          -> Ctx.Empty :> repr
+    Log          -> Ctx.Empty :> repr
+    Expm1        -> Ctx.Empty :> repr
+    Log1p        -> Ctx.Empty :> repr
+    Exp_2        -> Ctx.Empty :> repr
+    Log_2        -> Ctx.Empty :> repr
+    Exp_10       -> Ctx.Empty :> repr
+    Log_10       -> Ctx.Empty :> repr
+
+    Hypot        -> Ctx.Empty :> repr :> repr
+    Arctan2      -> Ctx.Empty :> repr :> repr

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -150,6 +150,7 @@ library
     What4.ProgramLoc
     What4.SatResult
     What4.SemiRing
+    What4.SpecialFunctions
     What4.Symbol
     What4.SFloat
     What4.SWord


### PR DESCRIPTION
Implement a uniform representation for special functions on real and floating-point values.  We still have very limited solver support for these functions, but this allows us to at least represent the majority of the operation appearing in, e.g., `math.h`.
