### PR TITLE
Allow building with `versions-6.0.*`

### DIFF
--- a/what4/src/What4/Utils/Versions.hs
+++ b/what4/src/What4/Utils/Versions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -22,7 +23,14 @@ import           Language.Haskell.TH
 import           Language.Haskell.TH.Lift
 
 -- NB, orphan instances :-(
+-- See also https://github.com/fosskers/versions/issues/68
+#if MIN_VERSION_versions(6,0,0)
+deriving instance Lift Versions.Chunk
+deriving instance Lift Versions.Chunks
+deriving instance Lift Versions.Release
+#else
 deriving instance Lift Versions.VUnit
+#endif
 deriving instance Lift Versions.Version
 
 ver :: Text -> Q Exp

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -135,7 +135,7 @@ library
     unordered-containers >= 0.2.10,
     utf8-string >= 1.0.1,
     vector >= 0.12.1,
-    versions >= 4.0 && < 6.0,
+    versions >= 4.0 && < 6.1,
     zenc >= 0.1.0 && < 0.2.0,
     ghc-prim >= 0.5.2
 


### PR DESCRIPTION
`versions-6.0.*` removes the `VChunk` data type, which `what4` defines an orphan `Lift` instance for. This requires some CPP to fix up. This is somewhat messy, and in an ideal world, we'd move these orphan instances directly to the `versions` library. (See also https://github.com/fosskers/versions/issues/68.)

Fixes #240.