### PR TITLE
ci: Use Dependabot for weekly bumps to pinned GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
We have previously manually bumped the pinned versions of the actions used in our CI workflows. Let's automate this process using Dependabot. With this configuration, Dependabot will check for updates weekly, and open pull requests for each of them.

Benefits:

- Save maintainer time when updates are push-button
- See benefits from updated dependencies more quickly and reliably

Risks:

- Requires maintainers to review and merge more PRs
- May create noise for updates that aren't push-button and require some manual intervention

I think our experience using Dependabot on parameterized-utils justifies integrating it here. We've had 3 PRs so far over a period of a few months, and each was merged quickly and without manual intervention.

Fixes #317.