### PR TITLE
CVC5: Don't use Tuple workaround when declaring structs

### DIFF
--- a/.github/workflows/gen_matrix.pl
+++ b/.github/workflows/gen_matrix.pl
@@ -78,7 +78,7 @@ main_version(z3, "4_8_14").
 main_version(yices, "2_6_4").
 main_version(stp, "2_3_3").
 main_version(cvc4, "1_8").
-main_version(cvc5, "1_0_2").
+main_version(cvc5, "1_1_2").
 main_version(bitwuzla, "0_3_0").
 main_version(boolector, "3_2_2").
 main_version(abc, "2021_12_30").
@@ -118,7 +118,7 @@ version(stp, "2_3_2").
 % n.b. stp 2_2_0 fails, no reason to test it
 
 version(cvc4, "1_8").
-version(cvc5, "1_0_2").
+version(cvc5, "1_1_2").
 
 version(bitwuzla, "0_3_0").
 

--- a/what4/src/What4/Solver/CVC4.hs
+++ b/what4/src/What4/Solver/CVC4.hs
@@ -131,6 +131,14 @@ instance SMT2.SMTLib2Tweaks CVC4 where
   smtlib2arraySelect a i = SMT2.arraySelect a (indexCtor i)
   smtlib2arrayUpdate a i = SMT2.arrayStore a (indexCtor i)
 
+  -- CVC4's support for user-defined datatypes is somewhat buggy (see
+  -- https://github.com/cvc5/cvc5/issues/3402). Instead of using user-defined
+  -- datatypes to encode What4 structs, we instead use CVC4's built-in Tuple
+  -- datatype, which does not suffer from this bug. We use the Tuple syntax
+  -- described in https://cvc4.github.io/datatypes.html#tuples.
+  --
+  -- Note that this bug has been fixed in CVC5, so we do not apply the same
+  -- workaround in What4.Solver.CVC5.
   smtlib2declareStructCmd _ = Nothing
   smtlib2StructSort []  = Syntax.varSort "Tuple"
   smtlib2StructSort tps = Syntax.Sort $ "(Tuple" <> foldMap f tps <> ")"

--- a/what4/src/What4/Solver/CVC5.hs
+++ b/what4/src/What4/Solver/CVC5.hs
@@ -125,14 +125,6 @@ instance SMT2.SMTLib2Tweaks CVC5 where
   smtlib2arraySelect a i = SMT2.arraySelect a (indexCtor i)
   smtlib2arrayUpdate a i = SMT2.arrayStore a (indexCtor i)
 
-  smtlib2declareStructCmd _ = Nothing
-  smtlib2StructSort []  = Syntax.varSort "Tuple"
-  smtlib2StructSort tps = Syntax.Sort $ "(Tuple" <> foldMap f tps <> ")"
-    where f x = " " <> Syntax.unSort x
-
-  smtlib2StructCtor args = Syntax.term_app "mkTuple" args
-  smtlib2StructProj _n i x = Syntax.term_app (Syntax.builder_list ["_", "tupSel", fromString (show i)]) [ x ]
-
 cvc5Features :: ProblemFeatures
 cvc5Features = useComputableReals
            .|. useIntegerArithmetic

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1068,8 +1068,8 @@ issue182Test sym solver = do
     let idx = Ctx.Empty Ctx.:> idxInt
     let arrLookup = arrayLookup sym arr idx
     elt <- arrLookup
-    bvZero <- bvZero sym w
-    p <- bvEq sym elt bvZero
+    zeroBV <- bvZero sym w
+    p <- bvEq sym elt zeroBV
 
     checkSatisfiableWithModel solver "test" p $ \case
       Sat fn ->


### PR DESCRIPTION
Due to a bug in CVC4 (https://github.com/cvc5/cvc5/issues/3402), the What4 bindings to CVC4 avoid user-defined datatypes and instead use CVC4's built-in `Tuple` datatype. This same `Tuple` workaround was applied to the CVC5 bindings (added in https://github.com/GaloisInc/what4/pull/204), but they don't really work properly, as CVC4 and CVC5 use completely different syntaxes for tuples. See https://github.com/GaloisInc/what4/issues/265.

We could attempt to update the CVC5 bindings to use the modern tuple syntax, but this is somewhat non-trivial, as the syntax for 1-tuples changed in `cvc5-1.0.9` from `Tuple` to `UnitTuple` (see https://github.com/cvc5/cvc5/pull/10012). As such, we would have to generate different code for different versions of CVC5, which would be unpleasant.

Thankfully, we need not worry about tuples at all when it comes to CVC5. This is because the original CVC4 issue (https://github.com/cvc5/cvc5/issues/3402) does not affect CVC5. As such, we can drop the tuple workaround entirely and just generate user-defined datatypes to represent What4 structs, exactly like the other solver bindings do. This means that we can fix https://github.com/GaloisInc/what4/issues/265 by simply deleting code, which is nice.

In addition, this PR tweaks the `expr-builder-smtlib2` test suite to _actually_ run its tests with both CVC4 and CVC5. The `0-tuple` and `1-tuple` tests catch the exact bug described in #265, so these serve as a regression test for #265 when run with CVC5.

Fixes https://github.com/GaloisInc/what4/issues/265.