### PR TITLE
Require `versions >= 6.0.2`

### DIFF
--- a/what4/src/What4/Utils/Versions.hs
+++ b/what4/src/What4/Utils/Versions.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module What4.Utils.Versions where
 
@@ -21,17 +18,6 @@ import           Instances.TH.Lift ()
 
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Lift
-
--- NB, orphan instances :-(
--- See also https://github.com/fosskers/versions/issues/68
-#if MIN_VERSION_versions(6,0,0)
-deriving instance Lift Versions.Chunk
-deriving instance Lift Versions.Chunks
-deriving instance Lift Versions.Release
-#else
-deriving instance Lift Versions.VUnit
-#endif
-deriving instance Lift Versions.Version
 
 ver :: Text -> Q Exp
 ver nm =

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -135,7 +135,7 @@ library
     unordered-containers >= 0.2.10,
     utf8-string >= 1.0.1,
     vector >= 0.12.1,
-    versions >= 4.0 && < 6.1,
+    versions >= 6.0.2 && < 6.1,
     zenc >= 0.1.0 && < 0.2.0,
     ghc-prim >= 0.5.2
 


### PR DESCRIPTION
`versions-6.0.2` introduces a `Lift Version` instance, which finally allows us to delete the ugly, CPP'd mess of orphan instances that we define in `What4.Utils.Versions`.

Related to #240.