### PR TITLE
Allow tasty-sugar 2.0+

### DIFF
--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -422,7 +422,7 @@ test-suite solver_parsing_tests
                , exceptions
                , io-streams
                , lumberjack
-               , tasty-sugar >= 1.3 && < 1.4
+               , tasty-sugar >= 1.3 && < 2.1
                , text
 
 test-suite what4-serialize-tests


### PR DESCRIPTION
Builds fine and all tests pass here with tasty-sugar 2.0.0.0.