### PR TITLE
ci: Stop caching `~/.cabal/{packages,store}`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,6 @@ jobs:
         with:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
-            ~/.cabal/packages
-            ~/.cabal/store
             dist-newstyle
           key: |
             ${{ env.key }}-${{ github.ref }}
@@ -208,7 +206,5 @@ jobs:
         with:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
-            ~/.cabal/packages
-            ~/.cabal/store
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
We already cache `${{ steps.setup-haskell.outputs.cabal-store }}`, so caching the store this way was likely redundant. Not sure why `packages` was cached, but it's probably unnecessary.

Also, in cabal-3.12 or later, the cache is written to ~/.local/state/cabal/store (to respect the XDG Base Directory Specification), so ~/.cabal/store will be flat-out wrong at that point.

Fixes #291.