### PR TITLE
Fix some issues with string escaping/unescaping in the SMTLib2 writer

### DIFF
--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -922,6 +922,62 @@ stringTest5 sym solver = withChecklist "string5" $
        _ -> fail "expected satisfable model"
 
 
+stringTest6 ::
+  OnlineSolver solver =>
+  SimpleExprBuilder t fs ->
+  SolverProcess t solver ->
+  IO ()
+stringTest6 sym solver = withChecklist "string6" $
+  do let conn = solverConn solver
+     x <- freshConstant sym (safeSymbol "x") (BaseStringRepr UnicodeRepr)
+     l <- stringLength sym x
+     intLit sym 1 >>= isEq sym l >>= assume conn
+     stringLit sym (UnicodeLiteral (Text.pack "\\")) >>= isEq sym x >>= assume conn
+     checkAndGetModel solver "test" >>= \case
+       Sat ge -> do
+         v <- groundEval ge x
+         TC.check "correct string" (v ==) (UnicodeLiteral (Text.pack "\\"))
+       _ -> fail "unsatisfiable"
+
+stringTest7 ::
+  OnlineSolver solver =>
+  SimpleExprBuilder t fs ->
+  SolverProcess t solver ->
+  IO ()
+stringTest7 sym solver = withChecklist "string6" $
+  do chars <- getChars sym solver 200
+     TC.check "correct number of characters" (length chars ==) 200
+
+getChars ::
+  OnlineSolver solver =>
+  SimpleExprBuilder t fs ->
+  SolverProcess t solver ->
+  Integer ->
+  IO [Char]
+getChars sym solver bound = do
+    let conn = solverConn solver
+    -- Create string var and constrain its length to 1
+    x <- freshConstant sym (safeSymbol "x") (BaseStringRepr UnicodeRepr)
+    l <- stringLength sym x
+    intLit sym 1 >>= isEq sym l >>= assume conn
+    -- Recursively generate characters
+    let getModelsRecursive n
+          | n >= bound = return ""
+          | otherwise =
+          checkAndGetModel solver "test" >>= \case
+            Sat ge -> do
+              v <- groundEval ge x
+              -- Exclude value
+              stringLit sym v >>= isEq sym x >>= notPred sym >>= assume conn
+              let c = Text.head $ fromUnicodeLit v
+              cs <- getModelsRecursive (n+1)
+              return (c:cs)
+            _ -> return []
+
+    cs <- getModelsRecursive 0
+    return cs
+
+
 multidimArrayTest ::
   OnlineSolver solver =>
   SimpleExprBuilder t fs ->
@@ -1163,6 +1219,8 @@ main = do
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string3" $ withOnlineZ3 stringTest3
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
+        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string6" $ withOnlineZ3 stringTest6
+        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string7" $ withOnlineZ3 stringTest7
 
         , testCase "Z3 binder tuple1" $ withOnlineZ3 binderTupleTest1
         , testCase "Z3 binder tuple2" $ withOnlineZ3 binderTupleTest2
@@ -1190,6 +1248,8 @@ main = do
         , testCase "CVC4 string3" $ withCVC4 stringTest3
         , testCase "CVC4 string4" $ withCVC4 stringTest4
         , testCase "CVC4 string5" $ withCVC4 stringTest5
+        , testCase "CVC4 string6" $ withCVC4 stringTest6
+        , testCase "CVC4 string7" $ withCVC4 stringTest7
 
         , testCase "CVC4 binder tuple1" $ withCVC4 binderTupleTest1
         , testCase "CVC4 binder tuple2" $ withCVC4 binderTupleTest2
@@ -1233,4 +1293,3 @@ main = do
     <> (skipIfNotPresent "cvc4" cvc4Tests)
     <> (skipIfNotPresent "yices" yicesTests)
     <> (skipIfNotPresent "z3" z3Tests)
-

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -922,6 +922,9 @@ stringTest5 sym solver = withChecklist "string5" $
        _ -> fail "expected satisfable model"
 
 
+-- This test verifies that we can correctly round-trip the
+-- '\' character. It is a bit of a corner case, since it
+-- is is involved in the codepoint escape sequences '\u{abcd}'.
 stringTest6 ::
   OnlineSolver solver =>
   SimpleExprBuilder t fs ->
@@ -939,6 +942,13 @@ stringTest6 sym solver = withChecklist "string6" $
          TC.check "correct string" (v ==) (UnicodeLiteral (Text.pack "\\"))
        _ -> fail "unsatisfiable"
 
+-- This test asks the solver to produce a sequence of 200 unique characters
+-- This helps to ensure that we can correclty recieve and send back to the
+-- solver enough characters to exhaust the standard printable ASCII sequence,
+-- which ensures that we are testing nontrivial escape sequences.
+--
+-- We don't verify that any particular string is returned because the solvers
+-- make different choices about what characters to return.
 stringTest7 ::
   OnlineSolver solver =>
   SimpleExprBuilder t fs ->
@@ -1220,7 +1230,8 @@ main = do
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string4" $ withOnlineZ3 stringTest4
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string5" $ withOnlineZ3 stringTest5
         , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string6" $ withOnlineZ3 stringTest6
-        , skipPre4_8_12 incompatZ3Strings $ testCase "Z3 string7" $ withOnlineZ3 stringTest7
+          -- this test apparently passes on older Z3 despite the escaping changes...
+        , testCase "Z3 string7" $ withOnlineZ3 stringTest7
 
         , testCase "Z3 binder tuple1" $ withOnlineZ3 binderTupleTest1
         , testCase "Z3 binder tuple2" $ withOnlineZ3 binderTupleTest2


### PR DESCRIPTION
Previously, we were too liberal with the characters we would emit
without escaping, and we would incorrectly fail to escape `\` characters
if they had a following `u` character.  In addition, our unescaping routine
was incorrectly rejecting strings from solvers if they ended with a literal
`\` character.

Fixes #184
Fixes #185