### PR TITLE
Draft: Try bumping cache version (#169)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 # (e.g. cabal complains it can't find a valid version of the "happy"
 # tool).
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
 
 jobs:
   linux:


### PR DESCRIPTION
I'm not exactly sure why GHC wouldn't be able to find `libz.so`, but perhaps building everything from scratch will make a difference. See #169.