### PR TITLE
Only declare struct type for multidimensional SMT arrays if solver supports it

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,5 +1,8 @@
 # next (TBA)
 
+* Fix a bug in which `what4`'s Bitwuzla adapter would generate invalid code
+  involving SMT arrays.
+
 # 1.7.2 (November 2025)
 
 * Fix a regression in `what4-1.7.1` in which `sbvToInteger` could compute

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -1166,7 +1166,8 @@ declareTypes conn = \case
   ComplexToArrayTypeMap  -> return ()
   PrimArrayTypeMap args ret ->
     do traverseFC_ (declareTypes conn) args
-       declareStructDatatype conn args
+       when (supportedFeatures conn `hasProblemFeature` useStructs) $
+         declareStructDatatype conn args
        declareTypes conn ret
   FnArrayTypeMap args ret ->
     do traverseFC_ (declareTypes conn) args


### PR DESCRIPTION
This is crucial for Bitwuzla to be able to support SMT arrays, as it lacks the ability to define structs.

Fixes #333.