### PR TITLE
Deprecate `What4.Utils.Endian`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -1,5 +1,6 @@
 # next
 
+* Deprecate `What4.Utils.Endian`, use `Data.Parameterized.Utils.Endian` instead.
 * Fix a bug where persistent side conditions (e.g., @Nat >= 0@ constraints)
   were lost after @reset-assertions@. These constraints are now properly
   re-asserted after reset. This fix ensures that variables cached with

--- a/what4/src/What4/Utils/Endian.hs
+++ b/what4/src/What4/Utils/Endian.hs
@@ -1,3 +1,3 @@
-module What4.Utils.Endian where
+module What4.Utils.Endian {-# DEPRECATED "Use Data.Parameterized.Utils.Endian instead" #-} where
 
 data Endian = LittleEndian | BigEndian deriving (Eq,Show,Ord)


### PR DESCRIPTION
Fixes #368.