### PR TITLE
Prepare 1.7.2 release

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,3 +1,5 @@
+# next (TBA)
+
 # 1.7.2 (November 2025)
 
 * Fix a regression in `what4-1.7.1` in which `sbvToInteger` could compute

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.4
 Name:          what4
-Version:       1.7.2
+Version:       1.7.2.0.99
 Author:        Galois Inc.
 Maintainer:    rscott@galois.com, kquick@galois.com
 Copyright:     (c) Galois, Inc 2014-2023


### PR DESCRIPTION
This is in preparation of a point release for Hackage that includes that fixes from https://github.com/GaloisInc/what4/pull/330, which fixes a regression introduced in the `what4-1.7.1` release.