### PR TITLE
`what4-transition-system`: Allow building with `ansi-wl-pprint-1.0.*` and `containers-0.7.*`

### DIFF
--- a/what4-transition-system/what4-transition-system.cabal
+++ b/what4-transition-system/what4-transition-system.cabal
@@ -12,10 +12,10 @@ build-type:    Simple
 
 common dependencies
   build-depends:
-    , ansi-wl-pprint       ^>=0.6
+    , ansi-wl-pprint       ^>=0.6 || ^>=1.0
     , base                 >=4.12 && <4.22
     , bytestring
-    , containers           ^>=0.6
+    , containers           ^>=0.6 || ^>=0.7
     , io-streams
     , lens
     , parameterized-utils  >=2.0  && <2.2


### PR DESCRIPTION
This is needed to allow more build plans when building `what4-transition-system` using GHC 9.12.