### PR TITLE
ci: Fix caching of Cabal store

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,8 +89,12 @@ jobs:
           # latter as part of the cache key
           key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-ghc${{ matrix.ghc }}
         with:
+          # Note that in Cabal 3.12 and later, ~/.cabal/store moved to
+          # ~/.local/state/cabal/store. We support lots of versions of GHC and
+          # Cabal, so we cache both. Someday, we can remove the former.
           path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
+            ~/.cabal/store
+            ~/.local/state/cabal/store
             dist-newstyle
           key: |
             ${{ env.key }}-${{ github.ref }}
@@ -205,6 +209,7 @@ jobs:
         if: always()
         with:
           path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
+            ~/.cabal/store
+            ~/.local/state/cabal/store
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Previously, this refered to a nonexistent `step`. Fixes #300.