### PR TITLE
CI update to lock nix version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,17 +29,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v16
         name: Nix 20.09 base
         if: matrix.ghc != '9.0.1'
         with:
           nix_path: nixpkgs=channel:nixos-20.09
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v16
         name: Nix 21.05 base
         if: matrix.ghc == '9.0.1'
         with:
           nix_path: nixpkgs=channel:nixos-21.05
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v16
         name: Nix unstable base
         # if: matrix.ghc == '9.0.1'
         if: false  # not currently needed, but may be in the future

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,17 +34,20 @@ jobs:
         if: matrix.ghc != '9.0.1'
         with:
           nix_path: nixpkgs=channel:nixos-20.09
+          install_url: https://releases.nixos.org/nix/nix-2.4/install
       - uses: cachix/install-nix-action@v16
         name: Nix 21.05 base
         if: matrix.ghc == '9.0.1'
         with:
           nix_path: nixpkgs=channel:nixos-21.05
+          install_url: https://releases.nixos.org/nix/nix-2.4/install
       - uses: cachix/install-nix-action@v16
         name: Nix unstable base
         # if: matrix.ghc == '9.0.1'
         if: false  # not currently needed, but may be in the future
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.4/install
       - uses: actions/cache@v2
         name: Cache builds
         with:
@@ -65,7 +68,7 @@ jobs:
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           echo GHC=$GHC >> $GITHUB_ENV
           echo GHCPKGS=haskell.packages.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g) >> $GITHUB_ENV
-          echo ZLIB_LOC="$(nix eval --raw nixpkgs.zlib)/lib" >> $GITHUB_ENV
+          echo ZLIB_LOC="$(nix eval --raw nixpkgs#zlib)/lib" >> $GITHUB_ENV
           echo NS="nix-shell -p cabal-install $GHC gmp zlib --run" >> $GITHUB_ENV
 
       - name: Package's Cabal/GHC compatibility
@@ -110,11 +113,11 @@ jobs:
         shell: bash
         run: |
           cd what4
-          echo Boolector version $(nix eval nixpkgs.boolector.version)
-          echo CVC4 version $(nix eval nixpkgs.cvc4.version)
-          echo Yices version $(nix eval nixpkgs.yices.version)
-          echo Z3 version $(nix eval nixpkgs.z3.version)
-          echo STP version $(nix eval nixpkgs.z3.version)
+          echo Boolector version $(nix eval nixpkgs#boolector.version)
+          echo CVC4 version $(nix eval nixpkgs#cvc4.version)
+          echo Yices version $(nix eval nixpkgs#yices.version)
+          echo Z3 version $(nix eval nixpkgs#z3.version)
+          echo STP version $(nix eval nixpkgs#stp.version)
           nix-shell -p cabal-install $GHC abc-verifier boolector cvc4 stp yices z3 zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal test --extra-lib-dirs="$ZLIB_LOC"'
       - name: Documentation
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,20 @@ on:
   - push
   - pull_request
 
+# This CI configuration uses nix tooling to obtain the needed GHC and
+# cabal-install packages, as well as the external dependencies
+# (solvers, libz, libgmp, etc.).  The cabal + cabal project files
+# handle Haskell-level dependencies within the nix shell used for the
+# build.
+#
+# Variable aspects of this CI configuration:
+#
+# * GHC versions
+#   - specified in the strategy matrix
+#   - provided via nix: ensure the nix base and NIXPKGS used provide the requested GHC version
+# * nix tool version 2.4
+#   - all nix operations use new tool suite and cmdline interface (available in 2.4) instead of older format
+
 # The CACHE_VERSION can be updated to force the use of a new cache if
 # the current cache contents become corrupted/invalid.  This can
 # sometimes happen when (for example) the OS version is changed but

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 # (e.g. cabal complains it can't find a valid version of the "happy"
 # tool).
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
 
 jobs:
   linux:
@@ -29,25 +29,44 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v16
-        name: Nix 20.09 base
+
+      - name: Nix 20.09 base
         if: matrix.ghc != '9.0.1'
+        uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-20.09
           install_url: https://releases.nixos.org/nix/nix-2.4/install
-      - uses: cachix/install-nix-action@v16
-        name: Nix 21.05 base
+      - name: Nix 21.05 base
         if: matrix.ghc == '9.0.1'
+        uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-21.05
           install_url: https://releases.nixos.org/nix/nix-2.4/install
-      - uses: cachix/install-nix-action@v16
-        name: Nix unstable base
+      - name: Nix unstable base
         # if: matrix.ghc == '9.0.1'
         if: false  # not currently needed, but may be in the future
+        uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           install_url: https://releases.nixos.org/nix/nix-2.4/install
+
+      - name: Set GHC 9.0 nix base
+        if: matrix.ghc == '9.0.1'
+        run:
+          echo NIXPKGS=github:NixOS/nixpkgs/21.05 >> $GITHUB_ENV
+      - name: Set GHC 8.10.4 nix base
+        if: matrix.ghc == '8.10.4'
+        run:
+          echo NIXPKGS=github:NixOS/nixpkgs/21.05 >> $GITHUB_ENV
+      - name: Set GHC 8.x nix base
+        if: matrix.ghc != '9.0.1' && matrix.ghc != '8.10.4'
+        run:
+          echo NIXPKGS=github:NixOS/nixpkgs/20.09 >> $GITHUB_ENV
+      - name: Setup GHC ?? base
+        if: false  # not currently needed, but may be in the future
+        run:
+          echo NIXPKGS=github:NixOS/nixpkgs/nixos-unstable >> $GITHUB_ENV
+
       - uses: actions/cache@v2
         name: Cache builds
         with:
@@ -60,16 +79,18 @@ jobs:
             ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-${{ github.ref }}
           restore-keys: |
             ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-
-      - name: Cabal update
-        shell: bash
-        run: nix-shell -p cabal-install --run 'cabal update'
+
       - name: Setup Environment Vars
+        # Setup a nix shell environment command that will supply the
+        # appropriate GHC version as well as dependent libraries (and
+        # includes for zlib) as well as the cabal-install tool.
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
-          echo GHC=$GHC >> $GITHUB_ENV
-          echo GHCPKGS=haskell.packages.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g) >> $GITHUB_ENV
-          echo ZLIB_LOC="$(nix eval --raw nixpkgs#zlib)/lib" >> $GITHUB_ENV
-          echo NS="nix-shell -p cabal-install $GHC gmp zlib --run" >> $GITHUB_ENV
+          echo NS="nix shell github:nixos/nixpkgs/21.05#cabal-install ${NIXPKGS}#$GHC ${NIXPKGS}#gmp ${NIXPKGS}#zlib ${NIXPKGS}#zlib.dev" >> $GITHUB_ENV
+
+      - name: Cabal update
+        shell: bash
+        run: $NS -c cabal update
 
       - name: Package's Cabal/GHC compatibility
         shell: bash
@@ -83,7 +104,7 @@ jobs:
           defsetup()  { echo import Distribution.Simple; echo main = defaultMain; }
           setup_src() { if [ ! -f Setup.hs ] ; then defsetup > DefSetup.hs; fi; ls *Setup.hs; }
           setup_bin() { echo setup.${{ matrix.ghc }}; }
-          with_ghc()  { nix-shell -p $GHC --run "$(echo ${@})"; }
+          with_ghc()  { $NS -c ${@}; }
           (cd what4;     with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
           (cd what4-abc; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
           (cd what4-blt; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
@@ -91,36 +112,43 @@ jobs:
       - name: Cabal check
         shell: bash
         run: |
-          (cd what4;     $NS 'cabal check')
-          (cd what4-abc; $NS 'cabal check')
-          (cd what4-blt; $NS 'cabal check')
+          (cd what4;     $NS -c cabal check)
+          (cd what4-abc; $NS -c cabal check)
+          (cd what4-blt; $NS -c cabal check)
 
-      - name: Cabal configure
+      - name: Cabal configure what4
         shell: bash
-        # Note: the explicit LD_LIBRARY_PATH is needed for GHC 8.6.5
-        # which doesn't seem to process the --extra-lib-dirs
-        # correctly.  When only GHC 8.8 or later are supported, the
-        # LD_LIBRARY_PATH manipulation may be removed for all steps.
+        # Note: the extra-lib-dirs and extra-include-dirs specified on
+        # the command-line are placed at the top-level of the
+        # generated cabal.project.local, but only apply to the primary
+        # package.  The zlib dependency also needs these flags, so the
+        # following adds a zlib package-specific stanza for these.
         run: |
           cd what4
-          $NS 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal configure --enable-tests -fdRealTestDisable -fsolverTests --extra-lib-dirs="$ZLIB_LOC"'
+          $NS -c cabal configure --enable-tests -fdRealTestDisable -fsolverTests --extra-lib-dirs=$(nix eval --raw ${NIXPKGS}#zlib)/lib --extra-include-dirs=$(nix eval --raw ${NIXPKGS}#zlib.dev)/include
+          echo "" >> ../cabal.project.local
+          echo package zlib >> ../cabal.project.local
+          echo "  extra-lib-dirs: $(nix eval --raw ${NIXPKGS}#zlib)/lib" >> ../cabal.project.local
+          echo "  extra-include-dirs: $(nix eval --raw ${NIXPKGS}#zlib.dev)/include" >> ../cabal.project.local
+          cp ../cabal.project.local ./
+
       - name: Build
         shell: bash
         run: |
           cd what4
-          $NS 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal build --extra-lib-dirs="$ZLIB_LOC"'
+          $NS -c cabal build
       - name: Test
         shell: bash
         run: |
           cd what4
-          echo Boolector version $(nix eval nixpkgs#boolector.version)
-          echo CVC4 version $(nix eval nixpkgs#cvc4.version)
-          echo Yices version $(nix eval nixpkgs#yices.version)
-          echo Z3 version $(nix eval nixpkgs#z3.version)
-          echo STP version $(nix eval nixpkgs#stp.version)
-          nix-shell -p cabal-install $GHC abc-verifier boolector cvc4 stp yices z3 zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal test --extra-lib-dirs="$ZLIB_LOC"'
+          echo Boolector version $(nix eval ${NIXPKGS}#boolector.version)
+          echo CVC4 version $(nix eval ${NIXPKGS}#cvc4.version)
+          echo STP version $(nix eval ${NIXPKGS}#stp.version)
+          echo Yices version $(nix eval ${NIXPKGS}#yices.version)
+          echo Z3 version $(nix eval ${NIXPKGS}#z3.version)
+          $NS ${NIXPKGS}#abc-verifier ${NIXPKGS}#boolector ${NIXPKGS}#cvc4 ${NIXPKGS}#stp ${NIXPKGS}#yices ${NIXPKGS}#z3 -c cabal test
       - name: Documentation
         shell: bash
         run: |
           cd what4
-          nix-shell -p cabal-install $GHC zlib --run 'LD_LIBRARY_PATH="$ZLIB_LOC:$LD_LIBRARY_PATH" cabal haddock what4 --extra-lib-dirs="$ZLIB_LOC"'
+          $NS -c cabal haddock what4


### PR DESCRIPTION
Previous CI was just installing the latext nix version, which broke when switching from 2.3 to 2.4 due to cmdline syntax changes.

Also ensured that both library and includes for zlib package are present and available for the build process.

Switched to use newer nix commands and syntax, and use cabal.project.local file to ensure zlib installation can be utilized.