### PR TITLE
Backport #288 changes to new minor release (1.6.3)

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,4 +1,4 @@
-# next (TBA)
+# 1.6.3 (Feb 2025)
 
 * Fixed a bug where `What4.Protocol.SMTLib2.shutdownSolver` would raise
   an exception if the solver process had already terminated. This can occur

--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,3 +1,10 @@
+# next (TBA)
+
+* Fixed a bug where `What4.Protocol.SMTLib2.shutdownSolver` would raise
+  an exception if the solver process had already terminated. This can occur
+  when a solver fails to gracefully time out and the process is killed via
+  `What4.Protocol.killSolver`.
+
 # 1.6.2 (Sep 2024)
 
 * Allow building with GHC 9.10.

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -1647,8 +1647,11 @@ startSolver solver ack setup tmout feats strictOpt auxOutput sym = do
 shutdownSolver
   :: SMTLib2GenericSolver a => a -> SolverProcess t (Writer a) -> IO (Exit.ExitCode, Lazy.Text)
 shutdownSolver _solver p = do
-  -- Tell solver to exit
-  writeExit (solverConn p)
+  -- Tell solver to exit, if the process is still running
+  status <- Streams.getProcessExitCode (solverHandle p)
+  case status of
+    Just _ -> return ()
+    Nothing -> writeExit (solverConn p)
   txt <- readAllLines (solverStderr p)
   stopHandleReader (solverStderr p)
   ec <- solverCleanupCallback p

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -422,7 +422,10 @@ timeoutTests testLevel solvers =
                 -- quickly (~0.25s).  This doesn't allow timeout
                 -- testing, and the speed suggests an improper
                 -- result as well.
-                (SolverName "CVC4", SolverVersion v) | "1.7" `elem` words v->
+                (SolverName "CVC4", SolverVersion v) | "1.7" `elem` words v ->
+                  ignoreTestBecause "solver completes too quickly"
+                -- TODO(#278): Maybe the same problem as above?
+                (SolverName "CVC4", SolverVersion v) | "1.8" `elem` words v ->
                   ignoreTestBecause "solver completes too quickly"
                 _ -> id
         in maybeSkipTest $ testGroup (snamestr $ testSolverName sti)

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.4
 Name:          what4
-Version:       1.6.2
+Version:       1.6.3
 Author:        Galois Inc.
 Maintainer:    rscott@galois.com, kquick@galois.com
 Copyright:     (c) Galois, Inc 2014-2023


### PR DESCRIPTION
This backports the bugfix from #288 to the `1.6` branch, which will form the basis for a new minor Hackage release of `what4` (1.6.3).