### PR TITLE
`template_tests`: Emit an error code if tests fail

### DIFF
--- a/what4/test/TestTemplate.hs
+++ b/what4/test/TestTemplate.hs
@@ -11,7 +11,7 @@
 module Main where
 
 import Control.Exception
-import Control.Monad ((<=<)) -- , when)
+import Control.Monad ((<=<), unless)
 import Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Maybe
 import Data.Bits
@@ -22,6 +22,7 @@ import Data.Parameterized.Pair
 import Data.Parameterized.Some
 import Data.String
 import Numeric (showHex)
+import System.Exit (exitFailure)
 -- import System.IO
 
 import LibBF
@@ -78,8 +79,8 @@ main =
                             pure (fromString (show t), p)
                        | Some t <- xs
                        ]
-     _ <- checkSequential $ Group "Float tests" tests
-     return ()
+     testsPassed <- checkSequential $ Group "Float tests" tests
+     unless testsPassed exitFailure
 
 
 data FUnOp


### PR DESCRIPTION
Running `hedgehog`'s `checkSequential` function alone isn't enough to cause a test suite to fail if one or more of the test cases to fail. Per a comment in the `hedgehog` source code [here](https://github.com/hedgehogqa/haskell-hedgehog/blob/3d4dde46e15ab25a10cac0deff03bae10ecacc4e/hedgehog-example/test/test.hs#L34-L42), the idiomatic way to do make a `checkSequential` failure imply test suite failure is to check the result of running `checkSequential` and, if that is `False`, throw `exitFailure`. This patch incorporates that advice into the `test_templates` test suite.

Fixes #206.