### PR TITLE
Don't use `rationalTerm` when ground-evaluating integers

### DIFF
--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -3000,7 +3000,7 @@ smtIndicesTerms tps vals = Ctx.forIndexRange 0 sz f []
         f i l = (r:l)
          where GVW v = vals Ctx.! i
                r = case tps Ctx.! i of
-                      IntegerTypeMap -> rationalTerm (fromInteger v)
+                      IntegerTypeMap -> integerTerm v
                       BVTypeMap w -> bvTerm w v
                       _ -> error "Do not yet support other index types."
 


### PR DESCRIPTION
Doing so will cause the integers to be rendered with decimals (e.g., `0.0` instead of `0`). While some solvers are OK with such integers, CVC4 is picky and will reject integers with decimal places, as seen in #182. The fix is straightforward: just use `integerTerm` instead of `rationalTerm . fromInteger`.

Fixes #182.