### PR TITLE
Allow building with `hashable-1.4.*`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,3 +1,14 @@
+# next (TBA)
+
+* Allow building with `hashable-1.4.*`:
+  * Add `Eq` instances for all data types with `Hashable` instances that
+    were missing corresponding `Eq` instances. This is required since
+    `hashable-1.4.0.0` adds an `Eq` superclass to `Hashable`.
+  * Some `Hashable` instances now have extra constraints to match the
+    constraints in their corresponding `Eq` instances. For example,
+    the `Hashable` instance for `SymNat` now has an extra `TestEquality`
+    constraint to match its `Eq` instance.
+
 # 1.2.1 (June 2021)
 
 * Include test suite data in the Hackage tarball.

--- a/what4/src/What4/BaseTypes.hs
+++ b/what4/src/What4/BaseTypes.hs
@@ -311,6 +311,8 @@ instance TestEquality BaseTypeRepr where
                      )
                    ]
                   )
+instance Eq (BaseTypeRepr bt) where
+  x == y = isJust (testEquality x y)
 
 instance OrdF BaseTypeRepr where
   compareF = $(structuralTypeOrd [t|BaseTypeRepr|]
@@ -328,6 +330,8 @@ instance TestEquality FloatPrecisionRepr where
   testEquality = $(structuralTypeEquality [t|FloatPrecisionRepr|]
       [(TypeApp (ConType [t|NatRepr|]) AnyType, [|testEquality|])]
     )
+instance Eq (FloatPrecisionRepr fpp) where
+  x == y = isJust (testEquality x y)
 instance OrdF FloatPrecisionRepr where
   compareF = $(structuralTypeOrd [t|FloatPrecisionRepr|]
       [(TypeApp (ConType [t|NatRepr|]) AnyType, [|compareF|])]
@@ -335,5 +339,7 @@ instance OrdF FloatPrecisionRepr where
 
 instance TestEquality StringInfoRepr where
   testEquality = $(structuralTypeEquality [t|StringInfoRepr|] [])
+instance Eq (StringInfoRepr si) where
+  x == y = isJust (testEquality x y)
 instance OrdF StringInfoRepr where
   compareF = $(structuralTypeOrd [t|StringInfoRepr|] [])

--- a/what4/src/What4/Expr/App.hs
+++ b/what4/src/What4/Expr/App.hs
@@ -937,7 +937,7 @@ instance TestEquality e => TestEquality (NonceApp t e) where
            ]
           )
 
-instance HashableF e => HashableF (NonceApp t e) where
+instance (HashableF e, TestEquality e) => HashableF (NonceApp t e) where
   hashWithSaltF = $(structuralHashWithSalt [t|NonceApp|]
                       [ (DataArg 1 `TypeApp` AnyType, [|hashWithSaltF|]) ])
 
@@ -1697,6 +1697,9 @@ asMatlabSolverFn f
   | MatlabSolverFnInfo g _ _ <- symFnInfo f = Just g
   | otherwise = Nothing
 
+
+instance Eq (ExprSymFn t args tp) where
+  x == y = isJust (testExprSymFnEq x y)
 
 instance Hashable (ExprSymFn t args tp) where
   hashWithSalt s f = s `hashWithSalt` symFnId f

--- a/what4/src/What4/Expr/ArrayUpdateMap.hs
+++ b/what4/src/What4/Expr/ArrayUpdateMap.hs
@@ -65,7 +65,7 @@ newtype ArrayUpdateMap e ctx tp =
 instance TestEquality e => Eq (ArrayUpdateMap e ctx tp) where
   ArrayUpdateMap m1 == ArrayUpdateMap m2 = AM.eqBy (\ x y -> isJust $ testEquality x y) m1 m2
 
-instance Hashable (ArrayUpdateMap e ctx tp) where
+instance TestEquality e => Hashable (ArrayUpdateMap e ctx tp) where
   hashWithSalt s (ArrayUpdateMap m) =
     case AM.annotation m of
       Nothing  -> hashWithSalt s (111::Int)

--- a/what4/src/What4/Expr/BoolMap.hs
+++ b/what4/src/What4/Expr/BoolMap.hs
@@ -63,7 +63,7 @@ instance TestEquality f => Eq (Wrap f x) where
   Wrap a == Wrap b = isJust $ testEquality a b
 instance OrdF f => Ord (Wrap f x) where
   compare (Wrap a) (Wrap b) = toOrdering $ compareF a b
-instance HashableF f => Hashable (Wrap f x) where
+instance (HashableF f, TestEquality f) => Hashable (Wrap f x) where
   hashWithSalt s (Wrap a) = hashWithSaltF s a
 
 -- | This data structure keeps track of a collection of expressions

--- a/what4/src/What4/Expr/MATLAB.hs
+++ b/what4/src/What4/Expr/MATLAB.hs
@@ -731,9 +731,13 @@ testSolverFnEq = $(structuralTypeEquality [t|MatlabSolverFn|]
                    ]
                   )
 
+instance TestEquality f => Eq (MatlabSolverFn f args tp) where
+  x == y = isJust (testSolverFnEq x y)
+
 instance ( Hashable (f BaseRealType)
          , Hashable (f BaseIntegerType)
          , HashableF f
+         , TestEquality f
          )
          => Hashable (MatlabSolverFn f args tp) where
   hashWithSalt = $(structuralHashWithSalt [t|MatlabSolverFn|] [])

--- a/what4/src/What4/Expr/StringSeq.hs
+++ b/what4/src/What4/Expr/StringSeq.hs
@@ -106,7 +106,7 @@ instance (TestEquality e, HasAbsValue e, HashableF e) => Eq (StringSeq e si) whe
 instance (HasAbsValue e, HashableF e) => HashableF (StringSeq e) where
   hashWithSaltF s (StringSeq _si xs) = hashWithSalt s (sft_hash xs)
 
-instance (HasAbsValue e, HashableF e) => Hashable (StringSeq e si) where
+instance (HasAbsValue e, HashableF e, TestEquality e) => Hashable (StringSeq e si) where
   hashWithSalt = hashWithSaltF
 
 singleton :: (HasAbsValue e, HashableF e, IsExpr e) => StringInfoRepr si -> e (BaseStringType si) -> StringSeq e si

--- a/what4/src/What4/Expr/UnaryBV.hs
+++ b/what4/src/What4/Expr/UnaryBV.hs
@@ -135,6 +135,8 @@ instance Eq p => TestEquality (UnaryBV p) where
       Just Refl
     else
       Nothing
+instance Eq p => Eq (UnaryBV p n) where
+  x == y = isJust (testEquality x y)
 
 instance Hashable p => Hashable (UnaryBV p n) where
   hashWithSalt s0 u = Map.foldlWithKey' go s0 (unaryBVMap u)

--- a/what4/src/What4/Expr/WeightedSum.hs
+++ b/what4/src/What4/Expr/WeightedSum.hs
@@ -166,7 +166,7 @@ instance OrdF f => Ord (WrapF f i) where
 instance TestEquality f => Eq (WrapF f i) where
   (WrapF x) == (WrapF y) = isJust $ testEquality x y
 
-instance HashableF f => Hashable (WrapF f i) where
+instance (HashableF f, TestEquality f) => Hashable (WrapF f i) where
   hashWithSalt s (WrapF x) = hashWithSaltF s x
 
 traverseWrap :: Functor m => (f (SR.SemiRingBase i) -> m (g (SR.SemiRingBase i))) -> WrapF f i -> m (WrapF g i)
@@ -303,6 +303,9 @@ instance OrdF f => TestEquality (SemiRingProduct f) where
            unless (AM.eqBy (SR.occ_eq (prodRepr x)) (_prodMap x) (_prodMap y)) Nothing
            return Refl
 
+instance OrdF f => Eq (SemiRingProduct f sr) where
+  x == y = isJust (testEquality x y)
+
 instance OrdF f => TestEquality (WeightedSum f) where
   testEquality x y
     | sumMapHash x /= sumMapHash y = Nothing
@@ -311,6 +314,9 @@ instance OrdF f => TestEquality (WeightedSum f) where
             unless (SR.eq (sumRepr x) (_sumOffset x) (_sumOffset y)) Nothing
             unless (AM.eqBy (SR.eq (sumRepr x)) (_sumMap x) (_sumMap y)) Nothing
             return Refl
+
+instance OrdF f => Eq (WeightedSum f sr) where
+  x == y = isJust (testEquality x y)
 
 
 -- | Created a weighted sum directly from a map and constant.

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -543,7 +543,7 @@ instance TestEquality (SymExpr sym) => Eq (SymNat sym) where
 instance OrdF (SymExpr sym) => Ord (SymNat sym) where
   compare (SymNat x) (SymNat y) = toOrdering (compareF x y)
 
-instance HashableF (SymExpr sym) => Hashable (SymNat sym) where
+instance (HashableF (SymExpr sym), TestEquality (SymExpr sym)) => Hashable (SymNat sym) where
   hashWithSalt s (SymNat x) = hashWithSaltF s x
 
 ------------------------------------------------------------------------

--- a/what4/src/What4/InterpretedFloatingPoint.hs
+++ b/what4/src/What4/InterpretedFloatingPoint.hs
@@ -107,6 +107,8 @@ instance ShowF FloatInfoRepr
 
 instance TestEquality FloatInfoRepr where
   testEquality = $(structuralTypeEquality [t|FloatInfoRepr|] [])
+instance Eq (FloatInfoRepr fi) where
+  x == y = isJust (testEquality x y)
 instance OrdF FloatInfoRepr where
   compareF = $(structuralTypeOrd [t|FloatInfoRepr|] [])
 

--- a/what4/src/What4/SemiRing.hs
+++ b/what4/src/What4/SemiRing.hs
@@ -233,9 +233,13 @@ $(return [])
 
 instance TestEquality BVFlavorRepr where
   testEquality = $(structuralTypeEquality [t|BVFlavorRepr|] [])
+instance Eq (BVFlavorRepr fv) where
+  x == y = isJust (testEquality x y)
 
 instance TestEquality OrderedSemiRingRepr where
   testEquality = $(structuralTypeEquality [t|OrderedSemiRingRepr|] [])
+instance Eq (OrderedSemiRingRepr sr) where
+  x == y = isJust (testEquality x y)
 
 instance TestEquality SemiRingRepr where
   testEquality =
@@ -243,6 +247,8 @@ instance TestEquality SemiRingRepr where
       [ (ConType [t|NatRepr|] `TypeApp` AnyType, [|testEquality|])
       , (ConType [t|BVFlavorRepr|] `TypeApp` AnyType, [|testEquality|])
       ])
+instance Eq (SemiRingRepr sr) where
+  x == y = isJust (testEquality x y)
 
 instance OrdF BVFlavorRepr where
   compareF = $(structuralTypeOrd [t|BVFlavorRepr|] [])

--- a/what4/src/What4/SpecialFunctions.hs
+++ b/what4/src/What4/SpecialFunctions.hs
@@ -398,6 +398,9 @@ instance Hashable (SpecialFunction args) where
 instance TestEquality SpecialFunction where
   testEquality = $(structuralTypeEquality [t|SpecialFunction|] [])
 
+instance Eq (SpecialFunction args) where
+  x == y = isJust (testEquality x y)
+
 instance OrdF SpecialFunction where
   compareF = $(structuralTypeOrd [t|SpecialFunction|] [])
 
@@ -424,7 +427,7 @@ instance OrdF e => Eq (SpecialFnArgs e tp r) where
 instance OrdF e => Ord (SpecialFnArgs e tp r) where
   compare (SpecialFnArgs xs) (SpecialFnArgs ys) = compare xs ys
 
-instance HashableF e => Hashable (SpecialFnArgs e tp args) where
+instance (HashableF e, OrdF e) => Hashable (SpecialFnArgs e tp args) where
   hashWithSalt s (SpecialFnArgs xs) = hashWithSaltF s xs
 
 

--- a/what4/src/What4/Utils/OnlyIntRepr.hs
+++ b/what4/src/What4/Utils/OnlyIntRepr.hs
@@ -25,6 +25,9 @@ data OnlyIntRepr tp
 instance TestEquality OnlyIntRepr where
   testEquality OnlyIntRepr OnlyIntRepr = Just Refl
 
+instance Eq (OnlyIntRepr tp) where
+  OnlyIntRepr == OnlyIntRepr = True
+
 instance Hashable (OnlyIntRepr tp) where
   hashWithSalt s OnlyIntRepr = s
 


### PR DESCRIPTION
This was prompted by GaloisInc/parameterized-utils#126, but the changes needed on `what4`'s end can be applied independently.