### PR TITLE
what4: Don't annotate bound variables

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -1630,6 +1630,7 @@ instance IsExprBuilder (ExprBuilder t st fs) where
 
   annotateTerm sym e =
     case e of
+      BoundVarExpr (bvarId -> n) -> return (n, e)
       NonceAppExpr (nonceExprApp -> Annotation _ n _) -> return (n, e)
       _ -> do
         let tpr = exprType e
@@ -1639,11 +1640,13 @@ instance IsExprBuilder (ExprBuilder t st fs) where
 
   getAnnotation _sym e =
     case e of
+      BoundVarExpr (bvarId -> n) -> Just n
       NonceAppExpr (nonceExprApp -> Annotation _ n _) -> Just n
       _ -> Nothing
 
   getUnannotatedTerm _sym e =
     case e of
+      BoundVarExpr {} -> Just e
       NonceAppExpr (nonceExprApp -> Annotation _ _ x) -> Just x
       _ -> Nothing
 

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -1646,7 +1646,6 @@ instance IsExprBuilder (ExprBuilder t st fs) where
 
   getUnannotatedTerm _sym e =
     case e of
-      BoundVarExpr {} -> Just e
       NonceAppExpr (nonceExprApp -> Annotation _ _ x) -> Just x
       _ -> Nothing
 

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -691,7 +691,8 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym), HashableF (BoundVar sym)
   getAnnotation :: sym -> SymExpr sym tp -> Maybe (SymAnnotation sym tp)
 
   -- | Project the original, unannotated term from an annotated term.
-  --   This returns 'Nothing' for terms that do not have annotations.
+  --   This returns 'Nothing' for terms that do not have annotations,
+  --   or for terms that cannot be separated from their annotations.
   getUnannotatedTerm :: sym -> SymExpr sym tp -> Maybe (SymExpr sym tp)
 
   ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #244. Should result in slightly better performance for code that annotates bound variables, and prettier printing.