### PR TITLE
1.6.1 release prep

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -3,6 +3,10 @@
 * Fix a bug in which `what4`'s CVC5 adapter would fail to parse models
   involving structs. ([#265](https://github.com/GaloisInc/what4/issues/265))
 
+* Add `What4.Expr.GroundEval.groundToSym`, which allows injecting
+  `GroundValue`s back into `SymExpr`s.
+  ([#268](https://github.com/GaloisInc/what4/pull/268))
+
 # 1.6 (May 2024)
 
 * Allow building with GHC 9.8.

--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,4 +1,4 @@
-# next (TBA)
+# 1.6.1 (Sep 2024)
 
 * Fix a bug in which `what4`'s CVC5 adapter would fail to parse models
   involving structs. ([#265](https://github.com/GaloisInc/what4/issues/265))

--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,3 +1,8 @@
+# next (TBA)
+
+* Fix a bug in which `what4`'s CVC5 adapter would fail to parse models
+  involving structs. ([#265](https://github.com/GaloisInc/what4/issues/265))
+
 # 1.6 (May 2024)
 
 * Allow building with GHC 9.8.

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.4
 Name:          what4
-Version:       1.6.0.0.99
+Version:       1.6.1
 Author:        Galois Inc.
 Maintainer:    rscott@galois.com, kquick@galois.com
 Copyright:     (c) Galois, Inc 2014-2023

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.4
 Name:          what4
-Version:       1.6.1
+Version:       1.6.1.0.99
 Author:        Galois Inc.
 Maintainer:    rscott@galois.com, kquick@galois.com
 Copyright:     (c) Galois, Inc 2014-2023


### PR DESCRIPTION
A new Hackage release is needed as part of a fix for https://github.com/GaloisInc/crucible/issues/1246.