### PR TITLE
Expose uninterpreted functions cache

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,3 +1,7 @@
+# Next release (TBA)
+
+* Expose `ExprBuilder`'s uninterpreted functoin cache
+
 # 1.7 (March 2025)
 
 * The `BoolMap` parameter of `ConjPred` is now a `ConjMap`. This is a `newtype`


### PR DESCRIPTION
When building terms with uninterpreted functions, we'd like to only make a new uninterpreted function once per symbol.
As such, we need to keep track of which symbols we've already processed.   The `ExpreBuilder` has such a cache for when it translates things to uninterpreted functions.  However, for user defined uninterpreted functions we were using a completely separate cache.

I can't think of a good reason to keep these two separate, so this PR exposes the `IORef` for the cache, which makes
it easier to reuse in other contexts that also need to user uninterpreted functions.

To makes things compatable we slightly tweak the type of the cache, but it is essentially the same as it was before.



