### PR TITLE
Support building with GHC 9.6

### DIFF
--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -92,6 +92,7 @@ main_version(abc, "2021_12_30").
 
 version(ubuntu, "ubuntu-latest").
 
+version(ghc, "9.6.2").
 version(ghc, "9.4.4").
 version(ghc, "9.2.2").
 version(ghc, "9.0.2").

--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -72,7 +72,7 @@ solver(abc).
 %% version (which is not necessarily the "most recently released"
 %% version.
 main_version(ubuntu, "ubuntu-latest").
-main_version(ghc, "8.10.7").
+main_version(ghc, "9.2.2").
 main_version(z3, "4_8_14").
 main_version(yices, "2_6_4").
 main_version(stp, "2_3_3").

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
             9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             9.4.4) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
+            9.6.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#cabal-install ${GHC_NIXPKGS}#${GHC} nixpkgs#gmp nixpkgs#zlib nixpkgs#zlib.dev" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,8 @@ jobs:
           name: galois
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - uses: actions/cache@v2
-        name: Cache builds
+      - uses: actions/cache/restore@v3
+        name: Restore cabal store cache
         with:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
@@ -185,3 +185,15 @@ jobs:
         run: |
           cd what4
           $NS -c cabal haddock what4
+
+      - uses: actions/cache/save@v3
+        name: Save cabal store cache
+        if: always()
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: |
+            ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-ghc${{ matrix.ghc }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,8 +103,8 @@ jobs:
             8.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/20.09 ;;
             9.0.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
-            9.4.4) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
-            9.6.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-unstable ;;
+            9.4.4) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
+            9.6.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#cabal-install ${GHC_NIXPKGS}#${GHC} nixpkgs#gmp nixpkgs#zlib nixpkgs#zlib.dev" >> $GITHUB_ENV

--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -45,7 +45,7 @@ import Control.Monad.Fail( MonadFail )
 import           Control.Concurrent
 import           Control.Exception hiding (evaluate)
 import           Control.Lens
-import           Control.Monad.Identity
+import           Control.Monad (foldM, join, unless, when)
 import           Control.Monad.ST
 import           Data.Bits
 import qualified Data.BitVector.Sized as BV
@@ -56,6 +56,7 @@ import qualified Data.AIG.Interface as AIG
 
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Foldable as Fold
+import           Data.Functor (void)
 import qualified Data.HashSet as HSet
 import           Data.IORef
 import           Data.List (zipWith4)

--- a/what4-abc/what4-abc.cabal
+++ b/what4-abc/what4-abc.cabal
@@ -17,7 +17,7 @@ Description:
 
 library
   build-depends:
-    base >= 4.7 && < 4.18,
+    base >= 4.7 && < 4.19,
     aig,
     abcBridge >= 0.11,
     bv-sized >= 1.0.0,
@@ -26,7 +26,6 @@ library
     directory,
     io-streams,
     lens,
-    mtl,
     parameterized-utils,
     prettyprinter >= 1.7.0,
     process,

--- a/what4-blt/what4-blt.cabal
+++ b/what4-blt/what4-blt.cabal
@@ -26,7 +26,7 @@ common bldflags
 library
   import: bldflags
   build-depends:
-    base >= 4.7 && < 4.18,
+    base >= 4.7 && < 4.19,
     blt >= 0.12.1,
     containers,
     what4 >= 0.4,

--- a/what4-transition-system/src/What4/TransitionSystem.hs
+++ b/what4-transition-system/src/What4/TransitionSystem.hs
@@ -24,7 +24,7 @@ module What4.TransitionSystem
 where
 
 import qualified Control.Lens as L
-import Control.Monad.Identity (forM)
+import Control.Monad (forM)
 import Data.Functor.Const (Const (..))
 import qualified Data.Parameterized.Context as Ctx
 import qualified What4.BaseTypes as BaseTypes

--- a/what4-transition-system/what4-transition-system.cabal
+++ b/what4-transition-system/what4-transition-system.cabal
@@ -13,12 +13,11 @@ build-type:    Simple
 common dependencies
   build-depends:
     , ansi-wl-pprint       ^>=0.6
-    , base                 >=4.12 && <4.18
+    , base                 >=4.12 && <4.19
     , bytestring
     , containers           ^>=0.6
     , io-streams
     , lens
-    , mtl
     , parameterized-utils  >=2.0  && <2.2
     , text
     , what4                ^>=1.4

--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,3 +1,11 @@
+# next (TBA)
+
+* Allow building with GHC 9.6.
+
+* The `MonadTrans (PartialT sym)` instance now has a `IsExpr (SymExpr sym)`
+  constraint in its instance context. (This is a requirement imposed by
+  `MonadTrans` gaining a quantified `Monad` superclass in `mtl-2.3`.)
+
 # 1.4 (January 2023)
 
 * Allow building with GHC 9.4.

--- a/what4/src/What4/Config.hs
+++ b/what4/src/What4/Config.hs
@@ -175,10 +175,10 @@ import           Control.Concurrent.MVar
 import qualified Control.Concurrent.ReadWriteVar as RWV
 import           Control.Lens ((&))
 import qualified Control.Lens.Combinators as LC
+import           Control.Monad (foldM, when)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
-import           Control.Monad.Identity
-import           Control.Monad.Writer.Strict hiding ((<>))
+import           Control.Monad.Writer.Strict (MonadWriter(..), WriterT, execWriterT)
 import           Data.Foldable (toList)
 import           Data.Kind
 import           Data.List.NonEmpty (NonEmpty(..))

--- a/what4/src/What4/Expr/Simplify.hs
+++ b/what4/src/What4/Expr/Simplify.hs
@@ -20,8 +20,9 @@ module What4.Expr.Simplify
   ) where
 
 import           Control.Lens ((^.))
+import           Control.Monad (void, when)
 import           Control.Monad.ST
-import           Control.Monad.State
+import           Control.Monad.State (MonadState(..), State, execState)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe

--- a/what4/src/What4/Expr/Simplify.hs
+++ b/what4/src/What4/Expr/Simplify.hs
@@ -144,7 +144,7 @@ recordExpr n = do
 count_subterms' :: Expr t tp -> Counter ()
 count_subterms' e0 =
   case e0 of
-    BoolExpr{} -> pure () 
+    BoolExpr{} -> pure ()
     SemiRingLiteral{} -> pure ()
     StringExpr{} -> pure ()
     FloatExpr{} -> pure ()

--- a/what4/src/What4/Expr/VarIdentification.hs
+++ b/what4/src/What4/Expr/VarIdentification.hs
@@ -42,9 +42,10 @@ import Control.Monad.Fail( MonadFail )
 #endif
 
 import           Control.Lens
-import           Control.Monad.Reader
+import           Control.Monad (when)
+import           Control.Monad.Reader (MonadReader(..), ReaderT(..))
 import           Control.Monad.ST
-import           Control.Monad.State
+import           Control.Monad.State (StateT, execStateT)
 import           Data.Bits
 import qualified Data.HashTable.ST.Basic as H
 import           Data.List.NonEmpty (NonEmpty(..))

--- a/what4/src/What4/Expr/WeightedSum.hs
+++ b/what4/src/What4/Expr/WeightedSum.hs
@@ -70,7 +70,7 @@ module What4.Expr.WeightedSum
   ) where
 
 import           Control.Lens
-import           Control.Monad.State
+import           Control.Monad (unless)
 import qualified Data.BitVector.Sized as BV
 import           Data.Hashable
 import           Data.Kind

--- a/what4/src/What4/Partial.hs
+++ b/what4/src/What4/Partial.hs
@@ -266,7 +266,7 @@ instance (IsExpr (SymExpr sym), Monad m) => Monad (PartialT sym m) where
 instance (IsExpr (SymExpr sym), MonadFail m) => MonadFail (PartialT sym m) where
   fail msg = PartialT $ \_ _ -> fail msg
 
-instance MonadTrans (PartialT sym) where
+instance IsExpr (SymExpr sym) => MonadTrans (PartialT sym) where
   lift m = PartialT $ \_ p -> PE p <$> m
 
 instance (IsExpr (SymExpr sym), MonadIO m) => MonadIO (PartialT sym m) where

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -707,7 +707,7 @@ instance SMTLib2Tweaks a => SMTWriter (Writer a) where
   getUnsatCoreCommand _ = SMT2.getUnsatCore
   getAbductCommand _ nm e = SMT2.getAbduct nm e
   getAbductNextCommand _ = SMT2.getAbductNext
-  
+
   setOptCommand _ = SMT2.setOption
 
   declareCommand _proxy v argTypes retType =
@@ -1283,7 +1283,7 @@ runGetAbducts :: SMTLib2Tweaks a
              -> Text
              -> Term
              -> IO [String]
-runGetAbducts s n nm p = 
+runGetAbducts s n nm p =
   if (n > 0) then do
     writeGetAbduct (sessionWriter s) nm p
     let valRsp = \x -> case x of

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -101,8 +101,10 @@ import Control.Monad.Fail( MonadFail )
 
 import           Control.Applicative
 import           Control.Exception
-import           Control.Monad.Except
-import           Control.Monad.Reader
+import           Control.Monad (forM, forM_, replicateM_, unless, when)
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Except (MonadError(..), ExceptT, runExceptT)
+import           Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
 import qualified Data.Bimap as Bimap
 import qualified Data.BitVector.Sized as BV
 import           Data.Char (digitToInt, isAscii)

--- a/what4/src/What4/Protocol/SMTLib2/Parse.hs
+++ b/what4/src/What4/Protocol/SMTLib2/Parse.hs
@@ -39,7 +39,8 @@ import Control.Monad.Fail( MonadFail )
 import qualified Control.Monad.Fail
 #endif
 
-import           Control.Monad.Reader
+import           Control.Monad (when)
+import           Control.Monad.Reader (ReaderT(..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.UTF8 as UTF8
 import           Data.Char

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -111,11 +111,13 @@ import           Control.Monad.Fail ( MonadFail )
 
 import           Control.Exception
 import           Control.Lens hiding ((.>), Strict)
+import           Control.Monad (forM_, unless, when)
 import           Control.Monad.IO.Class
-import           Control.Monad.Reader
+import           Control.Monad.Reader (ReaderT(..), asks)
 import           Control.Monad.ST
-import           Control.Monad.State.Strict
-import           Control.Monad.Trans.Maybe
+import           Control.Monad.State.Strict (State, runState)
+import           Control.Monad.Trans (MonadTrans(..))
+import           Control.Monad.Trans.Maybe (MaybeT(..))
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import qualified Data.BitVector.Sized as BV

--- a/what4/src/What4/Protocol/VerilogWriter/AST.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/AST.hs
@@ -19,7 +19,9 @@ import qualified Data.Text as T
 import qualified Data.Set as Set
 import           Data.String
 import           Data.Word
-import           Control.Monad.Except
+import           Control.Monad (forM_)
+import           Control.Monad.Except (ExceptT, MonadError(..))
+import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.State (MonadState(), StateT(..), get, put, modify, gets)
 
 import qualified What4.BaseTypes as WT

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -16,8 +16,9 @@ module What4.Protocol.VerilogWriter.Backend
   where
 
 
+import           Control.Monad (foldM)
 import           Control.Monad.State (get)
-import           Control.Monad.Except
+import           Control.Monad.Except (MonadError(..))
 import qualified Data.BitVector.Sized as BV
 import           Data.List.NonEmpty ( NonEmpty(..) )
 

--- a/what4/src/What4/Serialize/Parser.hs
+++ b/what4/src/What4/Serialize/Parser.hs
@@ -886,7 +886,7 @@ readLetFnExpr ((S.WFSList [S.WFSAtom (AId f), e]):rst) body = do
 readLetFnExpr bindings _body = E.throwError $
   "invalid s-expression for let-bindings: " ++ (show bindings)
 
-  
+
 -- | Parse an arbitrary expression.
 readExpr ::
   forall sym t st fs . (sym ~ W4.ExprBuilder t st fs)

--- a/what4/src/What4/Serialize/Parser.hs
+++ b/what4/src/What4/Serialize/Parser.hs
@@ -34,6 +34,7 @@ module What4.Serialize.Parser
   , printSExpr
   ) where
 
+import           Control.Monad ( when )
 import qualified Control.Monad.Except as E
 import           Control.Monad.IO.Class ( liftIO )
 import qualified Control.Monad.Reader as R
@@ -1030,7 +1031,7 @@ readSymFn (S.WFSList [ S.WFSAtom (AId "definedfn")
                  Right solverSym -> return solverSym
   argNames <- readFnArgs argVarsRaw
   (argTys, _retTy) <- readFnType rawFnType
-  E.when (not (length argTys == length argNames)) $
+  when (not (length argTys == length argNames)) $
     E.throwError $ "Function type expected "
     ++ (show $ length argTys)
     ++ " args but found "

--- a/what4/src/What4/Serialize/Printer.hs
+++ b/what4/src/What4/Serialize/Printer.hs
@@ -89,7 +89,7 @@ instance Eq (SomeExprSymFn t) where
 
 instance Ord (SomeExprSymFn t) where
   compare (SomeExprSymFn fn1) (SomeExprSymFn fn2) =
-    compare (Nonce.indexValue $ W4.symFnId fn1) (Nonce.indexValue $ W4.symFnId fn2) 
+    compare (Nonce.indexValue $ W4.symFnId fn1) (Nonce.indexValue $ W4.symFnId fn2)
 
 
 instance Show (SomeExprSymFn t) where
@@ -376,7 +376,7 @@ freshFnName :: W4.ExprSymFn t args ret -> Memo t Text
 freshFnName fn = do
   idCount <- MS.gets envIdCounter
   MS.modify' $ (\e -> e {envIdCounter = idCount + 1})
-  let prefix = case W4.symFnInfo fn of 
+  let prefix = case W4.symFnInfo fn of
                  W4.UninterpFnInfo{} -> "ufn"
                  W4.DefinedFnInfo{} -> "dfn"
                  W4.MatlabSolverFnInfo{} -> "mfn"
@@ -412,7 +412,7 @@ convertExpr initialExpr = do
           sexp <- go initialExpr
           case sexp of
             S.A _ -> return sexp -- Don't memoize atomic s-expressions - that's just silly.
-            _ -> do 
+            _ -> do
               letVarName <- addLetBinding key sexp (W4.exprType initialExpr)
               return $ ident letVarName
   where go :: W4.Expr t tp -> Memo t SExpr
@@ -683,7 +683,7 @@ convertAppExpr' = go . W4.appExprApp
                        ]
 
         -- -- -- -- Helper functions! -- -- -- --
-        
+
         goE :: forall tp' . W4.Expr t tp' -> Memo t SExpr
         goE = convertExpr
 

--- a/what4/src/What4/Serialize/Printer.hs
+++ b/what4/src/What4/Serialize/Printer.hs
@@ -448,7 +448,7 @@ convertBoundVarExpr x = do
   bvs <- MS.gets envBoundVars
   -- If this variable is not bound (in the standard syntactic sense)
   -- and free variables are not explicitly permitted, raise an error.
-  MS.when ((not $ Set.member (Some x) bvs) && (not fvsAllowed)) $
+  M.when ((not $ Set.member (Some x) bvs) && (not fvsAllowed)) $
     error $
     "encountered the free What4 ExprBoundVar `"
     ++ (T.unpack (W4.solverSymbolAsText (W4.bvarName x)))

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -127,7 +127,6 @@ library
     temporary >= 1.2,
     template-haskell,
     text >= 1.2.4.0 && < 2.1,
-    th-abstraction >=0.1 && <0.5,
     th-lift >= 0.8.2 && < 0.9,
     th-lift-instances >= 0.1 && < 0.2,
     time >= 1.8 && < 1.13,


### PR DESCRIPTION
This patch contains a variety of fixes needed to build the libraries in the
`what4` repo with GHC 9.6:

* GHC 9.6 bundles `mtl-2.3.*`, which no longer re-exports `Control.Monad`,
  `Control.Monad.IO.Class`, and similar modules from `mtl`-related modules.
  To accommodate this, various imports have been made more explicit.
* `MonadTrans t` now has a quantified `forall m. Monad m => Monad (t m)`
  superclass in `mtl-2.3.*`. As a result, the `MonadTrans (PartialT sym)`
  instance must now have an `IsExpr (SymExpr sym)` instance context in order
  for it to typecheck, as this is the same instance context that `PartialT`'s
  `Monad` instance has.

  This is technically a breaking change, so I have noted it in the `what4`
  changelog. That being said, this change is unlikely to affect many people
  in practice, considering that the `MonadTrans` instance for `PartialT` is
  usually used in tandem with the `Monad` instance.
* Various upper version bounds on `base` have been lifted to allow building
  with `base-4.18`.
* The `aig` submodule has been bumped to bring in the changes from
  https://github.com/GaloisInc/aig/pull/15, which allows it to build with GHC 9.6.