### PR TITLE
Fix side conditions lost after `reset-assertions`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,5 +1,10 @@
 # next
 
+* Fix a bug where persistent side conditions (e.g., @Nat >= 0@ constraints)
+  were lost after @reset-assertions@. These constraints are now properly
+  re-asserted after reset. This fix ensures that variables cached with
+  @DeleteNever@ maintain their necessary constraints across solver resets.
+
 # 1.7.3 -- 2026-01-26
 
 * Fix a bug in which `what4`'s Bitwuzla adapter would generate invalid code

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -305,7 +305,8 @@ reset p =
      n <- popEntryStackToTop c
      writeIORef (solverEarlyUnsat p) Nothing
      if solverSupportsResetAssertions p then
-       addCommand c (resetCommand c)
+       do addCommand c (resetCommand c)
+          reassertSideConditions c
      else
        do mapM_ (addCommand c) (popManyCommands c n)
           addCommand c (pushCommand c)

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -306,7 +306,7 @@ reset p =
      writeIORef (solverEarlyUnsat p) Nothing
      if solverSupportsResetAssertions p then
        do addCommand c (resetCommand c)
-          reassertSideConditions c
+          reassertPersistentSideConditions c
      else
        do mapM_ (addCommand c) (popManyCommands c n)
           addCommand c (pushCommand c)

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -64,6 +64,7 @@ module What4.Protocol.SMTWriter
               )
   , connState
   , newWriterConn
+  , reassertSideConditions
   , resetEntryStack
   , popEntryStackToTop
   , entryStackHeight
@@ -643,6 +644,12 @@ data WriterConn t (h :: Type) =
              , consumeAcknowledgement :: AcknowledgementAction t h
                -- ^ Consume an acknowledgement notifications the solver, if
                --   it produces one
+             , sideConditions :: !(IORef [Term h])
+               -- ^ Side conditions that must be re-asserted after
+               --   a @(reset-assertions)@ command. These arise from
+               --   'addPartialSideCond' for variables cached with
+               --   'DeleteNever', whose cache entries survive a reset but whose
+               --   solver-level assertions do not.
              }
 
 -- | An action for consuming an acknowledgement message from the solver,
@@ -729,6 +736,7 @@ newWriterConn h in_h ack solver_name beStrict features bindings cs = do
   entry <- newStackEntry
   stk_ref <- newIORef [entry]
   r <- newIORef emptyState
+  scRef <- newIORef []
   return $! WriterConn { smtWriterName = solver_name
                        , connHandle    = h
                        , connInputHandle = in_h
@@ -742,6 +750,7 @@ newWriterConn h in_h ack solver_name beStrict features bindings cs = do
                        , varBindings  = bindings
                        , connState    = cs
                        , consumeAcknowledgement = ack
+                       , sideConditions = scRef
                        }
 
 -- | Strictness level for parsing solver responses.
@@ -1075,6 +1084,16 @@ bindVarAsFree conn var = do
       addCommand conn $ declareCommand conn var_name Ctx.empty smt_type
       cacheValueExpr conn (bvarId var) DeleteOnPop $ SMTName smt_type var_name
 
+-- | Re-assert all side conditions that were recorded by 'addPartialSideCond'.
+--
+-- See 'sideConditions' for more details.
+reassertSideConditions :: SMTWriter h => WriterConn t h -> IO ()
+reassertSideConditions conn = do
+  conds <- readIORef (sideConditions conn)
+  -- This adds them back in the reverse order they were originally added, but
+  -- that shouldn't matter semantically.
+  mapM_ (assumeFormula conn) conds
+
 -- | Assume that the given formula holds.
 assumeFormula :: SMTWriter h => WriterConn t h -> Term h -> IO ()
 assumeFormula c p = addCommand c (assertCommand c p)
@@ -1358,6 +1377,21 @@ addSideCondition nm t = do
      fail $ "Cannot add a side condition within a function needed to define the "
        ++ nm ++ " term created at " ++ show loc ++ "."
 
+-- | Add a persistent side condition that will be re-asserted after reset.
+--
+-- This is specifically for side conditions on DeleteNever variables (like
+-- UninterpVarKind variables from freshNat, freshConstant, etc.) whose
+-- constraints must persist across reset.
+addPersistentSideCondition ::
+   SMTWriter h =>
+   WriterConn t h ->
+   String {- ^ Reason that condition is being added. -} ->
+   Term h {- ^ Predicate that should hold. -} ->
+   SMTCollector t h ()
+addPersistentSideCondition conn nm t = do
+  addSideCondition nm t
+  liftIO $ modifyIORef' (sideConditions conn) (t:)
+
 addPartialSideCond ::
   forall t h tp.
   SMTWriter h =>
@@ -1371,53 +1405,53 @@ addPartialSideCond ::
 addPartialSideCond _ _ _ Nothing = return ()
 
 addPartialSideCond _ _ BoolTypeMap (Just Nothing) = return ()
-addPartialSideCond _ t BoolTypeMap (Just (Just b)) =
+addPartialSideCond conn t BoolTypeMap (Just (Just b)) =
    -- This is a weird case, but technically possible, so...
-  addSideCondition "bool_val" $ t .== boolExpr b
+  addPersistentSideCondition conn "bool_val" $ t .== boolExpr b
 
-addPartialSideCond _ t IntegerTypeMap (Just rng) =
+addPartialSideCond conn t IntegerTypeMap (Just rng) =
   do case rangeLowBound rng of
        Unbounded -> return ()
-       Inclusive lo -> addSideCondition "int_range" $ t .>= integerTerm lo
+       Inclusive lo -> addPersistentSideCondition conn "int_range" $ t .>= integerTerm lo
      case rangeHiBound rng of
        Unbounded -> return ()
-       Inclusive hi -> addSideCondition "int_range" $ t .<= integerTerm hi
+       Inclusive hi -> addPersistentSideCondition conn "int_range" $ t .<= integerTerm hi
 
-addPartialSideCond _ t RealTypeMap (Just rng) =
+addPartialSideCond conn t RealTypeMap (Just rng) =
   do case rangeLowBound (ravRange rng) of
        Unbounded -> return ()
-       Inclusive lo -> addSideCondition "real_range" $ t .>= rationalTerm lo
+       Inclusive lo -> addPersistentSideCondition conn "real_range" $ t .>= rationalTerm lo
      case rangeHiBound (ravRange rng) of
        Unbounded -> return ()
-       Inclusive hi -> addSideCondition "real_range" $ t .<= rationalTerm hi
+       Inclusive hi -> addPersistentSideCondition conn "real_range" $ t .<= rationalTerm hi
 
-addPartialSideCond _ t (BVTypeMap w) (Just (BVD.BVDArith rng)) = assertRange (BVD.arithDomainData rng)
+addPartialSideCond conn t (BVTypeMap w) (Just (BVD.BVDArith rng)) = assertRange (BVD.arithDomainData rng)
    where
    assertRange Nothing = return ()
    assertRange (Just (lo, sz)) =
-     addSideCondition "bv_range" $ bvULe (bvSub t (bvTerm w (BV.mkBV w lo))) (bvTerm w (BV.mkBV w sz))
+     addPersistentSideCondition conn "bv_range" $ bvULe (bvSub t (bvTerm w (BV.mkBV w lo))) (bvTerm w (BV.mkBV w sz))
 
-addPartialSideCond _ t (BVTypeMap w) (Just (BVD.BVDBitwise rng)) = assertBitRange (BVD.bitbounds rng)
+addPartialSideCond conn t (BVTypeMap w) (Just (BVD.BVDBitwise rng)) = assertBitRange (BVD.bitbounds rng)
    where
    assertBitRange (lo, hi) = do
      when (lo > 0) $
-       addSideCondition "bv_bitrange" $ (bvOr (bvTerm w (BV.mkBV w lo)) t) .== t
+       addPersistentSideCondition conn "bv_bitrange" $ (bvOr (bvTerm w (BV.mkBV w lo)) t) .== t
      when (hi < maxUnsigned w) $
-       addSideCondition "bv_bitrange" $ (bvOr t (bvTerm w (BV.mkBV w hi))) .== (bvTerm w (BV.mkBV w hi))
+       addPersistentSideCondition conn "bv_bitrange" $ (bvOr t (bvTerm w (BV.mkBV w hi))) .== (bvTerm w (BV.mkBV w hi))
 
-addPartialSideCond _ t (UnicodeTypeMap) (Just (StringAbs len)) =
+addPartialSideCond conn t (UnicodeTypeMap) (Just (StringAbs len)) =
   do case rangeLowBound len of
        Inclusive lo ->
-          addSideCondition "string length low range" $
+          addPersistentSideCondition conn "string length low range" $
              integerTerm (max 0 lo) .<= stringLength @h t
        Unbounded ->
-          addSideCondition "string length low range" $
+          addPersistentSideCondition conn "string length low range" $
              integerTerm 0 .<= stringLength @h t
 
      case rangeHiBound len of
        Unbounded -> return ()
        Inclusive hi ->
-         addSideCondition "string length high range" $
+         addPersistentSideCondition conn "string length high range" $
            stringLength @h t .<= integerTerm hi
 
 addPartialSideCond _ _ (FloatTypeMap _) (Just ()) = return ()

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -64,7 +64,7 @@ module What4.Protocol.SMTWriter
               )
   , connState
   , newWriterConn
-  , reassertSideConditions
+  , reassertPersistentSideConditions
   , resetEntryStack
   , popEntryStackToTop
   , entryStackHeight
@@ -644,8 +644,8 @@ data WriterConn t (h :: Type) =
              , consumeAcknowledgement :: AcknowledgementAction t h
                -- ^ Consume an acknowledgement notifications the solver, if
                --   it produces one
-             , sideConditions :: !(IORef [Term h])
-               -- ^ Side conditions that must be re-asserted after
+             , persistentSideConditions :: !(IORef [Term h])
+               -- ^ Persistent side conditions that must be re-asserted after
                --   a @(reset-assertions)@ command. These arise from
                --   'addPartialSideCond' for variables cached with
                --   'DeleteNever', whose cache entries survive a reset but whose
@@ -750,7 +750,7 @@ newWriterConn h in_h ack solver_name beStrict features bindings cs = do
                        , varBindings  = bindings
                        , connState    = cs
                        , consumeAcknowledgement = ack
-                       , sideConditions = scRef
+                       , persistentSideConditions = scRef
                        }
 
 -- | Strictness level for parsing solver responses.
@@ -1084,12 +1084,12 @@ bindVarAsFree conn var = do
       addCommand conn $ declareCommand conn var_name Ctx.empty smt_type
       cacheValueExpr conn (bvarId var) DeleteOnPop $ SMTName smt_type var_name
 
--- | Re-assert all side conditions that were recorded by 'addPartialSideCond'.
+-- | Re-assert all persistent side conditions that were recorded by 'addPartialSideCond'.
 --
--- See 'sideConditions' for more details.
-reassertSideConditions :: SMTWriter h => WriterConn t h -> IO ()
-reassertSideConditions conn = do
-  conds <- readIORef (sideConditions conn)
+-- See 'persistentSideConditions' for more details.
+reassertPersistentSideConditions :: SMTWriter h => WriterConn t h -> IO ()
+reassertPersistentSideConditions conn = do
+  conds <- readIORef (persistentSideConditions conn)
   -- This adds them back in the reverse order they were originally added, but
   -- that shouldn't matter semantically.
   mapM_ (assumeFormula conn) conds
@@ -1362,6 +1362,10 @@ freshBoundTerm' t = SMTName tp <$> freshBoundFn [] tp (asBase t)
   where tp = smtExprType t
 
 -- | Assert a predicate holds as a side condition to some formula.
+--
+-- For conditions that must persist across resets (e.g., constraints on
+-- 'DeleteNever' variables), use 'addPersistentSideCondition' or
+-- 'addPartialSideCond' instead.
 addSideCondition ::
    String {- ^ Reason that condition is being added. -} ->
    Term h {- ^ Predicate that should hold. -} ->
@@ -1381,7 +1385,7 @@ addSideCondition nm t = do
 --
 -- This is specifically for side conditions on DeleteNever variables (like
 -- UninterpVarKind variables from freshNat, freshConstant, etc.) whose
--- constraints must persist across reset.
+-- constraints must persist across reset. See 'persistentSideConditions'.
 addPersistentSideCondition ::
    SMTWriter h =>
    WriterConn t h ->
@@ -1390,8 +1394,10 @@ addPersistentSideCondition ::
    SMTCollector t h ()
 addPersistentSideCondition conn nm t = do
   addSideCondition nm t
-  liftIO $ modifyIORef' (sideConditions conn) (t:)
+  liftIO $ modifyIORef' (persistentSideConditions conn) (t:)
 
+-- | Add side conditions arising from the abstract value of a fresh variable via
+-- 'addPersistentSideCondition'.
 addPartialSideCond ::
   forall t h tp.
   SMTWriter h =>

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -293,6 +293,150 @@ longTimeTest (SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, 
 ----------------------------------------------------------------------
 
 
+-- | Test that side conditions (e.g., Nat >= 0) are preserved after 'reset'.
+--
+-- When a fresh Nat variable is created and sent to the solver, 'mkExpr'
+-- declares it and adds a side condition @n >= 0@ via 'addPartialSideCond'.
+-- After 'reset' (which sends @(reset-assertions)@), these side conditions
+-- should still hold.
+--
+-- We use an unconstrained integer @m@ linked to @n@ via @m = n@ to prevent
+-- the ExprBuilder from optimizing away the check based on abstract domains.
+mkResetSideCondTest :: (SolverTestData, SolverVersion) -> TestTree
+mkResetSideCondTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _), _)
+  | nm `elem` ["Bitwuzla", "Boolector", "STP"]
+  = testCase nm $ assertBool "skipped (no integer support)" True
+  | otherwise
+  = testCase nm $ withIONonceGenerator $ \gen -> do
+    sym <- newExprBuilder FloatUninterpretedRepr EmptyExprBuilderState gen
+    extendConfig opts (getConfiguration sym)
+    proc <- startSolverProcess @s features Nothing sym
+    let conn = solverConn proc
+
+    n <- freshNat sym (safeSymbol "n")
+    nInt <- natToInteger sym n
+    m <- freshConstant sym (safeSymbol "m") BaseIntegerRepr
+    mEqN <- intEq sym m nInt
+
+    -- Force mkExpr to process n (which declares it and adds n >= 0 side condition)
+    inNewFrame proc $ do
+      assume conn mEqN
+      check proc "m = n before reset" >>= \case
+        Unsat _ -> fail "m = n should be SAT"
+        Unknown -> fail "Solver returned UNKNOWN"
+        Sat _ -> return ()
+
+    -- Reset clears all assertions via (reset-assertions), including n >= 0
+    reset proc
+
+    -- After reset, re-assert m = n and check if m < 0 is satisfiable.
+    -- With n >= 0 side condition: m = n >= 0, so m < 0 is UNSAT.
+    -- Without n >= 0 side condition: m = n, n unconstrained, m < 0 is SAT.
+    zero <- intLit sym 0
+    mNeg <- intLt sym m zero
+    inNewFrame proc $ do
+      assume conn mEqN
+      assume conn mNeg
+      check proc "m < 0 after reset" >>= \case
+        Unsat _ -> return ()  -- Correct: n >= 0 side condition preserved
+        Unknown -> fail "Solver returned UNKNOWN"
+        Sat _ -> assertFailure
+          "Side conditions lost after reset: m = n and m < 0 was SAT (n should be >= 0)"
+
+-- | Test that reset actually clears regular assertions.
+--
+-- This test verifies the basic semantics of reset: that it forgets
+-- all previously asserted formulas. We assert a formula, reset, then
+-- assert its negation. If reset worked, the negation should be SAT.
+-- If reset failed to clear the original assertion, we'd get UNSAT.
+mkResetClearsAssertionsTest :: (SolverTestData, SolverVersion) -> TestTree
+mkResetClearsAssertionsTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _), _)
+  | nm `elem` ["Bitwuzla", "Boolector", "STP"]
+  = testCase nm $ assertBool "skipped (no integer support)" True
+  | otherwise
+  = testCase nm $ withIONonceGenerator $ \gen -> do
+    sym <- newExprBuilder FloatUninterpretedRepr EmptyExprBuilderState gen
+    extendConfig opts (getConfiguration sym)
+    proc <- startSolverProcess @s features Nothing sym
+    let conn = solverConn proc
+
+    -- Create an unconstrained integer variable
+    n <- freshConstant sym (safeSymbol "n") BaseIntegerRepr
+    zero <- intLit sym 0
+
+    -- Assert n >= 0 and verify it's satisfiable
+    nNonNegative <- intLe sym zero n
+    inNewFrame proc $ do
+      assume conn nNonNegative
+      check proc "n >= 0 before reset" >>= \case
+        Unsat _ -> fail "n >= 0 should be SAT"
+        Unknown -> fail "Solver returned UNKNOWN"
+        Sat _ -> return ()
+
+    -- Reset should clear all assertions including n >= 0
+    reset proc
+
+    -- Now assert n < 0, which contradicts the previous assertion.
+    -- If reset worked: n < 0 should be SAT (previous assertion cleared)
+    -- If reset failed: n < 0 would be UNSAT (n >= 0 still asserted)
+    nNegative <- intLt sym n zero
+    inNewFrame proc $ do
+      assume conn nNegative
+      check proc "n < 0 after reset" >>= \case
+        Sat _ -> return ()  -- Correct: reset cleared the previous assertion
+        Unknown -> fail "Solver returned UNKNOWN"
+        Unsat _ -> assertFailure
+          "Reset failed to clear assertions: n < 0 is UNSAT (n >= 0 still asserted)"
+
+-- | Test that operation-specific side conditions are not recorded as persistent.
+--
+-- Operations like RealSqrt add side conditions via addSideCondition within appSMTExpr.
+-- These should NOT be added to the persistent sideConditions list (only side conditions
+-- from addPartialSideCond for DeleteNever variables should persist). This test verifies
+-- that sqrt operations work correctly across reset with independent fresh variables.
+mkResetOperationSideCondsTest :: (SolverTestData, SolverVersion) -> TestTree
+mkResetOperationSideCondsTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _), _)
+  | nm `elem` ["Bitwuzla", "Boolector", "STP", "Yices"]
+  = testCase nm $ assertBool "skipped (no real/nonlinear support)" True
+  | otherwise
+  = testCase nm $ withIONonceGenerator $ \gen -> do
+    sym <- newExprBuilder FloatUninterpretedRepr EmptyExprBuilderState gen
+    extendConfig opts (getConfiguration sym)
+    proc <- startSolverProcess @s features Nothing sym
+    let conn = solverConn proc
+
+    -- Create x1 and assert sqrt(x1) = 2
+    -- This creates fresh variable for sqrt result with side conditions
+    x1 <- freshConstant sym (safeSymbol "x1") BaseRealRepr
+    sqrt_x1 <- realSqrt sym x1
+    two <- realLit sym 2
+    sqrt_eq_2 <- realEq sym sqrt_x1 two
+
+    inNewFrame proc $ do
+      assume conn sqrt_eq_2
+      check proc "sqrt(x1) = 2 before reset" >>= \case
+        Unsat _ -> fail "sqrt(x1) = 2 should be SAT"
+        Unknown -> fail "Solver returned UNKNOWN"
+        Sat _ -> return ()
+
+    -- Reset clears all assertions (but not variable declarations)
+    reset proc
+
+    -- Create x2 and assert sqrt(x2) = 3
+    -- This creates a NEW fresh variable for this sqrt result
+    -- Operation side conditions are NOT persistent, only freshConstant bounds are
+    x2 <- freshConstant sym (safeSymbol "x2") BaseRealRepr
+    sqrt_x2 <- realSqrt sym x2
+    three <- realLit sym 3
+    sqrt_eq_3 <- realEq sym sqrt_x2 three
+
+    inNewFrame proc $ do
+      assume conn sqrt_eq_3
+      check proc "sqrt(x2) = 3 after reset" >>= \case
+        Unsat _ -> fail "sqrt(x2) = 3 should be SAT"
+        Unknown -> fail "Solver returned UNKNOWN"
+        Sat _ -> return ()  -- Correct: independent sqrt operation works
+
 main :: IO ()
 main = do
   testLevel <- TestLevel . fromMaybe "0" <$> lookupEnv "CI_TEST_LEVEL"
@@ -305,6 +449,9 @@ main = do
       testGroup "SmokeTest" $ map mkSmokeTest solvers
     , testGroup "QuickStart Framed" $ map (quickstartTest True)  solvers
     , testGroup "QuickStart Direct" $ map (quickstartTest False) solvers
+    , testGroup "Reset Side Conditions" $ map mkResetSideCondTest solvers
+    , testGroup "Reset Clears Assertions" $ map mkResetClearsAssertionsTest solvers
+    , testGroup "Reset Operation Side Conditions" $ map mkResetOperationSideCondsTest solvers
     , timeoutTests testLevel solvers
     ]
 

--- a/what4/test/OnlineSolverTest.hs
+++ b/what4/test/OnlineSolverTest.hs
@@ -293,7 +293,7 @@ longTimeTest (SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, 
 ----------------------------------------------------------------------
 
 
--- | Test that side conditions (e.g., Nat >= 0) are preserved after 'reset'.
+-- | Test that persistent side conditions (e.g., Nat >= 0) are preserved after 'reset'.
 --
 -- When a fresh Nat variable is created and sent to the solver, 'mkExpr'
 -- declares it and adds a side condition @n >= 0@ via 'addPartialSideCond'.
@@ -304,7 +304,7 @@ longTimeTest (SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, 
 -- the ExprBuilder from optimizing away the check based on abstract domains.
 mkResetSideCondTest :: (SolverTestData, SolverVersion) -> TestTree
 mkResetSideCondTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _), _)
-  | nm `elem` ["Bitwuzla", "Boolector", "STP"]
+  | not (hasProblemFeature features useIntegerArithmetic) || nm == "STP" -- stp times out
   = testCase nm $ assertBool "skipped (no integer support)" True
   | otherwise
   = testCase nm $ withIONonceGenerator $ \gen -> do
@@ -351,7 +351,7 @@ mkResetSideCondTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features
 -- If reset failed to clear the original assertion, we'd get UNSAT.
 mkResetClearsAssertionsTest :: (SolverTestData, SolverVersion) -> TestTree
 mkResetClearsAssertionsTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _), _)
-  | nm `elem` ["Bitwuzla", "Boolector", "STP"]
+  | not (hasProblemFeature features useIntegerArithmetic) || nm == "STP" -- stp times out
   = testCase nm $ assertBool "skipped (no integer support)" True
   | otherwise
   = testCase nm $ withIONonceGenerator $ \gen -> do
@@ -391,12 +391,12 @@ mkResetClearsAssertionsTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), 
 -- | Test that operation-specific side conditions are not recorded as persistent.
 --
 -- Operations like RealSqrt add side conditions via addSideCondition within appSMTExpr.
--- These should NOT be added to the persistent sideConditions list (only side conditions
+-- These should NOT be added to the persistentSideConditions list (only side conditions
 -- from addPartialSideCond for DeleteNever variables should persist). This test verifies
 -- that sqrt operations work correctly across reset with independent fresh variables.
 mkResetOperationSideCondsTest :: (SolverTestData, SolverVersion) -> TestTree
 mkResetOperationSideCondsTest ((SolverName nm, AnOnlineSolver (Proxy :: Proxy s), features, opts, _), _)
-  | nm `elem` ["Bitwuzla", "Boolector", "STP", "Yices"]
+  | not (hasProblemFeature features useNonlinearArithmetic)
   = testCase nm $ assertBool "skipped (no real/nonlinear support)" True
   | otherwise
   = testCase nm $ withIONonceGenerator $ \gen -> do


### PR DESCRIPTION
After `reset` (which sends `(reset-assertions)` or equivalent), side conditions added by `addPartialSideCond` (e.g., Nat >= 0 for fresh Nat variables) are cleared from the solver. However, the `WriterConn` cache still has `DeleteNever` entries for these variables, so `mkExpr` doesn't re-add the side conditions when the variables are next encountered.

The test creates a `Nat` variable `n` (with side condition `n >= 0`), links it to an unconstrained integer `m` via `m = n`, resets the solver, then checks that `m < 0` is still UNSAT. Without the fix, the side condition is lost and `m < 0` becomes SAT.

The fix adds a `sideConditions` field to `WriterConn` that accumulates side condition terms as they are asserted via `runOnLiveConnection`. After `reset` sends `(reset-assertions)`, `reassertSideConditions` replays all accumulated side conditions to restore the solver's invariants.