### PR TITLE
Minor fixes to `Atan2`, `Pow` handling in `realSpecialFunction`

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -3355,12 +3355,10 @@ instance IsExprBuilder (ExprBuilder t st fs) where
       Just yc <- asRational y =
         case fn of
           SFn.Arctan2
-            | yc == 0 -> realLit sym 0
-            | yc /= 0, sbFloatReduce sym ->
-              realLit sym (toRational (atan2 (toDouble xc) (toDouble yc)))
+            | sbFloatReduce sym -> realLit sym (toRational (atan2 (toDouble xc) (toDouble yc)))
           SFn.Pow
             | yc == 0 -> realLit sym 1
-            | yc /= 0, sbFloatReduce sym ->
+            | sbFloatReduce sym ->
               realLit sym (toRational (toDouble xc ** toDouble yc))
           _ -> sbMakeExpr sym (RealSpecialFunction fn (SFn.SpecialFnArgs args))
 


### PR DESCRIPTION
* As suggested in https://github.com/GaloisInc/what4/pull/163#discussion_r739389598, remove an unnecessary (and likely incorrect) special case for `Atan2`.
* Delete a redundant check that a value is non-zero in the `Pow` case.