### PR TITLE
SMTLib2: only send exit command if solver process is active

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,5 +1,10 @@
 # next
 
+* Fixed a bug where `What4.Protocol.SMTLib2.shutdownSolver` would raise
+  an exception if the solver process had already terminated. This can occur
+  when a solver fails to gracefully time out and the process is killed via
+  `What4.Protocol.killSolver`.
+
 * The `BoolMap` parameter of `ConjPred` is now a `ConjMap`. This is a `newtype`
   wrapper around `BoolMap` that makes clear that the `BoolMap` in question
   represents a conjunction (as `BoolMap`s may also represent disjunctions).

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -1647,8 +1647,11 @@ startSolver solver ack setup tmout feats strictOpt auxOutput sym = do
 shutdownSolver
   :: SMTLib2GenericSolver a => a -> SolverProcess t (Writer a) -> IO (Exit.ExitCode, Lazy.Text)
 shutdownSolver _solver p = do
-  -- Tell solver to exit
-  writeExit (solverConn p)
+  -- Tell solver to exit, if the process is still running
+  status <- Streams.getProcessExitCode (solverHandle p)
+  case status of
+    Just _ -> return ()
+    Nothing -> writeExit (solverConn p)
   txt <- readAllLines (solverStderr p)
   stopHandleReader (solverStderr p)
   ec <- solverCleanupCallback p


### PR DESCRIPTION
this avoids issues where the solver process was
killed via `What4.Protocol.Online.killSolver`
(e.g. due to a forced timeout)