### PR TITLE
Fix solver versions

### DIFF
--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -73,7 +73,7 @@ solver(abc).
 main_version(ubuntu, "ubuntu-latest").
 main_version(ghc, "8.10.7").
 main_version(z3, "4_8_14").
-main_version(yices, "2_6").
+main_version(yices, "2_6_4").
 main_version(stp, "2_3_3").
 main_version(cvc4, "1_8").
 main_version(boolector, "3_2_2").
@@ -103,6 +103,7 @@ version(z3, "4_8_10").
 version(z3, "4_8_8").
 version(z3, "4_8_9").
 
+version(yices, "2_6_4").
 version(yices, "2_6_1").
 version(yices, "2_6").
 

--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -61,7 +61,7 @@ solver(boolector).
 solver(abc).
 
 %% Specify the main version of each variable (i.e. the most interesting value of that variable.
-main_version(ubuntu, ubuntu_latest).
+main_version(ubuntu, "ubuntu-latest").
 main_version(ghc, "8.10.7").
 main_version(z3, "4_8_14").
 main_version(yices, "2_6").
@@ -164,9 +164,10 @@ num_solver_versions(Solver, NumVer) :-
 nth_solver_version(Solver, N, Version) :-
     solver_alt_versions(Solver, Versions),
     (nth0(N, Versions, Version)
-     % Enable the following line to include other solvers at their
+     % Disable the following line to include only solvers with new
+     % versions.  When enabled, this specifies other solvers at their
      % main_version when there are no more alternate versions.
-     %% , !; main_version(Solver, Version)
+     , !; main_version(Solver, Version)
     ).
 
 solver_all_compiler_main(MatrixEntry) :-
@@ -180,7 +181,7 @@ solver_all_compiler_main(MatrixEntry) :-
             SolverSpec),
     compiler(Compiler), main_version(Compiler, CompilerVersion),
     os(OS), main_version(OS, OSVersion),
-    MatrixEntry = include{ os:[OSVersion] }
+    MatrixEntry = include{ os:OSVersion }
                   .put(Compiler, CompilerVersion)
                   .put(SolverSpec).
 

--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -1,0 +1,190 @@
+#!/usr/bin/env swipl
+
+%% This script is used to generate an output matrix (in JSON format)
+%% that the github actions can import and use to generate various test
+%% configurations.
+%%
+%% There are three main axes: os, compiler, and solver.  The os and
+%% compiler axis have a vector of versions, one or more of which
+%% should be designated as the main version.  The solver axis has a
+%% solver version vector for each defined solver, where again at least
+%% one of each should be designated as the main solver version.
+%%
+%% Adding versions or identifiers to any axis is done with a simple
+%% declarative statement in the first section below.
+%%
+%% The output matrix defines a more efficient selection of tests than
+%% a full cartesian product (because the latter would uselessly test
+%% many redundant configurations).
+%%
+%%  1. Test the main version of each solver on the code build with the
+%%     main version of the compiler, for each operating system
+%%     (solver_main_compiler_main).
+%%
+%%  2. Test the other versions of compiled code with the main version
+%%     of each solver, for each operating system
+%%     (solver_main_compiler_all).
+%%
+%%  3. Test the other versions of each solver on the main compiler
+%%     version of the code, for each operating system
+%%     (solver_all_compiler_main).  Note that the tests run against
+%%     each solver independently, but a test run will test all
+%%     available solvers (and skip any unavailable solvers), so the
+%%     most efficient matrix varies each solver version independently
+%%     (but in parallel) for each test run until all solver versions
+%%     are exhausted.
+%%
+%% This script can be run by hand to see the generated JSON output
+%% using SWI Prolog:
+%%
+%%    $ swipl .github/workflows/gen_matrix.pl
+
+:- initialization(main, main).
+:- use_module(library(http/json)).
+:- use_module(library(clpfd)).
+
+%% Declare every Operating System that should be tested (separately in
+%% sequence)
+os(ubuntu).
+
+%% Declare every Compiler that should be used to build the code
+%% (separately in sequence)
+compiler(ghc).
+
+%% Declare every Solver that should be used (in parallel, not in
+%% sequence: one version of every solver is chosen for each test.
+solver(z3).
+solver(yices).
+solver(stp).
+solver(cvc4).
+solver(boolector).
+solver(abc).
+
+%% Specify the main version of each variable (i.e. the most interesting value of that variable.
+main_version(ubuntu, ubuntu_latest).
+main_version(ghc, "8.10.7").
+main_version(z3, "4_8_14").
+main_version(yices, "2_6").
+main_version(stp, "2_3_3").
+main_version(cvc4, "1_8").
+main_version(boolector, "3_2_2").
+main_version(abc, "2021_12_30").
+
+%% Specify the versions of the operating system(s), along with the
+%% main version(s) that are of primary interest.
+version(ubuntu, ubuntu_latest).
+
+%% Specify the versions of the compiler(s), along with the main
+%% version that is of primary interest.
+version(ghc, "9.0.2").
+version(ghc, "8.10.7").
+version(ghc, "8.8.4").
+version(ghc, "8.6.5").
+
+version(z3, "4_8_8").
+version(z3, "4_8_9").
+version(z3, "4_8_10").
+version(z3, "4_8_11").
+version(z3, "4_8_12").
+version(z3, "4_8_13").
+version(z3, "4_8_14").
+
+version(yices, "2_6").
+version(yices, "2_6_1").
+
+version(stp, "2_3_3").
+version(stp, "2_3_2").
+% n.b. stp 2_2_0 fails, no reason to test it
+
+version(cvc4, "1_8").
+version(cvc4, "1_7").
+
+version(boolector, "3_2_2").
+version(boolector, "3_2_1").
+% n.b. boolector 3.1.0 builds fail; no reason to test it
+
+version(abc, "2021_12_30").
+version(abc, "2020_06_22").
+
+%% ----------------------------------------------------------------------
+%% No changes normally needed below
+
+matrix(Matrix) :-
+    findall(M, solver_main_compiler_main(M), MainMatrix),
+    findall(M,
+            ( solver_all_compiler_main(M)
+            ; solver_main_compiler_all(M)
+            ), AuxMatrix),
+    append(MainMatrix, AuxMatrix, FullMatrix),
+    Matrix = matrix{ include:FullMatrix }.
+
+main_solvers(Spec) :- findall(X, (solver(S), main_version(S, V) , X=S:V), Spec).
+
+solver_main_compiler_main(MatrixEntry) :-
+    main_solvers(Solvers),
+    compiler(Compiler),
+    main_version(Compiler, CompilerVersion),
+    os(OS), main_version(OS, OSVersion),
+    MatrixEntry = include{ os:OSVersion }
+                  .put(Compiler, CompilerVersion)
+                  .put(Solvers).
+
+solver_main_compiler_all(MatrixEntry) :-
+    main_solvers(Solvers),
+    compiler(Compiler),
+    version(Compiler, CompilerVersion),
+    \+ main_version(Compiler, CompilerVersion),
+    os(OS), main_version(OS, OSVersion),
+    MatrixEntry = include{ os:OSVersion }
+                  .put(Compiler, CompilerVersion)
+                  .put(Solvers).
+
+
+%% Need to check other solver versions.  It would be inefficient to
+%% test the cartesian product of solvers and versions because the
+%% solvers are used independently (i.e. z3 and yices are independent,
+%% so testing z3 4.8.4 only needs to be done once, not once for each
+%% version of yices.
+%%
+%% Also note that the tests will only run the solvers available to
+%% them.
+
+solver_alt_versions(Solver, Versions) :-
+    findall(V, (solver(Solver),
+                version(Solver, V),
+                \+ main_version(Solver, V)),
+            Versions).
+
+solvers(Solvers) :- findall(S, solver(S), Solvers).
+
+num_solver_versions(Solver, NumVer) :-
+    solver_alt_versions(Solver, Vs),
+    length(Vs, NumVer).
+
+nth_solver_version(Solver, N, Version) :-
+    solver_alt_versions(Solver, Versions),
+    (nth0(N, Versions, Version)
+     % Enable the following line to include other solvers at their
+     % main_version when there are no more alternate versions.
+     %% , !; main_version(Solver, Version)
+    ).
+
+solver_all_compiler_main(MatrixEntry) :-
+    solvers(Solvers), !,
+    maplist(num_solver_versions, Solvers, Cnt),
+    max_list(Cnt, M), L #= M - 1, N in 0..L, indomain(N),
+    findall(E,
+            (solver(S),
+             nth_solver_version(S, N, V),
+             E = S:V),
+            SolverSpec),
+    compiler(Compiler), main_version(Compiler, CompilerVersion),
+    os(OS), main_version(OS, OSVersion),
+    MatrixEntry = include{ os:[OSVersion] }
+                  .put(Compiler, CompilerVersion)
+                  .put(SolverSpec).
+
+
+main :-
+    matrix(Matrix),
+    json_write_dict(current_output, Matrix).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5]
         z3: [ 4_8_14 ]
         yices: [ 2_6 ]
-        allow-failure: [false]
+        allow-failure: [ false ]
         # Specify multiple older solver versions for the latest builds
         # to check backward compatibility.  These older solvers are
         # not simply added to the general matrix above to avoid
@@ -49,50 +49,62 @@ jobs:
             ghc: 9.0.2
             z3: 4_8_8
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_9
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_10
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_11
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_12
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_13
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_8
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_9
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_10
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_11
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_12
             yices: 2_5
+            allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_13
             yices: 2_5
+            allow-failure: false
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,254 +27,38 @@ env:
   CACHE_VERSION: 2
 
 jobs:
+  genmatrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-21.11
+          install_url: https://releases.nixos.org/nix/nix-2.4/install
+
+      - uses: cachix/cachix-action@v10
+        with:
+          name: galois
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - id: gen-matrix
+        run: |
+          echo ::set-output name=matrix::$(nix run nixpkgs#swiProlog -- .github/workflows/gen_matrix.pl)
+
   linux:
     name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} Boolector-${{ matrix.boolector }} ABC-${{ matrix.abc }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: genmatrix
     continue-on-error: ${{ matrix.allow-failure }}
     env:
       CI_TEST_LEVEL: "1"
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5]
-        z3: [ 4_8_14 ]
-        yices: [ 2_6 ]
-        stp: [ 2_3_3 ]
-        cvc4: [ 1_8 ]
-        boolector: [ 3_2_2 ]
-        abc: [ 2021_12_30 ]
-        allow-failure: [ false ]
-        # Specify multiple older solver versions for the latest builds
-        # to check backward compatibility.  These older solvers are
-        # not simply added to the general matrix above to avoid
-        # creating excessive numbers of repetitive jobs.
-        include:
-          ## GHC 9.0.2 ------------------------------
-          ### Z3 variations ----------
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            z3: 4_8_8
-            stp: 2_3_3
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_9
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_10
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_11
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_12
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_13
-            yices: 2_6
-            allow-failure: false
-          ### Yices variations ----------
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6_1
-            allow-failure: false
-            # Yices 2_5 fails: no reason to test it
-          ### CVC4 variations ----------
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_7
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-          ### STP variations ----------
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_7
-            stp: 2_3_2
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-            # STP 2_2_0 fails: no reason to test it
-          ### Boolector variations ----------
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_1
-            cvc4: 1_7
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-            # Boolector 3.1.0 builds fail: no reason to test it
-          ## GHC 8.10.7 ------------------------------
-          ### Z3 variations ----------
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_8
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_9
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_10
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_11
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_12
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_13
-            yices: 2_6
-            allow-failure: false
-          ### Yices variations ----------
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6_1
-            allow-failure: false
-            # Yices 2_5 fails: no reason to test it
-          ### CVC4 variations ----------
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_7
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-          ### STP variations ----------
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_7
-            stp: 2_3_2
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_7
-            stp: 2_3_1
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-            # STP 2_2_0 fails: no reason to test it
-          ### Boolector variations ----------
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_1
-            cvc4: 1_7
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_0
-            cvc4: 1_7
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
-            # Boolector 3.1.0 builds fail: no reason to test it
-          ### ABC variations ----------
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2020_06_22
-            boolector: 3_2_2
-            cvc4: 1_7
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_6
-            allow-failure: false
+      matrix: ${{fromJSON(needs.genmatrix.outputs.matrix)}}
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux:
-    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} ${{ matrix.os }}
+    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     env:
@@ -39,6 +39,7 @@ jobs:
         ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5]
         z3: [ 4_8_14 ]
         yices: [ 2_6 ]
+        cvc4: [ 1_8 ]
         allow-failure: [ false ]
         # Specify multiple older solver versions for the latest builds
         # to check backward compatibility.  These older solvers are
@@ -49,88 +50,118 @@ jobs:
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_8
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_9
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_10
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_11
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_12
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_13
             yices: 2_6
             allow-failure: false
           ### Yices variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_14
             yices: 2_6_1
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            cvc4: 1_8
             z3: 4_8_14
             yices: 2_5
             allow-failure: true
+          ### CVC4 variations ----------
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            cvc4: 1_7
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
           ## GHC 8.10.7 ------------------------------
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_8
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_9
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_10
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_11
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_12
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_13
             yices: 2_6
             allow-failure: false
           ### Yices variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_14
             yices: 2_6_1
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            cvc4: 1_8
             z3: 4_8_14
             yices: 2_5
             allow-failure: true
+          ### CVC4 variations ----------
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            cvc4: 1_7
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -230,11 +261,11 @@ jobs:
         run: |
           cd what4
           echo Boolector version $(nix eval nixpkgs#boolector.version)
-          echo CVC4 version $(nix eval nixpkgs#cvc4.version)
+          echo CVC4 version $(nix run github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} -- --version | head -n1)
           echo STP version $(nix eval nixpkgs#stp.version)
-          echo Yices version $(nix run github:GaloisInc/flakes#yices.v${{ matrix.yices }} -- --version)
-          echo Z3 version $(nix run github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -- --version)
-          $NS nixpkgs#abc-verifier nixpkgs#boolector nixpkgs#cvc4 nixpkgs#stp github:GaloisInc/flakes#yices.v${{ matrix.yices }} github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -c cabal test
+          echo Yices version $(nix run github:GaloisInc/flakes#yices.v${{ matrix.yices }} -- --version | head -n1)
+          echo Z3 version $(nix run github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -- --version | head -n1)
+          $NS nixpkgs#abc-verifier nixpkgs#boolector github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} nixpkgs#stp github:GaloisInc/flakes#yices.v${{ matrix.yices }} github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -c cabal test
 
       - name: Documentation
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,14 @@ jobs:
             z3: 4_8_14
             yices: 2_6
             allow-failure: false
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            boolector: 3_2_2
+            cvc4: 1_7
+            stp: 2_3_1
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
             # STP 2_2_0 fails: no reason to test it
           ### Boolector variations ----------
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,62 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5]
-        z3: [4_8_8, 4_8_9, 4_8_10, 4_8_11, 4_8_12, 4_8_13, 4_8_14]
-        yices: [ 2_6, 2_5 ];
+        z3: [ 4_8_14 ]
+        yices: [ 2_6 ]
         allow-failure: [false]
+        # Specify multiple older solver versions for the latest builds
+        # to check backward compatibility.  These older solvers are
+        # not simply added to the general matrix above to avoid
+        # creating excessive numbers of repetitive jobs.
+        include:
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_8
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_9
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_10
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_11
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_12
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_13
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_8
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_9
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_10
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_11
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_12
+            yices: 2_5
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_13
+            yices: 2_5
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,66 +45,92 @@ jobs:
         # not simply added to the general matrix above to avoid
         # creating excessive numbers of repetitive jobs.
         include:
+          ## GHC 9.0.2 ------------------------------
+          ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_8
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_9
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_10
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_11
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_12
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             z3: 4_8_13
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
+          ### Yices variations ----------
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_14
+            yices: 2_6_1
+            allow-failure: false
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            z3: 4_8_14
+            yices: 2_5
+            allow-failure: true
+          ## GHC 8.10.7 ------------------------------
+          ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_8
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_9
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_10
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_11
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_12
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             z3: 4_8_13
-            yices: 2_5
+            yices: 2_6
             allow-failure: false
+          ### Yices variations ----------
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_14
+            yices: 2_6_1
+            allow-failure: false
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            z3: 4_8_14
+            yices: 2_5
+            allow-failure: true
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux:
-    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} ${{ matrix.os }}
+    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} Boolector-${{ matrix.boolector }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     env:
@@ -41,6 +41,7 @@ jobs:
         yices: [ 2_6 ]
         stp: [ 2_3_3 ]
         cvc4: [ 1_8 ]
+        boolector: [ 3_2_2 ]
         allow-failure: [ false ]
         # Specify multiple older solver versions for the latest builds
         # to check backward compatibility.  These older solvers are
@@ -51,6 +52,7 @@ jobs:
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             z3: 4_8_8
             stp: 2_3_3
@@ -58,6 +60,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_9
@@ -65,6 +68,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_10
@@ -72,6 +76,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_11
@@ -79,6 +84,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_12
@@ -86,6 +92,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_13
@@ -94,6 +101,7 @@ jobs:
           ### Yices variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_14
@@ -101,6 +109,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_14
@@ -109,6 +118,7 @@ jobs:
           ### CVC4 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_3
             z3: 4_8_14
@@ -117,16 +127,28 @@ jobs:
           ### STP variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_2
             z3: 4_8_14
             yices: 2_6
             allow-failure: false
             # STP 2_2_0 fails: no reason to test it
+          ### Boolector variations ----------
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            boolector: 3_2_1
+            cvc4: 1_7
+            stp: 2_3_3
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
+            # Boolector 3.1.0 builds fail: no reason to test it
           ## GHC 8.10.7 ------------------------------
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_8
@@ -134,6 +156,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_9
@@ -141,6 +164,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_10
@@ -148,6 +172,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_11
@@ -155,6 +180,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_12
@@ -162,6 +188,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_13
@@ -170,6 +197,7 @@ jobs:
           ### Yices variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_14
@@ -177,6 +205,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
             z3: 4_8_14
@@ -185,6 +214,7 @@ jobs:
           ### CVC4 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_3
             z3: 4_8_14
@@ -193,12 +223,23 @@ jobs:
           ### STP variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_2
             z3: 4_8_14
             yices: 2_6
             allow-failure: false
             # STP 2_2_0 fails: no reason to test it
+          ### Boolector variations ----------
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            boolector: 3_2_1
+            cvc4: 1_7
+            stp: 2_3_3
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
+            # Boolector 3.1.0 builds fail: no reason to test it
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -297,12 +338,13 @@ jobs:
         shell: bash
         run: |
           cd what4
-          echo Boolector version $(nix eval nixpkgs#boolector.version)
+          echo Boolector version $(nix run github:GaloisInc/flakes#boolector.v${{ matrix.boolector }} -- --version | head -n1)
           echo CVC4 version $(nix run github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} -- --version | head -n1)
-          echo STP version $(nix run github:GaloisInc/flakes#stp.v${{ matrix.stp }} -- --version)
+          echo STP version $(nix run github:GaloisInc/flakes#stp.v${{ matrix.stp }} -- --version | head -n1)
           echo Yices version $(nix run github:GaloisInc/flakes#yices.v${{ matrix.yices }} -- --version | head -n1)
           echo Z3 version $(nix run github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -- --version | head -n1)
-          $NS nixpkgs#abc-verifier nixpkgs#boolector \
+          $NS nixpkgs#abc-verifier \
+            github:GaloisInc/flakes#boolector.v${{ matrix.boolector }} \
             github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} \
             github:GaloisInc/flakes#stp.v${{ matrix.stp }} \
             github:GaloisInc/flakes#yices.v${{ matrix.yices }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,15 +115,7 @@ jobs:
             z3: 4_8_14
             yices: 2_6_1
             allow-failure: false
-          - os: ubuntu-latest
-            ghc: 9.0.2
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_5
-            allow-failure: true
+            # Yices 2_5 fails: no reason to test it
           ### CVC4 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
@@ -222,15 +214,7 @@ jobs:
             z3: 4_8_14
             yices: 2_6_1
             allow-failure: false
-          - os: ubuntu-latest
-            ghc: 8.10.7
-            abc: 2021_12_30
-            boolector: 3_2_2
-            cvc4: 1_8
-            stp: 2_3_3
-            z3: 4_8_14
-            yices: 2_5
-            allow-failure: true
+            # Yices 2_5 fails: no reason to test it
           ### CVC4 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux:
-    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} Boolector-${{ matrix.boolector }} ${{ matrix.os }}
+    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} Boolector-${{ matrix.boolector }} ABC-${{ matrix.abc }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     env:
@@ -42,6 +42,7 @@ jobs:
         stp: [ 2_3_3 ]
         cvc4: [ 1_8 ]
         boolector: [ 3_2_2 ]
+        abc: [ 2021_12_30 ]
         allow-failure: [ false ]
         # Specify multiple older solver versions for the latest builds
         # to check backward compatibility.  These older solvers are
@@ -52,6 +53,7 @@ jobs:
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             z3: 4_8_8
@@ -60,6 +62,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -68,6 +71,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -76,6 +80,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -84,6 +89,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -92,6 +98,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -101,6 +108,7 @@ jobs:
           ### Yices variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -109,6 +117,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -118,6 +127,7 @@ jobs:
           ### CVC4 variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_3
@@ -127,6 +137,7 @@ jobs:
           ### STP variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_2
@@ -137,6 +148,7 @@ jobs:
           ### Boolector variations ----------
           - os: ubuntu-latest
             ghc: 9.0.2
+            abc: 2021_12_30
             boolector: 3_2_1
             cvc4: 1_7
             stp: 2_3_3
@@ -148,6 +160,7 @@ jobs:
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -156,6 +169,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -164,6 +178,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -172,6 +187,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -180,6 +196,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -188,6 +205,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -197,6 +215,7 @@ jobs:
           ### Yices variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -205,6 +224,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_8
             stp: 2_3_3
@@ -214,6 +234,7 @@ jobs:
           ### CVC4 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_3
@@ -223,6 +244,7 @@ jobs:
           ### STP variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_2
@@ -231,6 +253,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_2
             cvc4: 1_7
             stp: 2_3_1
@@ -241,6 +264,7 @@ jobs:
           ### Boolector variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_1
             cvc4: 1_7
             stp: 2_3_3
@@ -249,6 +273,7 @@ jobs:
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
+            abc: 2021_12_30
             boolector: 3_2_0
             cvc4: 1_7
             stp: 2_3_3
@@ -256,6 +281,16 @@ jobs:
             yices: 2_6
             allow-failure: false
             # Boolector 3.1.0 builds fail: no reason to test it
+          ### ABC variations ----------
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            abc: 2020_06_22
+            boolector: 3_2_2
+            cvc4: 1_7
+            stp: 2_3_3
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -354,12 +389,14 @@ jobs:
         shell: bash
         run: |
           cd what4
+          echo ABC version $(nix eval github:GaloisInc/flakes#abc.v${{ matrix.abc }}.version)
           echo Boolector version $(nix run github:GaloisInc/flakes#boolector.v${{ matrix.boolector }} -- --version | head -n1)
           echo CVC4 version $(nix run github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} -- --version | head -n1)
           echo STP version $(nix run github:GaloisInc/flakes#stp.v${{ matrix.stp }} -- --version | head -n1)
           echo Yices version $(nix run github:GaloisInc/flakes#yices.v${{ matrix.yices }} -- --version | head -n1)
           echo Z3 version $(nix run github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -- --version | head -n1)
-          $NS nixpkgs#abc-verifier \
+          $NS \
+            github:GaloisInc/flakes#abc.v${{ matrix.abc }} \
             github:GaloisInc/flakes#boolector.v${{ matrix.boolector }} \
             github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} \
             github:GaloisInc/flakes#stp.v${{ matrix.stp }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux:
-    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} ${{ matrix.os }}
+    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     env:
@@ -39,6 +39,7 @@ jobs:
         ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5]
         z3: [ 4_8_14 ]
         yices: [ 2_6 ]
+        stp: [ 2_3_3 ]
         cvc4: [ 1_8 ]
         allow-failure: [ false ]
         # Specify multiple older solver versions for the latest builds
@@ -52,35 +53,41 @@ jobs:
             ghc: 9.0.2
             cvc4: 1_8
             z3: 4_8_8
+            stp: 2_3_3
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_9
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_10
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_11
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_12
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_13
             yices: 2_6
             allow-failure: false
@@ -88,12 +95,14 @@ jobs:
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_14
             yices: 2_6_1
             allow-failure: false
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_14
             yices: 2_5
             allow-failure: true
@@ -101,44 +110,60 @@ jobs:
           - os: ubuntu-latest
             ghc: 9.0.2
             cvc4: 1_7
+            stp: 2_3_3
             z3: 4_8_14
             yices: 2_6
             allow-failure: false
+          ### STP variations ----------
+          - os: ubuntu-latest
+            ghc: 9.0.2
+            cvc4: 1_7
+            stp: 2_3_2
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
+            # STP 2_2_0 fails: no reason to test it
           ## GHC 8.10.7 ------------------------------
           ### Z3 variations ----------
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_8
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_9
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_10
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_11
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_12
             yices: 2_6
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_13
             yices: 2_6
             allow-failure: false
@@ -146,12 +171,14 @@ jobs:
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_14
             yices: 2_6_1
             allow-failure: false
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_8
+            stp: 2_3_3
             z3: 4_8_14
             yices: 2_5
             allow-failure: true
@@ -159,9 +186,19 @@ jobs:
           - os: ubuntu-latest
             ghc: 8.10.7
             cvc4: 1_7
+            stp: 2_3_3
             z3: 4_8_14
             yices: 2_6
             allow-failure: false
+          ### STP variations ----------
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            cvc4: 1_7
+            stp: 2_3_2
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
+            # STP 2_2_0 fails: no reason to test it
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -262,10 +299,15 @@ jobs:
           cd what4
           echo Boolector version $(nix eval nixpkgs#boolector.version)
           echo CVC4 version $(nix run github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} -- --version | head -n1)
-          echo STP version $(nix eval nixpkgs#stp.version)
+          echo STP version $(nix run github:GaloisInc/flakes#stp.v${{ matrix.stp }} -- --version)
           echo Yices version $(nix run github:GaloisInc/flakes#yices.v${{ matrix.yices }} -- --version | head -n1)
           echo Z3 version $(nix run github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -- --version | head -n1)
-          $NS nixpkgs#abc-verifier nixpkgs#boolector github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} nixpkgs#stp github:GaloisInc/flakes#yices.v${{ matrix.yices }} github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -c cabal test
+          $NS nixpkgs#abc-verifier nixpkgs#boolector \
+            github:GaloisInc/flakes#cvc4.v${{ matrix.cvc4 }} \
+            github:GaloisInc/flakes#stp.v${{ matrix.stp }} \
+            github:GaloisInc/flakes#yices.v${{ matrix.yices }} \
+            github:GaloisInc/flakes#z3.v${{ matrix.z3 }} \
+            -c cabal test
 
       - name: Documentation
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         os: [ubuntu-latest]
         ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5]
         z3: [4_8_8, 4_8_9, 4_8_10, 4_8_11, 4_8_12, 4_8_13, 4_8_14]
+        yices: [ 2_6, 2_5 ];
         allow-failure: [false]
       fail-fast: false
     steps:
@@ -140,9 +141,9 @@ jobs:
           echo Boolector version $(nix eval nixpkgs#boolector.version)
           echo CVC4 version $(nix eval nixpkgs#cvc4.version)
           echo STP version $(nix eval nixpkgs#stp.version)
-          echo Yices version $(nix eval nixpkgs#yices.version)
+          echo Yices version $(nix run github:GaloisInc/flakes#yices.v${{ matrix.yices }} -- --version)
           echo Z3 version $(nix run github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -- --version)
-          $NS nixpkgs#abc-verifier nixpkgs#boolector nixpkgs#cvc4 nixpkgs#stp nixpkgs#yices github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -c cabal test
+          $NS nixpkgs#abc-verifier nixpkgs#boolector nixpkgs#cvc4 nixpkgs#stp github:GaloisInc/flakes#yices.v${{ matrix.yices }} github:GaloisInc/flakes#z3.v${{ matrix.z3 }} -c cabal test
 
       - name: Documentation
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,6 +239,14 @@ jobs:
             z3: 4_8_14
             yices: 2_6
             allow-failure: false
+          - os: ubuntu-latest
+            ghc: 8.10.7
+            boolector: 3_2_0
+            cvc4: 1_7
+            stp: 2_3_3
+            z3: 4_8_14
+            yices: 2_6
+            allow-failure: false
             # Boolector 3.1.0 builds fail: no reason to test it
       fail-fast: false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux:
-    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} ${{ matrix.os }}
+    name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     name: GHC-${{ matrix.ghc }} Z3-${{ matrix.z3 }} Yices-${{ matrix.yices }} CVC4-${{ matrix.cvc4 }} STP-${{ matrix.stp }} Boolector-${{ matrix.boolector }} ABC-${{ matrix.abc }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: genmatrix
-    continue-on-error: ${{ matrix.allow-failure }}
+    continue-on-error: false
     env:
       CI_TEST_LEVEL: "1"
     strategy:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ views or policies of the Department of Defense or the U.S. Government.
 
 # Solver Compatibility
 
-| Feature                               | ABC | Boolector | CVC4        | Dreal | STP      | Yices    | Z3              |
-|---------------------------------------|-----|-----------|-------------|-------|----------|----------|-----------------|
-| Supported                             | yes | 3.2.2, ?  | >= 1.8, ? | yes   | 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
-| goal timeouts                         | ?   | yes       | yes         | ?     | yes      | yes      | ! 4.8.12        |
-| strings with unicode and escape codes | ?   | ?         | >= 1.8      | ?     | ?        | ?        | >= 4.8.12       |
+| Feature                               | ABC | Boolector   | CVC4      | Dreal | STP         | Yices    | Z3              |
+|---------------------------------------|-----|-------------|-----------|-------|-------------|----------|-----------------|
+| Supported                             | yes | >= 3.2.0, ? | >= 1.8, ? | yes   | >= 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
+| goal timeouts                         | ?   | yes         | yes       | ?     | yes         | yes      | ! 4.8.12        |
+| strings with unicode and escape codes | ?   | ?           | >= 1.8    | ?     | ?           | ?        | >= 4.8.12       |

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ views or policies of the Department of Defense or the U.S. Government.
 |---------------------------------------|-----|-------------|-----------|-------|-------------|----------|-----------------|
 | Supported                             | yes | >= 3.2.0, ? | >= 1.8, ? | yes   | >= 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
 | goal timeouts                         | ?   | yes         | yes       | ?     | yes         | yes      | ! 4.8.12        |
-| strings with unicode and escape codes | ?   | ?           | >= 1.8    | ?     | ?           | ?        | >= 4.8.12       |
+| strings with unicode and escape codes | ?   | ?           | >= 1.8    | ?     | ?           | ?        | >= 4.8.11       |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ views or policies of the Department of Defense or the U.S. Government.
 
 # Solver Compatibility
 
-| Feature                               | ABC | Boolector   | CVC4      | Dreal | STP         | Yices    | Z3              |
-|---------------------------------------|-----|-------------|-----------|-------|-------------|----------|-----------------|
-| Supported                             | yes | >= 3.2.0, ? | >= 1.8, ? | yes   | >= 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
-| goal timeouts                         | ?   | yes         | yes       | ?     | yes         | yes      | ! 4.8.12        |
-| strings with unicode and escape codes | ?   | ?           | >= 1.8    | ?     | ?           | ?        | >= 4.8.11       |
+| Feature                               | ABC | Boolector   | CVC4      | Dreal | STP         | Yices    | Z3                   |
+|---------------------------------------|-----|-------------|-----------|-------|-------------|----------|----------------------|
+| Supported                             | yes | >= 3.2.0, ? | >= 1.8, ? | yes   | >= 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14      |
+| goal timeouts                         | ?   | yes         | yes       | ?     | yes         | yes      | ! (4.8.11 or 4.8.12) |
+| strings with unicode and escape codes | ?   | ?           | >= 1.8    | ?     | ?           | ?        | >= 4.8.11            |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ views or policies of the Department of Defense or the U.S. Government.
 
 # Solver Compatibility
 
-| Feature                               | ABC | Boolector | CVC4   | Dreal | STP      | Yices    | Z3              |
-|---------------------------------------|-----|-----------|--------|-------|----------|----------|-----------------|
-| Supported                             | yes | 3.2.2, ?  | 1.8, ? | yes   | 2.3.3, ? | 2.6.4, ? | 4.8.8 -- 4.8.14 |
-| goal timeouts                         | ?   | yes       | yes    | ?     | yes      | yes      | ! 4.8.12        |
-| strings with unicode and escape codes | ?   | ?         | yes    | ?     | ?        | ?        | >= 4.8.12       |
+| Feature                               | ABC | Boolector | CVC4        | Dreal | STP      | Yices    | Z3              |
+|---------------------------------------|-----|-----------|-------------|-------|----------|----------|-----------------|
+| Supported                             | yes | 3.2.2, ?  | 1.7, 1.8, ? | yes   | 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
+| goal timeouts                         | ?   | yes       | yes         | ?     | yes      | yes      | ! 4.8.12        |
+| strings with unicode and escape codes | ?   | ?         | >= 1.8      | ?     | ?        | ?        | >= 4.8.12       |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ views or policies of the Department of Defense or the U.S. Government.
 
 | Feature                               | ABC | Boolector | CVC4        | Dreal | STP      | Yices    | Z3              |
 |---------------------------------------|-----|-----------|-------------|-------|----------|----------|-----------------|
-| Supported                             | yes | 3.2.2, ?  | 1.7, 1.8, ? | yes   | 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
+| Supported                             | yes | 3.2.2, ?  | >= 1.8, ? | yes   | 2.3.3, ? | 2.6.x, ? | 4.8.8 -- 4.8.14 |
 | goal timeouts                         | ?   | yes       | yes         | ?     | yes      | yes      | ! 4.8.12        |
 | strings with unicode and escape codes | ?   | ?         | >= 1.8      | ?     | ?        | ?        | >= 4.8.12       |

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1195,12 +1195,12 @@ main = do
   solvers <- reportSolverVersions testLevel id
              =<< (zip solverNames <$> mapM getSolverVersion solverNames)
   let z3Tests =
-        let skipPre4_8_11 why =
+        let skipPre4_8_12 why =
               let shouldSkip = case lookup (SolverName "z3") solvers of
-                    Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10" ]) $ words v
+                    Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10", "4.8.11" ]) $ words v
                     Nothing -> True
               in if shouldSkip then expectFailBecause why else id
-            unsuppStrings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.11"
+            incompatZ3Strings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.11"
         in
         [
           testUninterpretedFunctionScope
@@ -1224,7 +1224,7 @@ main = do
         , testCase "Z3 pair"    $ withOnlineZ3 pairTest
         , testCase "Z3 forall binder" $ withOnlineZ3 forallTest
 
-        , skipPre4_8_11 unsuppStrings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
+        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
         , testCase "Z3 string2" $ withOnlineZ3 stringTest2
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1195,9 +1195,9 @@ main = do
   solvers <- reportSolverVersions testLevel id
              =<< (zip solverNames <$> mapM getSolverVersion solverNames)
   let z3Tests =
-        let skipPre4_8_12 why =
+        let skipPre4_8_11 why =
               let shouldSkip = case lookup (SolverName "z3") solvers of
-                    Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10", "4.8.11" ]) $ words v
+                    Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10" ]) $ words v
                     Nothing -> True
               in if shouldSkip then expectFailBecause why else id
             incompatZ3Strings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.11"
@@ -1224,12 +1224,12 @@ main = do
         , testCase "Z3 pair"    $ withOnlineZ3 pairTest
         , testCase "Z3 forall binder" $ withOnlineZ3 forallTest
 
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
+        , skipPre4_8_11 incompatZ3Strings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
         , testCase "Z3 string2" $ withOnlineZ3 stringTest2
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string6" $ withOnlineZ3 stringTest6
+        , skipPre4_8_11 incompatZ3Strings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
+        , skipPre4_8_11 incompatZ3Strings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
+        , skipPre4_8_11 incompatZ3Strings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
+        , skipPre4_8_11 incompatZ3Strings $ testCase "Z3 string6" $ withOnlineZ3 stringTest6
           -- this test apparently passes on older Z3 despite the escaping changes...
         , testCase "Z3 string7" $ withOnlineZ3 stringTest7
 

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1034,12 +1034,12 @@ main = do
   solvers <- reportSolverVersions testLevel id
              =<< (zip solverNames <$> mapM getSolverVersion solverNames)
   let z3Tests =
-        let skipPre4_8_12 why =
+        let skipPre4_8_11 why =
               let shouldSkip = case lookup (SolverName "z3") solvers of
-                    Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10", "4.8.11" ]) $ words v
+                    Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10" ]) $ words v
                     Nothing -> True
               in if shouldSkip then expectFailBecause why else id
-            unsuppStrings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.12"
+            unsuppStrings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.11"
         in
         [
           testUninterpretedFunctionScope
@@ -1063,11 +1063,11 @@ main = do
         , testCase "Z3 pair"    $ withOnlineZ3 pairTest
         , testCase "Z3 forall binder" $ withOnlineZ3 forallTest
 
-        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
+        , skipPre4_8_11 unsuppStrings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
         , testCase "Z3 string2" $ withOnlineZ3 stringTest2
-        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
-        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
-        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
+        , skipPre4_8_11 unsuppStrings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
+        , skipPre4_8_11 unsuppStrings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
+        , skipPre4_8_11 unsuppStrings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
 
         , testCase "Z3 binder tuple1" $ withOnlineZ3 binderTupleTest1
         , testCase "Z3 binder tuple2" $ withOnlineZ3 binderTupleTest2

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1039,7 +1039,7 @@ main = do
                     Just (SolverVersion v) -> any (`elem` [ "4.8.8", "4.8.9", "4.8.10", "4.8.11" ]) $ words v
                     Nothing -> True
               in if shouldSkip then expectFailBecause why else id
-            incompatZ3Strings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.12"
+            unsuppStrings = "unicode and string escaping not supported for older Z3 versions; upgrade to at least 4.8.12"
         in
         [
           testUninterpretedFunctionScope
@@ -1063,11 +1063,11 @@ main = do
         , testCase "Z3 pair"    $ withOnlineZ3 pairTest
         , testCase "Z3 forall binder" $ withOnlineZ3 forallTest
 
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
+        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string1" $ withOnlineZ3 stringTest1
         , testCase "Z3 string2" $ withOnlineZ3 stringTest2
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
+        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
+        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
+        , skipPre4_8_12 unsuppStrings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
 
         , testCase "Z3 binder tuple1" $ withOnlineZ3 binderTupleTest1
         , testCase "Z3 binder tuple2" $ withOnlineZ3 binderTupleTest2
@@ -1081,6 +1081,13 @@ main = do
         , arrayCopySetTest
         ]
   let cvc4Tests =
+        let skipPre1_8 why =
+              let shouldSkip = case lookup (SolverName "cvc4") solvers of
+                    Just (SolverVersion v) -> any (`elem` [ "1.7" ]) $ words v
+                    Nothing -> True
+              in if shouldSkip then expectFailBecause why else id
+            unsuppStrings = "unicode and string escaping not supported for older CVC4 versions; upgrade to at least 1.8"
+        in
         [
           ignoreTestBecause "This test stalls the solver for some reason; line-buffering issue?" $
           testCase "CVC4 0-tuple" $ withCVC4 zeroTupleTest
@@ -1090,7 +1097,7 @@ main = do
 
         , testCase "CVC4 string1" $ withCVC4 stringTest1
         , testCase "CVC4 string2" $ withCVC4 stringTest2
-        , testCase "CVC4 string3" $ withCVC4 stringTest3
+        , skipPre1_8 unsuppStrings $ testCase "CVC4 string3" $ withCVC4 stringTest3
         , testCase "CVC4 string4" $ withCVC4 stringTest4
         , testCase "CVC4 string5" $ withCVC4 stringTest5
 

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1266,7 +1266,7 @@ main = do
         , skipPre1_8 unsuppStrings $ testCase "CVC4 string3" $ withCVC4 stringTest3
         , testCase "CVC4 string4" $ withCVC4 stringTest4
         , testCase "CVC4 string5" $ withCVC4 stringTest5
-        , testCase "CVC4 string6" $ withCVC4 stringTest6
+        , skipPre1_8 unsuppStrings $ testCase "CVC4 string6" $ withCVC4 stringTest6
         , testCase "CVC4 string7" $ withCVC4 stringTest7
 
         , testCase "CVC4 binder tuple1" $ withCVC4 binderTupleTest1

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -464,12 +464,13 @@ timeoutTests testLevel solvers =
            -- that timeout is reached (i.e. before the race timeout here).
            , let maybeRunTest =
                    case (testSolverName sti, sv) of
-                     -- Z3 4.8.12 goal-timeouts don't consistently
-                     -- work properly.  Occasionally it will abort but
-                     -- it generally seems to continue running and
-                     -- cannot be aborted by signals from the what4
-                     -- parent process.
-                     (SolverName "Z3", SolverVersion v)  | "4.8.12" `elem` words v->
+                     -- Z3 4.8.11 and 4.8.12 goal-timeouts don't
+                     -- consistently work properly.  Occasionally it
+                     -- will abort but it generally seems to continue
+                     -- running and cannot be aborted by signals from
+                     -- the what4 parent process.
+                     (SolverName "Z3", SolverVersion v)
+                       | any (`elem` ["4.8.11", "4.8.12"]) (words v) ->
                        expectFailBecause "goal timeouts feature not effective"
                      _ -> id
              in maybeRunTest $ testCase ("Test with goal timeout (" <> show testTimeout <> ")") $ do


### PR DESCRIPTION
Runs tests using various fixed versions of the supported solvers.

This now runs all tests against specific revisions of solvers, and will let us expand the set of revisions in the future as needed.  For many of the solvers, this also establishes a "lower limit" to the supported version; if it was important to show support for earlier versions of any of these solvers we could do so, but it would mean additional controls over which tests were run, and so that didn't seem worth it at the present time unless specific needs can be identified.

Overall, this will help us maintain a compatibility matrix and also identify any regressions that occur in the future.