### PR TITLE
CI: Use Nix 2.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ on:
 # * GHC versions
 #   - specified in the strategy matrix
 #   - provided via nix: ensure the nix base and NIXPKGS used provide the requested GHC version
-# * nix tool version 2.4
-#   - all nix operations use new tool suite and cmdline interface (available in 2.4) instead of older format
+# * nix tool version 2.11.0
+#   - all nix operations use new tool suite and cmdline interface (available in 2.4+) instead of older format
 
 # The CACHE_VERSION can be updated to force the use of a new cache if
 # the current cache contents become corrupted/invalid.  This can
@@ -40,7 +40,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.11.0/install
 
       - uses: cachix/cachix-action@v10
         with:
@@ -69,7 +69,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.11.0/install
 
       - uses: cachix/cachix-action@v10
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-21.11
           install_url: https://releases.nixos.org/nix/nix-2.11.0/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: cachix/cachix-action@v10
         with:
@@ -70,6 +72,8 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-21.11
           install_url: https://releases.nixos.org/nix/nix-2.11.0/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: cachix/cachix-action@v10
         with:


### PR DESCRIPTION
Nix 2.4 does not work well with GitHub Actions' Ubuntu 22.04 runners, as seen in https://github.com/cachix/install-nix-action/issues/141.

-----

I'm hoping that this addresses the CI woes encountered in #226.