### PR TITLE
Avoid `testProperty` deprecation warnings with `tasty-hedgehog-1.2`

### DIFF
--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -19,7 +19,7 @@ import           ProbeSolvers
 import           Test.Tasty
 import           Test.Tasty.Checklist as TC
 import           Test.Tasty.ExpectedFailure
-import           Test.Tasty.Hedgehog
+import           Test.Tasty.Hedgehog.Alt
 import           Test.Tasty.HUnit
 
 import           Control.Exception (bracket, try, finally, SomeException)

--- a/what4/test/ExprsTest.hs
+++ b/what4/test/ExprsTest.hs
@@ -28,7 +28,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import           Test.Tasty.Hedgehog
+import           Test.Tasty.Hedgehog.Alt
 import           What4.Concrete
 import           What4.Expr
 import           What4.Interface

--- a/what4/test/HH/VerifyBindings.hs
+++ b/what4/test/HH/VerifyBindings.hs
@@ -8,7 +8,7 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import           Test.Tasty.Hedgehog.Alt
 import qualified Test.Verification as V
 
 

--- a/what4/test/IteExprs.hs
+++ b/what4/test/IteExprs.hs
@@ -30,7 +30,7 @@ import           Hedgehog
 import qualified Hedgehog.Internal.Gen as IGen
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import           Test.Tasty.Hedgehog
+import           Test.Tasty.Hedgehog.Alt
 import           What4.Concrete
 import           What4.Expr
 import           What4.Interface

--- a/what4/test/hedgehog/Test/Tasty/Hedgehog/Alt.hs
+++ b/what4/test/hedgehog/Test/Tasty/Hedgehog/Alt.hs
@@ -1,0 +1,29 @@
+-- | Like "Test.Tasty.Hedgehog", but instead exposing an alternative
+-- implementation of 'testProperty' that does not induce deprecation warnings.
+module Test.Tasty.Hedgehog.Alt
+  ( module TTH
+  , testProperty
+  ) where
+
+import Data.String (IsString(fromString))
+import Hedgehog (Property)
+import Test.Tasty (TestName, TestTree)
+import Test.Tasty.Hedgehog as TTH hiding (testProperty)
+
+-- | Create a 'T.TestTree' from a Hedgehog 'Property'.
+--
+-- Note that @tasty-hedgehog@'s version of 'testProperty' has been deprecated
+-- in favor of 'testPropertyNamed', whose second argument is intended to
+-- represent the name of a top-level 'Property' value to run in the event that
+-- the test fails. See https://github.com/qfpl/tasty-hedgehog/pull/42.
+--
+-- That being said, @what4@ currently does not define any of the properties
+-- that it tests as top-level values, and it would be a pretty significant
+-- undertaking to migrate all of the properties to top-level values. In the
+-- meantime, we avoid incurring deprecation warnings by defining our own
+-- version of 'testProperty'. The downside to this workaround is that if a
+-- property fails, the error message it will produce will likely suggest
+-- running ill-formed Haskell code, so users will have to use context clues to
+-- determine how to /actually/ reproduce the error.
+testProperty :: TestName -> Property -> TestTree
+testProperty name = testPropertyNamed name (fromString name)

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -79,8 +79,10 @@ common testdefs-quickcheck
 
 common testdefs-hedgehog
   import: testdefs
+  hs-source-dirs: test/hedgehog
   build-depends: hedgehog >= 1.0.2
-               , tasty-hedgehog
+               , tasty-hedgehog >= 1.2
+  other-modules: Test.Tasty.Hedgehog.Alt
 
 common testdefs-hunit
   import: testdefs


### PR DESCRIPTION
This fixes #195—or, at the very least, makes the deprecation warnings that arise from `tasty-hedgehog`'s version of `testProperty` go away. The "real" fix would be to convert every use of `testProperty` into a top-level `Property` value, but given how tedious that would be, I'm disinclined to do this unless someone specifically requests it.