### PR TITLE
what4: Remove dependency on utf8-string

### DIFF
--- a/what4/src/What4/Protocol/SMTLib2/Parse.hs
+++ b/what4/src/What4/Protocol/SMTLib2/Parse.hs
@@ -42,17 +42,22 @@ import qualified Control.Monad.Fail
 import           Control.Monad (when)
 import           Control.Monad.Reader (ReaderT(..))
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.UTF8 as UTF8
 import           Data.Char
 import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HSet
 import           Data.Ratio
 import           Data.String
+import qualified Data.Text as Text
+import           Data.Text.Encoding (decodeUtf8With)
+import           Data.Text.Encoding.Error (lenientDecode)
 import           Data.Word
 import           System.IO
 
 c2b :: Char -> Word8
 c2b = fromIntegral . fromEnum
+
+decode :: BS.ByteString -> String
+decode = Text.unpack . decodeUtf8With lenientDecode
 
 ------------------------------------------------------------------------
 -- Parser definitions
@@ -162,7 +167,7 @@ parseQuotedString = do
   matchChar '"'
   l <- takeChars (/= '"')
   matchChar '"'
-  pure $ UTF8.toString l
+  pure $ decode l
 
 -- | Defines common operations for parsing SMTLIB results.
 class CanParse a where
@@ -309,7 +314,7 @@ matchApp actions = do
   case filter (\(m,_p) -> m == w) actions of
     [] -> do
       w' <- takeChars (\c -> c `notElem` ['\r', '\n'])
-      fail $ "Unsupported keyword: " ++ UTF8.toString (w <> w')
+      fail $ "Unsupported keyword: " ++ decode (w <> w')
     [(_,p)] -> p
     _:_:_ -> fail $ "internal error: Duplicate keywords " ++ show w
 

--- a/what4/src/What4/Utils/Streams.hs
+++ b/what4/src/What4/Utils/Streams.hs
@@ -11,11 +11,14 @@ module What4.Utils.Streams
 ( logErrorStream
 ) where
 
-import qualified Data.ByteString.UTF8 as UTF8
+import           Data.ByteString (ByteString)
+import           Data.Text (unpack)
+import           Data.Text.Encoding (decodeUtf8With)
+import           Data.Text.Encoding.Error (lenientDecode)
 import qualified System.IO.Streams as Streams
 
 -- | Write from input stream to a logging function.
-logErrorStream :: Streams.InputStream UTF8.ByteString
+logErrorStream :: Streams.InputStream ByteString
                -> (String -> IO ()) -- ^ Logging function
                -> IO ()
 logErrorStream err_stream logFn = do
@@ -23,5 +26,5 @@ logErrorStream err_stream logFn = do
   let write_err Nothing = return ()
       write_err (Just b) = logFn b
   err_output <- Streams.makeOutputStream write_err
-  lns <- Streams.map UTF8.toString =<< Streams.lines err_stream
+  lns <- Streams.map (unpack . decodeUtf8With lenientDecode) =<< Streams.lines err_stream
   Streams.connect lns err_output

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -132,7 +132,6 @@ library
     transformers >= 0.4,
     unliftio >= 0.2 && < 0.3,
     unordered-containers >= 0.2.10,
-    utf8-string >= 1.0.1,
     vector >= 0.12.1,
     versions >= 6.0.2 && < 6.1,
     zenc >= 0.1.0 && < 0.2.0,


### PR DESCRIPTION
It was only used for decoding `ByteString`s, which `Text` can do.