### PR TITLE
Add missing Foldable, Traversable, and Show instances for LabeledPred

### DIFF
--- a/what4/src/What4/LabeledPred.hs
+++ b/what4/src/What4/LabeledPred.hs
@@ -12,7 +12,9 @@
 ------------------------------------------------------------------------
 
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -47,7 +49,7 @@ data LabeledPred pred msg
        -- | Message added when assumption/assertion was made.
      , _labeledPredMsg :: !msg
      }
-   deriving (Eq, Data, Functor, Generic, Generic1, Ord, Typeable)
+   deriving (Eq, Data, Functor, Foldable, Generic, Generic1, Ord, Show, Traversable, Typeable)
 
 $(deriveBifunctor     ''LabeledPred)
 $(deriveBifoldable    ''LabeledPred)


### PR DESCRIPTION
`LabeledPred` already has `Bifoldable`, `Bitraversable`, and `Show{1,2}` instances, but for some reason, it does not have `Foldable`, `Traversable`, or `Show` instances. I believe this to be an oversight, which this patch corrects.