### PR TITLE
Add `unsafeSetAbstractValue` and `resolveSymBV`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -30,6 +30,11 @@
     the `Hashable` instance for `SymNat` now has an extra `TestEquality`
     constraint to match its `Eq` instance.
 
+* Add an `unsafeSetAbstractValue` function to the `IsExpr` class which allows
+  one to manually set the `AbstractValue` used in a symbolic expression.
+  As the name suggests, this function is unsound in the general case, so use
+  this with caution.
+
 # 1.2.1 (June 2021)
 
 * Include test suite data in the Hackage tarball.

--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -35,6 +35,11 @@
   As the name suggests, this function is unsound in the general case, so use
   this with caution.
 
+* Add a `What4.Utils.ResolveBounds.BV` module, which provides a `resolveSymBV`
+  function that checks if a `SymBV` is concrete. If it is not concrete, it
+  returns the lower and upper version bounds, as determined by querying an
+  online SMT solver.
+
 # 1.2.1 (June 2021)
 
 * Include test suite data in the Hackage tarball.

--- a/what4/src/What4/Expr/App.hs
+++ b/what4/src/What4/Expr/App.hs
@@ -1100,6 +1100,16 @@ instance IsExpr (Expr t) where
 
   printSymExpr = pretty
 
+  unsafeSetAbstractValue av e =
+    case e of
+      SemiRingLiteral{} -> e
+      BoolExpr{}        -> e
+      FloatExpr{}       -> e
+      StringExpr{}      -> e
+      AppExpr ae        -> AppExpr (ae{appExprAbsValue = av})
+      NonceAppExpr nae  -> NonceAppExpr (nae{nonceExprAbsValue = av})
+      BoundVarExpr ebv  -> BoundVarExpr (ebv{bvarAbstractValue = Just av})
+
 
 asSemiRingLit :: SR.SemiRingRepr sr -> Expr t (SR.SemiRingBase sr) -> Maybe (SR.Coefficient sr)
 asSemiRingLit sr (SemiRingLiteral sr' x _loc)

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -378,6 +378,24 @@ class HasAbsValue e => IsExpr e where
   -- | Print a sym expression for debugging or display purposes.
   printSymExpr :: e tp -> Doc ann
 
+  -- | Set the abstract value of an expression. This is primarily useful for
+  -- symbolic expressions where the domain is known to be narrower than what
+  -- is contained in the expression. Setting the abstract value to use the
+  -- narrower domain can, in some cases, allow the expression to be further
+  -- simplified.
+  --
+  -- This is prefixed with @unsafe-@ because it has the potential to
+  -- introduce unsoundness if the new abstract value does not accurately
+  -- represent the domain of the expression. As such, the burden is on users
+  -- of this function to ensure that the new abstract value is used soundly.
+  --
+  -- Note that composing expressions together can sometimes widen the abstract
+  -- domains involved, so if you use this function to change an abstract value,
+  -- be careful than subsequent operations do not widen away the value. As a
+  -- potential safeguard, one can use 'annotateTerm' on the new expression to
+  -- inhibit transformations that could change the abstract value.
+  unsafeSetAbstractValue :: AbstractValue tp -> e tp -> e tp
+
 
 newtype ArrayResultWrapper f idx tp =
   ArrayResultWrapper { unwrapArrayResult :: f (BaseArrayType idx tp) }

--- a/what4/src/What4/Utils/ResolveBounds/BV.hs
+++ b/what4/src/What4/Utils/ResolveBounds/BV.hs
@@ -71,6 +71,14 @@ data SearchStrategy
     --   bounds of the search and 'BV.maxUnsigned' as the rightmost bounds of
     --   the search.
 
+  -- Some possibilities for additional search strategies include:
+  --
+  -- - Using Z3's minimize/maximize commands. See
+  --   https://github.com/GaloisInc/what4/issues/188
+  --
+  -- - A custom, user-specified strategy that uses callback(s) to guide the
+  --   search at each iteration.
+
 instance PP.Pretty SearchStrategy where
   pretty ExponentialSearch = PP.pretty "exponential search"
   pretty BinarySearch      = PP.pretty "binary search"

--- a/what4/src/What4/Utils/ResolveBounds/BV.hs
+++ b/what4/src/What4/Utils/ResolveBounds/BV.hs
@@ -1,0 +1,294 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-|
+Module           : What4.Utils.ResolveBounds.BV
+Description      : Resolve the lower and upper bounds of a SymBV
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Ryan Scott <rscott@galois.com>
+
+A utility for using an 'WPO.OnlineSolver' to query if a 'WI.SymBV' is concrete
+or symbolic, and if it is symbolic, what the lower and upper bounds are.
+-}
+module What4.Utils.ResolveBounds.BV
+  ( resolveSymBV
+  , ResolvedSymBV(..)
+  ) where
+
+import           Data.BitVector.Sized ( BV )
+import qualified Data.BitVector.Sized as BV
+import qualified Data.Parameterized.NatRepr as PN
+
+import qualified What4.Expr.Builder as WEB
+import qualified What4.Expr.GroundEval as WEG
+import qualified What4.Interface as WI
+import qualified What4.Protocol.Online as WPO
+import qualified What4.Protocol.SMTWriter as WPS
+import qualified What4.SatResult as WSat
+import qualified What4.Utils.BVDomain.Arith as WUBA
+
+-- | The results of an 'WPO.OnlineSolver' trying to resolve a 'WI.SymBV' as
+-- concrete.
+data ResolvedSymBV w
+  = BVConcrete (BV w)
+    -- ^ A concrete bitvector, including its value as a 'BV'.
+  | BVSymbolic (WUBA.Domain w)
+    -- ^ A symbolic 'SymBV', including its lower and upper bounds as a
+    --   'WUBA.Domain'.
+
+instance Show (ResolvedSymBV w) where
+  showsPrec _p res =
+    case res of
+      BVConcrete bv ->
+        showString "BVConcrete " . showsPrec 11 bv
+      BVSymbolic d  ->
+        let (lb, ub) = WUBA.ubounds d in
+          showString "BVSymbolic ["
+        . showsPrec 11 lb
+        . showString ", "
+        . showsPrec 11 ub
+        . showString "]"
+
+-- | Use an 'WPO.OnlineSolver' to attempt to resolve a 'WI.SymBV' as concrete.
+-- If it cannot, return the lower and upper bounds. This is primarly intended
+-- for compound expressions whose bounds cannot trivially be determined by
+-- using 'WI.signedBVBounds' or 'WI.unsignedBVBounds'.
+resolveSymBV ::
+     forall w sym solver scope st fs
+   . ( 1 PN.<= w
+     , sym ~ WEB.ExprBuilder scope st fs
+     , WPO.OnlineSolver solver
+     )
+  => sym
+  -> PN.NatRepr w
+  -> WPO.SolverProcess scope solver
+  -> WI.SymBV sym w
+  -> IO (ResolvedSymBV w)
+resolveSymBV sym w proc symBV =
+  -- First check, if the SymBV can be trivially resolved as concrete. If so,
+  -- this can avoid the need to call out to the solver at all.
+  case WI.asBV symBV of
+    Just bv -> pure $ BVConcrete bv
+    -- Otherwise, we need to consult the solver.
+    Nothing -> do
+      -- First, ask for a particular model of the SymBV...
+      modelForBV <- WPO.inNewFrame proc $ do
+        msat <- WPO.checkAndGetModel proc "resolveSymBV (check with initial assumptions)"
+        model <- case msat of
+          WSat.Unknown   -> failUnknown
+          WSat.Unsat{}   -> fail "resolveSymBV: Initial assumptions are unsatisfiable"
+          WSat.Sat model -> pure model
+        WEG.groundEval model symBV
+      -- ...next, check if this is the only possible model for this SymBV. We
+      -- do this by adding a blocking clause that assumes the SymBV is /not/
+      -- equal to the model we found in the previous step. If this is
+      -- unsatisfiable, the SymBV can only be equal to that model, so we can
+      -- conclude it is concrete. If it is satisfiable, on the other hand, the
+      -- SymBV can be multiple values, so it is truly symbolic.
+      isSymbolic <- WPO.inNewFrame proc $ do
+        block <- WI.notPred sym =<< WI.bvEq sym symBV =<< WI.bvLit sym w modelForBV
+        WPS.assume conn block
+        msat <- WPO.check proc "resolveSymBV (check under assumption that model cannot happen)"
+        case msat of
+          WSat.Unknown -> failUnknown
+          WSat.Sat{}   -> pure True  -- Truly symbolic
+          WSat.Unsat{} -> pure False -- Concrete
+      if isSymbolic
+        then do
+          -- If we have a truly symbolic SymBV, search for its lower and upper
+          -- bounds, using the model from the previous step as a starting point
+          -- for the search.
+          lowerBound <- computeLowerBoundExponential modelForBV
+          upperBound <- computeUpperBoundExponential modelForBV
+          pure $ BVSymbolic $ WUBA.range w (BV.asUnsigned lowerBound) (BV.asUnsigned upperBound)
+        else pure $ BVConcrete modelForBV
+  where
+    conn :: WPS.WriterConn scope solver
+    conn = WPO.solverConn proc
+
+    failUnknown :: forall a. IO a
+    failUnknown = fail "resolveSymBV: Resolving value yielded UNKNOWN"
+
+    bvOne :: BV w
+    bvOne = BV.one w
+
+    bvTwo :: BV w
+    bvTwo = BV.mkBV w 2
+
+    -- The general strategy for finding a bound is that we start searching
+    -- from a particular value known to be within bounds. At each step, we
+    -- change this value by exponentially increasing amount, then check if we
+    -- have exceeded the bound by using the solver. If so, we then fall back to
+    -- binary search to determine an exact bound. If we are within bounds, we
+    -- repeat the process.
+    --
+    -- As an example, let's suppose we having a symbolic value with bounds of
+    -- [0, 12], and we start searching for the upper bound at the value 1:
+    --
+    -- * In the first step, we add 1 to the starting value to get 2. We check
+    --   if two has exceeded the upper bound using the solver. This is not the
+    --   case, so we continue.
+    -- * In the second step, we add 2 to the starting value. The result, 3,
+    --   is within bounds.
+    -- * We continue like this in the third and fourth steps, except that
+    --   we add 4 and 8 to the starting value to get 5 and 9, respectively.
+    -- * In the fifth step, we add 16 to the starting value. The result, 17,
+    --   has exceeded the upper bound. We will now fall back to binary search,
+    --   using the previous result (9) as the leftmost bounds of the search and
+    --   the current result (17) as the rightmost bounds of the search.
+    -- * Eventually, binary search discovers that 12 is the upper bound.
+    --
+    -- Note that at each step, we must also check to make sure that the amount
+    -- to increase the starting value by does not cause a numeric overflow. If
+    -- this would be the case, we fall back to binary search, using
+    -- BV.maxUnsigned as the rightmost bounds of the search.
+    --
+    -- The process for finding a lower bound is quite similar, except that we
+    -- /subtract/ an exponentially increasing amount from the starting value
+    -- each time rather than adding it.
+
+    computeLowerBoundExponential :: BV w -> IO (BV w)
+    computeLowerBoundExponential start = go start bvOne
+      where
+        go :: BV w -> BV w -> IO (BV w)
+        go previouslyTried diff
+          | -- If the diff is larger than the starting value, then subtracting
+            -- the diff from the starting value would cause underflow. Instead,
+            -- just fall back to binary search, using 0 as the leftmost bounds
+            -- of the search.
+            start `BV.ult` diff
+          = computeLowerBoundBinary (BV.zero w) previouslyTried
+
+          | -- Otherwise, check if (start - diff) exceeds the lower bound for
+            -- the symBV.
+            otherwise
+          = do let nextToTry = BV.sub w start diff
+               exceedsLB <- checkExceedsLowerBound nextToTry
+               if |  -- If we have exceeded the lower bound, fall back to
+                     -- binary search.
+                     exceedsLB
+                  -> computeLowerBoundBinary nextToTry previouslyTried
+                  |  -- Make sure that (diff * 2) doesn't overflow. If it
+                     -- would, fall back to binary search.
+                     BV.asUnsigned diff * 2 > BV.asUnsigned (BV.maxUnsigned w)
+                  -> computeLowerBoundBinary (BV.zero w) nextToTry
+                  |  -- Otherwise, keep exponentially searching.
+                     otherwise
+                  -> go nextToTry $ BV.mul w diff bvTwo
+
+    -- Search for the upper bound of the SymBV. This function assumes the
+    -- following invariants:
+    --
+    -- * l <= r
+    --
+    -- * The lower bound of the SymBV is somewhere within the range [l, r].
+    --
+    -- * The r value is always within the domain of possible values of the
+    --   SymBV. The l value, on the other hand, may be strictly less than the
+    --   lower bound of the SymBV.
+    computeLowerBoundBinary :: BV w -> BV w -> IO (BV w)
+    computeLowerBoundBinary l r
+      | -- If the leftmost and rightmost bounds are the same, we are done.
+        l == r
+      = pure l
+
+      | -- If the leftmost and rightmost bounds of the search are 1 apart, we
+        -- only have two possible choices for the lower bound. Consult the
+        -- solver to determine which one is the lower bound.
+        BV.sub w r l < bvTwo
+      = do lExceedsLB <- checkExceedsLowerBound l
+           pure $ if lExceedsLB then r else l
+
+      | -- Otherwise, keep binary searching.
+        otherwise
+      = do let nextToTry = BV.mkBV w ((BV.asUnsigned l + BV.asUnsigned r) `div` 2)
+           exceedsLB <- checkExceedsLowerBound nextToTry
+           if exceedsLB
+             then computeLowerBoundBinary nextToTry r
+             else computeLowerBoundBinary l nextToTry
+
+    checkExceedsLowerBound :: BV w -> IO Bool
+    checkExceedsLowerBound bv = WPO.inNewFrame proc $ do
+      leLowerBound <- WI.bvUle sym symBV =<< WI.bvLit sym w bv
+      WPS.assume conn leLowerBound
+      msat <- WPO.check proc "resolveSymBV (check if lower bound has been exceeded)"
+      case msat of
+        WSat.Unknown -> failUnknown
+        WSat.Sat{}   -> pure False
+        WSat.Unsat{} -> pure True -- symBV cannot be <= this value,
+                                  -- so the value must be strictly
+                                  -- less than the lower bound.
+
+    computeUpperBoundExponential :: BV w -> IO (BV w)
+    computeUpperBoundExponential start = go start bvOne
+      where
+        go :: BV w -> BV w -> IO (BV w)
+        go previouslyTried diff
+          | -- Make sure that adding the diff to the starting value will not
+            -- result in overflow. If it would, just fall back to binary
+            -- search, using BV.maxUnsigned as the rightmost bounds of the
+            -- search.
+            BV.asUnsigned start + BV.asUnsigned diff > BV.asUnsigned (BV.maxUnsigned w)
+          = computeUpperBoundBinary previouslyTried (BV.maxUnsigned w)
+
+          | otherwise
+          = do let nextToTry = BV.add w start diff
+               exceedsUB <- checkExceedsUpperBound nextToTry
+               if |  -- If we have exceeded the upper bound, fall back to
+                     -- binary search.
+                     exceedsUB
+                  -> computeUpperBoundBinary previouslyTried nextToTry
+                  |  -- Make sure that (diff * 2) doesn't overflow. If it
+                     -- would, fall back to binary search.
+                     BV.asUnsigned diff * 2 > BV.asUnsigned (BV.maxUnsigned w)
+                  -> computeUpperBoundBinary nextToTry (BV.maxUnsigned w)
+                  |  -- Otherwise, keep exponentially searching.
+                     otherwise
+                  -> go nextToTry $ BV.mul w diff bvTwo
+
+    -- Search for the upper bound of the SymBV. This function assumes the
+    -- following invariants:
+    --
+    -- * l <= r
+    --
+    -- * The upper bound of the SymBV is somewhere within the range [l, r].
+    --
+    -- * The l value is always within the domain of possible values of the
+    --   SymBV. The r value, on the other hand, may be strictly greater than the
+    --   upper bound of the SymBV.
+    computeUpperBoundBinary :: BV w -> BV w -> IO (BV w)
+    computeUpperBoundBinary l r
+      | -- If the leftmost and rightmost bounds are the same, we are done.
+        l == r
+      = pure l
+
+      | -- If the leftmost and rightmost bounds of the search are 1 apart, we
+        -- only have two possible choices for the upper bound. Consult the
+        -- solver to determine which one is the upper bound.
+        BV.sub w r l < bvTwo
+      = do rExceedsUB <- checkExceedsUpperBound r
+           pure $ if rExceedsUB then l else r
+
+      | -- Otherwise, keep binary searching.
+        otherwise
+      = do let nextToTry = BV.mkBV w ((BV.asUnsigned l + BV.asUnsigned r) `div` 2)
+           exceedsUB <- checkExceedsUpperBound nextToTry
+           if exceedsUB
+             then computeUpperBoundBinary l nextToTry
+             else computeUpperBoundBinary nextToTry r
+
+    checkExceedsUpperBound :: BV w -> IO Bool
+    checkExceedsUpperBound bv = WPO.inNewFrame proc $ do
+      geUpperBound <- WI.bvUge sym symBV =<< WI.bvLit sym w bv
+      WPS.assume conn geUpperBound
+      msat <- WPO.check proc "resolveSymBV (check if upper bound has been exceeded)"
+      case msat of
+        WSat.Unknown -> failUnknown
+        WSat.Sat{}   -> pure False
+        WSat.Unsat{} -> pure True -- symBV cannot be >= this upper bound,
+                                  -- so the value must be strictly
+                                  -- greater than the upper bound.

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -320,6 +320,7 @@ test-suite expr-builder-smtlib2
     containers,
     data-binary-ieee754,
     libBF,
+    prettyprinter,
     process,
     tasty-expected-failure >= 0.12 && < 0.13,
     tasty-checklist >= 1.0.3 && < 1.1,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -214,6 +214,7 @@ library
     What4.Utils.MonadST
     What4.Utils.OnlyIntRepr
     What4.Utils.Process
+    What4.Utils.ResolveBounds.BV
     What4.Utils.Streams
     What4.Utils.StringLiteral
     What4.Utils.Word16String
@@ -306,7 +307,7 @@ test-suite online-solver-test
     versions
 
 test-suite expr-builder-smtlib2
-  import: bldflags, testdefs-hunit
+  import: bldflags, testdefs-hedgehog, testdefs-hunit
   type: exitcode-stdio-1.0
 
   main-is: ExprBuilderSMTLib2.hs


### PR DESCRIPTION
This adds two functions whose functionality are technically separate, but are useful when used in combination with each other. `resolveSymBV` uses an online SMT solver to query the `BVDomain` (i.e., the lower and upper version bounds) of a `SymBV` in situations where `{un,}signedBVBounds` won't suffice. At that point, `unsafeSetAbstractValue` can be used to manually set the `AbstractValue` of a symbolic expression—or, in the case of `SymBV`, manually set the `BVDomain`. I have used this in a downstream project with moderate success, and since the underlying machinery could be applicable in other situations, I thought it worth upstreaming to `what4`.

I have added test cases for both functions to ensure that they behave as expected.