### PR TITLE
what4: Don't annotate `{Nonce,}AppExpr`s

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -4,6 +4,9 @@
   wrapper around `BoolMap` that makes clear that the `BoolMap` in question
   represents a conjunction (as `BoolMap`s may also represent disjunctions).
   See the Haddocks on `ConjMap` for more details.
+* Add `opacify`, `clarify` to `IsExprBuilder`, for preserving abstract values.
+  These should be used instead of `annotateTerm` for that purpose.
+* Modify `annotateTerm` to not annotate `{Nonce,}AppExpr`s.
 
 # 1.6.2 (Sep 2024)
 

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -42,6 +42,7 @@ quantTheory :: NonceApp t (Expr t) tp -> AppTheory
 quantTheory a0 =
   case a0 of
     Annotation tpr _ _ -> typeTheory tpr
+    Opaque tpr _ -> typeTheory tpr
     Forall{} -> QuantifierTheory
     Exists{} -> QuantifierTheory
     ArrayFromFn{}   -> FnTheory

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -2044,9 +2044,11 @@ instance IsExprBuilder (ExprBuilder t st fs) where
 
   annotateTerm sym e =
     case e of
+      AppExpr (appExprId -> n) -> return (n, e)
       BoundVarExpr (bvarId -> n) -> return (n, e)
       NonceAppExpr (nonceExprApp -> Annotation _ n _) -> return (n, e)
-      _ -> do
+      NonceAppExpr (nonceExprId -> n) -> return (n, e)
+      _ -> do  -- literals
         let tpr = exprType e
         n <- sbFreshIndex sym
         e' <- sbNonceExpr sym (Annotation tpr n e)
@@ -2054,8 +2056,10 @@ instance IsExprBuilder (ExprBuilder t st fs) where
 
   getAnnotation _sym e =
     case e of
+      AppExpr (appExprId -> n) -> Just n
       BoundVarExpr (bvarId -> n) -> Just n
       NonceAppExpr (nonceExprApp -> Annotation _ n _) -> Just n
+      NonceAppExpr (nonceExprId -> n) -> Just n
       _ -> Nothing
 
   getUnannotatedTerm _sym e =

--- a/what4/src/What4/Expr/GroundEval.hs
+++ b/what4/src/What4/Expr/GroundEval.hs
@@ -255,6 +255,7 @@ evalGroundNonceApp :: Monad m
 evalGroundNonceApp fn a0 =
   case a0 of
     Annotation _ _ t -> fn t
+    Opaque _ t -> fn t
     Forall{} -> mzero
     Exists{} -> mzero
     MapOverArrays{} -> mzero

--- a/what4/src/What4/Expr/VarIdentification.hs
+++ b/what4/src/What4/Expr/VarIdentification.hs
@@ -379,6 +379,8 @@ recurseNonceAppVars scope ea0 = do
   case a0 of
     Annotation _ _ x ->
       recordExprVars scope x
+    Opaque _ x ->
+      recordExprVars scope x
     Forall v x ->
       addBothVar scope ea0 ForallBound v x
     Exists v x ->

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -407,7 +407,7 @@ class HasAbsValue e => IsExpr e where
   -- Note that composing expressions together can sometimes widen the abstract
   -- domains involved, so if you use this function to change an abstract value,
   -- be careful than subsequent operations do not widen away the value. As a
-  -- potential safeguard, one can use 'annotateTerm' on the new expression to
+  -- potential safeguard, one can use 'opacify' on the new expression to
   -- inhibit transformations that could change the abstract value.
   unsafeSetAbstractValue :: AbstractValue tp -> e tp -> e tp
 
@@ -638,6 +638,9 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym), HashableF (BoundVar sym)
   -- | Set current location of program for term creation purposes.
   setCurrentProgramLoc :: sym -> ProgramLoc -> IO ()
 
+  ----------------------------------------------------------------------
+  -- Basic operations
+
   -- | Return true if two expressions are equal. The default
   -- implementation dispatches 'eqPred', 'bvEq', 'natEq', 'intEq',
   -- 'realEq', 'cplxEq', 'structEq', or 'arrayEq', depending on the
@@ -676,6 +679,9 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym), HashableF (BoundVar sym)
       BaseStructRepr{} -> structIte sym c x y
       BaseArrayRepr{}  -> arrayIte  sym c x y
 
+  ----------------------------------------------------------------------
+  -- Annotations and opaque expressions
+
   -- | Given a symbolic expression, annotate it with a unique identifier
   --   that can be used to maintain a connection with the given term.
   --   The 'SymAnnotation' is intended to be used as the key in a hash
@@ -699,6 +705,14 @@ class ( IsExpr (SymExpr sym), HashableF (SymExpr sym), HashableF (BoundVar sym)
   --   This returns 'Nothing' for terms that do not have annotations,
   --   or for terms that cannot be separated from their annotations.
   getUnannotatedTerm :: sym -> SymExpr sym tp -> Maybe (SymExpr sym tp)
+
+  -- | Make an expression /opaque/, inhibiting rewrites that, in many cases,
+  -- coarsen abstract domain information. See #248 for discussion and #249 for
+  -- progress towards obviating opaque expressions.
+  opacify :: sym -> SymExpr sym tp -> IO (SymExpr sym tp)
+
+  -- | Inverse operation of 'opacify'.
+  clarify :: sym -> SymExpr sym tp -> SymExpr sym tp
 
   ----------------------------------------------------------------------
   -- Boolean operations.

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -1931,6 +1931,7 @@ predSMTExpr e0 = do
   liftIO $ updateProgramLoc h (nonceExprLoc e0)
   case nonceExprApp e0 of
     Annotation _tpr _n e -> mkExpr e
+    Opaque _tpr e -> mkExpr e
     Forall var e -> do
       checkQuantifierSupport "universal quantifier" i
 

--- a/what4/src/What4/Protocol/VerilogWriter/Backend.hs
+++ b/what4/src/What4/Protocol/VerilogWriter/Backend.hs
@@ -93,6 +93,7 @@ nonceAppExprVerilogExpr nae =
     -- TODO: implement uninterpreted functions as uninterpreted functions
     FnApp _ _ -> doNotSupportError "named function applications"
     Annotation _ _ e -> exprToVerilogExpr e
+    Opaque _ e -> exprToVerilogExpr e
 
 boolMapToExpr ::
   (IsExprBuilder sym, SymExpr sym ~ Expr n) =>

--- a/what4/src/What4/Serialize/Printer.hs
+++ b/what4/src/What4/Serialize/Printer.hs
@@ -438,6 +438,7 @@ convertExpr initialExpr = do
             W4.MapOverArrays {} -> error "MapOverArrays NonceAppExpr not yet supported"
             W4.ArrayTrueOnEntries {} -> error "ArrayTrueOnEntries NonceAppExpr not yet supported"
             W4.Annotation {} -> error "Annotation NonceAppExpr not yet supported"
+            W4.Opaque {} -> error "Opaque NonceAppExpr not yet supported"
         go (W4.BoundVarExpr var) = convertBoundVarExpr var
 
 -- | Serialize bound variables as the s-expression identifier `name_nonce`. This allows us to

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1164,7 +1164,7 @@ testUnsafeSetAbstractValue2 = testCase "test unsafeSetAbstractValue2" $
     e2A <- freshConstant sym (userSymbol' "x2A") (BaseBVRepr w)
     e2B <- freshConstant sym (userSymbol' "x2B") (BaseBVRepr w)
     e2C <- bvAdd sym e2A e2B
-    (_, e2C') <- annotateTerm sym $ unsafeSetAbstractValue (WUB.BVDArith (WUBA.range w 2 2)) e2C
+    e2C' <- opacify sym $ unsafeSetAbstractValue (WUB.BVDArith (WUBA.range w 2 2)) e2C
     unsignedBVBounds e2C' @?= Just (2, 2)
     e2D <- bvAdd sym e2C' =<< bvOne sym w
     case asBV e2D of


### PR DESCRIPTION
Fixes #246. Really, `Annotation` shouldn't need to carry a `Nonce`, because the outer `NonceAppExpr` will already have one. However, actually removing it is challenging due to the return type of `sbNonceExpr`, and in turn `ExprAllocator`'s `nonceExpr`, which returns an `Expr`. Surely in practice, this is always a `NonceAppExpr`, but there's no way to tell from the type. To avoid a larger refactor or introducing partiality, I'm keeping the `Nonce` in `Annotation` for now.

Fixes #246, though we may want to create a follow-up about removing the `Nonce` from `Annotation`.