### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -94,6 +94,7 @@ main_version(abc, "2021_12_30").
 
 version(ubuntu, "ubuntu-latest").
 
+version(ghc, "9.8.1").
 version(ghc, "9.6.2").
 version(ghc, "9.4.4").
 version(ghc, "9.2.2").

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
             9.2.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-22.05 ;;
             9.4.4) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
             9.6.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.05 ;;
+            9.8.1) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-23.11 ;;
             *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
           esac
           echo NS="nix shell ${GHC_NIXPKGS}#cabal-install ${GHC_NIXPKGS}#${GHC} nixpkgs#gmp nixpkgs#zlib nixpkgs#zlib.dev" >> $GITHUB_ENV

--- a/what4-abc/what4-abc.cabal
+++ b/what4-abc/what4-abc.cabal
@@ -17,7 +17,7 @@ Description:
 
 library
   build-depends:
-    base >= 4.7 && < 4.19,
+    base >= 4.7 && < 4.20,
     aig,
     abcBridge >= 0.11,
     bv-sized >= 1.0.0,

--- a/what4-blt/what4-blt.cabal
+++ b/what4-blt/what4-blt.cabal
@@ -26,7 +26,7 @@ common bldflags
 library
   import: bldflags
   build-depends:
-    base >= 4.7 && < 4.19,
+    base >= 4.7 && < 4.20,
     blt >= 0.12.1,
     containers,
     what4 >= 0.4,

--- a/what4-transition-system/what4-transition-system.cabal
+++ b/what4-transition-system/what4-transition-system.cabal
@@ -13,7 +13,7 @@ build-type:    Simple
 common dependencies
   build-depends:
     , ansi-wl-pprint       ^>=0.6
-    , base                 >=4.12 && <4.19
+    , base                 >=4.12 && <4.20
     , bytestring
     , containers           ^>=0.6
     , io-streams

--- a/what4/test/AdapterTest.hs
+++ b/what4/test/AdapterTest.hs
@@ -34,6 +34,7 @@ import           Data.Parameterized.Some
 import           What4.Config
 import           What4.Expr
 import           What4.Interface
+import           What4.Panic
 import           What4.Protocol.SMTLib2.Response ( strictSMTParsing )
 import           What4.Protocol.SMTWriter ( parserStrictness, ResponseStrictness(..) )
 import           What4.Protocol.VerilogWriter
@@ -224,6 +225,11 @@ mkConfigTests adapters =
       in fmap mkPCTest adaptrs
 
     deprecatedConfigTests adaptrs =
+      let firstAdapter adptrs =
+            case adptrs of
+              adptr:_ -> adptr
+              [] -> panic "deprecatedConfigTests" ["Empty list of adapters"]
+      in
       [
 
         testCaseSteps "deprecated default_solver is equivalent to solver.default" $
@@ -258,7 +264,7 @@ mkConfigTests adapters =
 
           step "Update the value via regular (text identification)"
           res2 <- try $ setUnicodeOpt settera $
-                  pack $ solver_adapter_name $ head adaptrs
+                  pack $ solver_adapter_name $ firstAdapter adaptrs
           case res2 of
             Right warns -> fmap show warns @?= []
             Left (SomeException e) -> assertFailure $ show e
@@ -283,7 +289,7 @@ mkConfigTests adapters =
 
           step "Reset to original value"
           res4 <- try $ setOpt settera' $
-                  pack $ solver_adapter_name $ head adaptrs
+                  pack $ solver_adapter_name $ firstAdapter adaptrs
           case res4 of
             Right warns -> fmap show warns @?= []
             Left (SomeException e) -> assertFailure $ show e

--- a/what4/test/ConfigTest.hs
+++ b/what4/test/ConfigTest.hs
@@ -471,10 +471,12 @@ testHelp =
     withChecklist "builtins" $ do
       cfg <- initialConfig 0 []
       help <- configHelp "" cfg
+      let nonEmptyOr :: (a -> b) -> b -> [a] -> b
+          nonEmptyOr f = foldr (\h _ -> f h)
       help `checkValues`
         (Empty
         :> Val "num" length 1
-        :> Val "verbosity" (L.isInfixOf "verbosity =" . show . head) True
+        :> Val "verbosity" (nonEmptyOr (L.isInfixOf "verbosity =" . show) False) True
         )
 
 

--- a/what4/test/ProbeSolvers.hs
+++ b/what4/test/ProbeSolvers.hs
@@ -27,7 +27,9 @@ getSolverVersion (SolverName solver) =
       if r == ExitSuccess
       then let ol = lines o in
              return $ Right $ SolverVersion
-             $ if null ol then (solver <> " v??") else head ol
+             $ case ol of
+                 [] -> solver <> " v??"
+                 olh:_ -> olh
       else return $ Left $ solver <> " version error: " <> show r <> " /;/ " <> e
     Left (err :: SomeException) -> return $ Left $ solver <> " invocation error: " <> show err
 


### PR DESCRIPTION
This patch contains a variety of fixes needed to build the libraries in the `what4` repo with GHC 9.8:

* Bump the upper version bounds on `base` and `text` to allow building with the versions that are bundled with GHC 9.8 (`base-4.19.*` and `text-2.1.*`, respectively).
* Replace uses of `head` and `tail` (which trigger `-Wx-partial` warnings with GHC 9.8) with total functions or `panic`s, depending on what is appropriate.
* Bump the `aig` submodule to bring in the changes from GaloisInc/aig#16 and GaloisInc/aig#17.