### PR TITLE
Check for linear arithmetic support in `floatToReal`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -4,6 +4,9 @@
   were lost after @reset-assertions@. These constraints are now properly
   re-asserted after reset. This fix ensures that variables cached with
   @DeleteNever@ maintain their necessary constraints across solver resets.
+* What4 now gives a proper error message when preparing to send a query to
+  Bitwuzla involving the `floatToReal` operation (which Bitwuzla does not
+  support) instead of throwing a parse exception.
 * Replace `lens` with `microlens-{,-mtl,-th}`.
 
 # 1.7.3 -- 2026-01-26

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -2677,6 +2677,7 @@ appSMTExpr ae = do
       xe <- mkBaseExpr x
       freshBoundTerm (BVTypeMap w) $ floatToSBV (natValue w) r xe
     FloatToReal x -> do
+      checkLinearSupport i
       xe <- mkBaseExpr x
       freshBoundTerm RealTypeMap $ floatToReal xe
     FloatSpecialFunction{} -> unsupportedTerm i


### PR DESCRIPTION
This ensures that solvers which do not support linear arithmetic (e.g., Bitwuzla) will raise a proper error message when encountering `floatToReal` operations instead of throwing an inscrutable parse exception.

Fixes #361.