### PR TITLE
domains: Strided interval domain

### DIFF
--- a/what4-domains/doc/arithdomain.cry
+++ b/what4-domains/doc/arithdomain.cry
@@ -11,6 +11,8 @@ bit width) by loading this file in cryptol and entering ":prove".
 */
 module arithdomain where
 
+import bitsdomain as B
+
 ////////////////////////////////////////////////////////////
 // Library
 
@@ -209,6 +211,9 @@ add a b = withBot (a.isBot \/ b.isBot)
   (if carry a.sz b.sz then top
    else interval (a.lo + b.lo) (a.sz .+. b.sz))
 
+sub : {n} (fin n) => Dom n -> Dom n -> Dom n
+sub a b = add a (neg b)
+
 neg : {n} (fin n) => Dom n -> Dom n
 neg a = withBot a.isBot (interval (- (a.lo + a.sz)) a.sz)
 
@@ -217,6 +222,28 @@ neg a = withBot a.isBot (interval (- (a.lo + a.sz)) a.sz)
 bnot : {n} (fin n) => Dom n -> Dom n
 bnot a = withBot a.isBot (interval (~ ah) a.sz)
   where ah = a.lo + a.sz
+
+toBitwise : {n} (fin n, n >= 1) => Dom n -> B::Dom n
+toBitwise a = { lomask = hi ^ u, himask = hi }
+  where
+    u  = unknowns a
+    hi = a.lo || u
+
+fromBitwise : {n} (fin n) => B::Dom n -> Dom n
+fromBitwise bw = if bw.himask - bw.lomask == ~0 then top
+                 else interval bw.lomask (bw.himask - bw.lomask)
+
+band : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+band a b = withBot (a.isBot \/ b.isBot)
+  (fromBitwise (B::band (toBitwise a) (toBitwise b)))
+
+bor : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+bor a b = withBot (a.isBot \/ b.isBot)
+  (fromBitwise (B::bor (toBitwise a) (toBitwise b)))
+
+bxor : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+bxor a b = withBot (a.isBot \/ b.isBot)
+  (fromBitwise (B::bxor (toBitwise a) (toBitwise b)))
 
 mul : {n} (fin n) => Dom n -> Dom n -> Dom n
 mul a b = withBot (a.isBot \/ b.isBot)
@@ -345,6 +372,14 @@ ashr a b = withBot (a.isBot \/ b.isBot) (interval cl (ch - cl))
     (bl, bh) = ubounds b
     cl = al >>$ (if al <$ 0 then bl else bh)
     ch = ah >>$ (if ah <$ 0 then bh else bl)
+
+rol : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+rol a b = withBot (a.isBot \/ b.isBot)
+  (fromBitwise (B::rolAbstract (toBitwise a) (toBitwise b)))
+
+ror : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+ror a b = withBot (a.isBot \/ b.isBot)
+  (fromBitwise (B::rorAbstract (toBitwise a) (toBitwise b)))
 
 ////////////////////////////////////////////////////////////
 // Comparisons
@@ -528,6 +563,10 @@ correct_add : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Property
 correct_add a b x y =
   mem a x ==> mem b y ==> mem (add a b) (x + y)
 
+correct_sub : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Property
+correct_sub a b x y =
+  mem a x ==> mem b y ==> mem (sub a b) (x - y)
+
 correct_neg : {n} (fin n) => Dom n -> [n] -> Property
 correct_neg a x =
   mem a x <==> mem (neg a) (- x)
@@ -576,6 +615,14 @@ correct_ashr : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
 correct_ashr a b x y =
   mem a x ==> mem b y ==> mem (ashr a b) (x >>$ y)
 
+correct_rol : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
+correct_rol a b x y =
+  mem a x ==> mem b y ==> mem (rol a b) (x <<< y)
+
+correct_ror : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
+correct_ror a b x y =
+  mem a x ==> mem b y ==> mem (ror a b) (x >>> y)
+
 correct_slt : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
 correct_slt a b x y =
   slt a b ==> mem a x ==> mem b y ==> x <$ y
@@ -603,6 +650,18 @@ correct_not : {n} (fin n) => Dom n -> [n] -> Property
 correct_not a x =
   mem a x <==> mem (bnot a) (~ x)
 
+correct_and : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
+correct_and a b x y =
+  mem a x ==> mem b y ==> mem (band a b) (x && y)
+
+correct_or : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
+correct_or a b x y =
+  mem a x ==> mem b y ==> mem (bor a b) (x || y)
+
+correct_xor : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Property
+correct_xor a b x y =
+  mem a x ==> mem b y ==> mem (bxor a b) (x ^ y)
+
 correct_asSingleton : {n} (fin n) => Dom n -> Property
 correct_asSingleton a =
   isSingleton a ==> a == singleton a.lo
@@ -610,6 +669,14 @@ correct_asSingleton a =
 correct_unknowns : {n} (fin n, n >= 1) => Dom n -> [n] -> [n] -> Property
 correct_unknowns a x y =
   mem a x ==> mem a y ==> (x || unknowns a) == (y || unknowns a)
+
+correct_toBitwise : {n} (fin n, n >= 1) => Dom n -> [n] -> Property
+correct_toBitwise a x =
+  mem a x ==> B::mem (toBitwise a) x
+
+correct_fromBitwise : {n} (fin n, n >= 1) => B::Dom n -> [n] -> Property
+correct_fromBitwise bw x =
+  B::mem bw x ==> mem (fromBitwise bw) x
 
 property p1 = correct_any`{16}
 property p2 = correct_ubounds`{16}
@@ -625,20 +692,28 @@ property p10 = correct_shrink`{8, 8}
 property p11 = correct_trunc`{8, 8}
 property p12 = correct_unknowns`{16}
 property p13 = correct_asSingleton`{16}
+property p14 = correct_toBitwise`{16}
+property p15 = correct_fromBitwise`{16}
 
 property a1 = correct_add`{8}
-property a2 = correct_neg`{16}
-property a3 = correct_mul`{4}
-property a4 = correct_udiv`{8}
-property a5 = correct_urem`{6}
-property a6 = correct_sdiv`{6}
-property a7 = correct_srem`{6}
-property a8 = correct_not`{16}
+property a2 = correct_sub`{8}
+property a3 = correct_neg`{16}
+property a4 = correct_mul`{4}
+property a5 = correct_udiv`{8}
+property a6 = correct_urem`{6}
+property a7 = correct_sdiv`{6}
+property a8 = correct_srem`{6}
 property a9 = correct_sdivRange`{6}
+property a10 = correct_not`{16}
+property a11 = correct_and`{8}
+property a12 = correct_or`{8}
+property a13 = correct_xor`{8}
 
 property s1 = correct_shl`{8}
 property s2 = correct_lshr`{8}
 property s3 = correct_ashr`{8}
+property s4 = correct_rol`{8}
+property s5 = correct_ror`{8}
 
 property o1 = correct_slt`{16}
 property o2 = correct_sle`{16}

--- a/what4-domains/doc/stridedinterval.cry
+++ b/what4-domains/doc/stridedinterval.cry
@@ -1,0 +1,1536 @@
+/*
+
+This file contains a Cryptol implementation of the strided-interval
+abstract domain operations from
+What4.Domains.BV.StridedInterval in what4-domains.
+
+A strided interval at width n represents
+  { (base + i * stride) mod 2^n | 0 <= i <= range }.
+The empty set is encoded by `stride = 0`; non-empty SIs require `stride
+>= 1`, leaving that slot free for the bottom sentinel. Field names and
+the encoding match the Haskell module exactly.
+
+In addition to the algorithms themselves, this file also contains
+specifications of correctness for each of the operations. All of the
+correctness properties can be formally proven (each at some specific
+bit width) by loading this file in cryptol and entering ":prove".
+
+Stride-1 operations delegate to `arithdomain.cry` (imported as `A`); this
+mirrors how the Haskell module routes through `What4.Domains.BV.Arith` for
+the same paths.
+
+*/
+module stridedinterval where
+
+import arithdomain as A
+
+////////////////////////////////////////////////////////////
+// Library
+
+/** Greatest common divisor of two unsigned bitvectors. Iterates the
+Euclidean step `(a, b) ↦ (b, a mod b)` until `b` reaches 0; this
+terminates in at most 2n steps for n-bit inputs (Fibonacci bound). */
+gcd : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+gcd x y = (steps ! 0).0
+  where
+  step : ([n], [n]) -> ([n], [n])
+  step (a, b) = if b == 0 then (a, 0) else (b, a % b)
+  steps : [2*n]([n], [n])
+  steps = take`{2*n} (iterate step (x, y))
+
+/** True iff `x + y` overflows the unsigned [n] range. */
+overflow_add : {n} (fin n) => [n] -> [n] -> Bit
+overflow_add x y = carry x y
+
+/** True iff `x * y` overflows the unsigned [n] range. */
+overflow_mul : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+overflow_mul x y = take`{n} (zext`{2*n} x * zext y) != 0
+
+/** Least common multiple of two unsigned bitvectors. Returns `0` when
+either input is `0`. Computed via `(x * y) / gcd x y`; we widen to `2n`
+for the multiplication so it doesn't wrap, and conservatively return `0`
+(meaning "saturated") when the true `lcm` doesn't fit in `[n]`. */
+lcm : {n} (fin n, n >= 1) => [n] -> [n] -> [n]
+lcm x y =
+  if x == 0 \/ y == 0 then 0
+  else if hi == 0 then lo else 0
+  where
+  prod : [2*n]
+  prod = zext x * zext y
+  q    = prod / zext (gcd x y)
+  hi   = take`{n} q
+  lo   = drop`{n} q
+
+////////////////////////////////////////////////////////////
+// Diophantine helpers
+//
+// `glb` (greatest lower bound) needs to solve
+//
+//     a * x - b * y = c
+//
+// for nonnegative bounded integers x, y. We work in `Integer` so that
+// intermediate Bezout coefficients can grow without overflow, mirroring
+// the Haskell implementation in What4.Domains.BV.StridedInterval.Internal,
+// which uses unbounded `Integer` arithmetic.
+
+/** Extended Euclidean algorithm. Returns `(g, n', m')` with `g >= 0`
+and `n' * a + m' * b = g`. When `a` and `b` are both nonzero,
+`g = gcd a b`. We unfold a finite number of Euclidean steps; for any
+inputs with `gcd <= 2^k`, `4k + 4` iterations is safely sufficient,
+matching the Fibonacci-style bound on the iteration count. The
+`{steps}` type parameter selects this iteration cap; callers should
+pick `steps` large enough for the scale of inputs they're proving
+about (we use `4*n + 4` for the bit-width-`n` proofs). */
+eGCD :
+  {steps} (fin steps) =>
+  Integer -> Integer -> (Integer, Integer, Integer)
+eGCD a0 b0 = if final.0 < 0 then (- final.0, - final.1, - final.2) else final
+  where
+  step (a, b, x0, x1, y0, y1) =
+    if b == 0 then (a, 0, x0, x1, y0, y1)
+    // Haskell uses `quot`/`rem` (truncated toward zero), which is what
+    // `sIntegerQuot`/`sIntegerRem` model; built-in `/` and `%` on
+    // Integer are floor div / floor mod and would diverge for negative
+    // operands.
+    else (b, sIntegerRem a b,
+          x1, x0 - sIntegerQuot a b * x1,
+          y1, y0 - sIntegerQuot a b * y1)
+  iters : [steps](Integer, Integer, Integer, Integer, Integer, Integer)
+  iters = take`{steps} (iterate step (a0, b0, 1, 0, 0, 1))
+  finalState  = iters ! 0
+  final = (finalState.0, finalState.2, finalState.4)
+
+/** Signed quotient on `Integer` (Haskell `quot`): truncated toward zero. */
+sIntegerQuot : Integer -> Integer -> Integer
+sIntegerQuot x y =
+  if (x < 0) ^ (y < 0) then - (sIntegerAbs x / sIntegerAbs y)
+                       else sIntegerAbs x / sIntegerAbs y
+
+sIntegerAbs : Integer -> Integer
+sIntegerAbs v = if v < 0 then -v else v
+
+/** Signed remainder on `Integer` (Haskell `rem`): sign matches dividend. */
+sIntegerRem : Integer -> Integer -> Integer
+sIntegerRem x y = x - sIntegerQuot x y * y
+
+/** `ceiling(x / y)` on `Integer`. Requires `y > 0`. Mirrors the Haskell
+`ceilDivPos x y = negate (negate x \`div\` y)` where `div` is floor
+division on `Integer`. */
+ceilDivPos : Integer -> Integer -> Integer
+ceilDivPos x y = - integerFloorDiv (-x) y
+
+/** `floor(x / y)` on `Integer`. Requires `y > 0`. Mirrors the Haskell
+`floorDivPos x y = x \`div\` y`. */
+floorDivPos : Integer -> Integer -> Integer
+floorDivPos x y = integerFloorDiv x y
+
+/** Floor division on `Integer` (mirrors Haskell `div`): rounds toward
+negative infinity. */
+integerFloorDiv : Integer -> Integer -> Integer
+integerFloorDiv u v =
+  if (u < 0) ^ (v < 0) /\ sIntegerRem u v != 0
+    then sIntegerQuot u v - 1
+    else sIntegerQuot u v
+
+/** Solve `a * x - b * y = c` for nonnegative `x`, `y` with `x <= a_max`
+and `y <= b_max`. Assumes `a > 0`, `b > 0`, `a_max >= 0`, `b_max >= 0`,
+and `c /= 0`. Returns `(False, _, _)` when no such pair exists. Works
+on `Integer` to mirror the unbounded-integer arithmetic of the Haskell
+counterpart. The `{steps}` parameter caps the eGCD iteration count. */
+solveLinearDiophantine :
+  {steps} (fin steps) =>
+  Integer -> Integer -> Integer -> Integer -> Integer ->
+  (Bit, Integer, Integer)
+solveLinearDiophantine a b c a_max b_max =
+  if cr != 0 then (False, 0, 0)
+  else if t <= t_upper then (True, n_co * cq + bq * t, m_co * cq + aq * t)
+  else (False, 0, 0)
+  where
+  egcd_res = eGCD`{steps} a (-b)
+  g    = egcd_res.0
+  n_co = egcd_res.1
+  m_co = egcd_res.2
+  cq   = sIntegerQuot c g
+  cr   = sIntegerRem c g
+  aq   = sIntegerQuot a g
+  bq   = sIntegerQuot b g
+  nc   = n_co * c
+  mc   = m_co * c
+  t       = maxI (ceilDivPos (-nc) b) (ceilDivPos (-mc) a)
+  t_upper = minI (floorDivPos (a_max * g - nc) b)
+                 (floorDivPos (b_max * g - mc) a)
+  // Local max/min on Integer (the Cryptol prelude versions are over
+  // ordered bitvectors and don't fire here without help).
+  maxI u v = if u < v then v else u
+  minI u v = if u < v then u else v
+
+////////////////////////////////////////////////////////////
+// Domain type
+//
+// Field names and encoding match the Haskell record exactly. Empty SIs
+// are represented by `stride = 0`; the `stride >= 1` invariant on
+// non-empty SIs leaves that slot free for the bottom sentinel. The
+// canonical bottom shape pins `base = 0, siRange = 0, stride = 0`.
+
+/** Strided-interval domain element at width n.
+
+When `stride >= 1` the represented set is
+@{ (base + i * stride) mod 2^n | 0 <= i <= siRange }@. When `stride = 0`
+the domain is the empty set; `base` and `siRange` are pinned to `0`
+(see `proper`). */
+type StridedInterval n =
+  { base : [n], siRange : [n], stride : [n] }
+
+/** Largest element of a non-empty SI, before the mod-2^n reduction.
+Undefined for empty. */
+intervalEnd : {n} (fin n, n >= 1) => StridedInterval n -> [n]
+intervalEnd a = a.base + a.siRange * a.stride
+
+/** Cardinality of the SI (0 when empty). Mirrors Haskell `size`. */
+size : {n} (fin n, n >= 1) => StridedInterval n -> [n]
+size a = if isBottom a then 0 else a.siRange + 1
+
+isSingleton : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+isSingleton a = ~ isBottom a /\ a.siRange == 0
+
+/** True iff `a` is the full domain @[0, 2^n - 1]@ (canonical `top`). */
+isAny : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+isAny a = a == (top : StridedInterval n)
+
+/** Defining membership: `x` is in the SI iff `x = (base + i * stride) mod 2^n`
+for some `0 <= i <= siRange`.  We compute this without overflow by working
+modulo 2^n and then dividing by stride. */
+member : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+member a x =
+  ~ isBottom a /\ (s == 1 \/ d % s == 0) /\ d / s <= a.siRange
+  where
+  d = x - a.base  // Already mod 2^n thanks to bitvector arithmetic.
+  // For non-bottom proper SIs the stride is >= 1; the guard is a no-op
+  // there, but keeps the division well-defined when this is called on
+  // a bottom SI before the `~ isBottom` check short-circuits.
+  s = if a.stride == 0 then 1 else a.stride
+
+/** Proper-and-member. Mirrors Haskell `pmember`. */
+pmember : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+pmember a x = proper a /\ member a x
+
+/** Width invariant: every public SI is bottom (in canonical form) or
+non-empty with stride >= 1 and `(siRange + 1) * stride <= 2^n`.
+Mirrors `What4.Domains.BV.StridedInterval.proper`. */
+proper : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+proper a =
+  if isBottom a
+    then a.base == 0 /\ a.siRange == 0
+    else a.stride >= 1 /\
+         ~ (overflow_mul a.siRange a.stride) /\
+         ~ overflowsModulus /\
+         ~ uncanonical_full /\
+         ~ uncanonical_singleton
+  where
+  // (siRange + 1) * stride <= 2^n: same condition the Haskell uses,
+  // expressed without subtraction-induced wrap.
+  prod = zext`{2*n} a.siRange * zext a.stride + zext a.stride
+  overflowsModulus = prod > zext (~0 : [n]) + 1
+  // Canonicalize "full set" shapes to `top` (base = 0).
+  uncanonical_full = a.siRange == ~0 /\ a.stride == 1 /\ a.base != 0
+  // Canonicalize singletons to stride 1 (the constructor's choice).
+  uncanonical_singleton = a.siRange == 0 /\ a.stride != 1
+
+////////////////////////////////////////////////////////////
+// Constructors
+
+/** Singleton interval at value `v`. */
+singleton : {n} (fin n, n >= 1) => [n] -> StridedInterval n
+singleton v = { base = v, siRange = 0, stride = 1 }
+
+/** Contiguous (stride-1) interval of width covering `[lo, hi]` (mod 2^n).
+Mirrors Haskell `range`, which delegates to Arith's `range`. */
+range : {n} (fin n, n >= 1) => [n] -> [n] -> StridedInterval n
+range lo hi = fromArith (A::range lo hi)
+
+/** Construct an SI starting at `lo` with stride `s` whose largest
+element is at most `hi`. When `roundUp` is true the upper bound is
+rounded up to `lo + r * s`; otherwise it's rounded down. Returns `bottom`
+when `hi < lo`. Stride 0 (or range 0) collapses to a singleton. Mirrors
+Haskell `mkStridedInterval`. */
+mkStridedInterval :
+  {n} (fin n, n >= 1) => Bit -> [n] -> [n] -> [n] -> StridedInterval n
+mkStridedInterval roundUp lo hi s =
+  if hi < lo then bottom
+  else if s == 0 then singleton lo
+  else if r == 0 then singleton lo
+  else normalize { base = lo, siRange = r, stride = s }
+  where
+  // Round-up the difference in [n+1] to avoid `+(s-1)` overflowing.
+  rWide : [n+1]
+  rWide = if roundUp then (zext (hi - lo) + zext (s - 1)) / zext s
+                     else zext (hi - lo) / zext s
+  r = drop`{1} rWide
+
+/** Force a possibly-out-of-range SI into proper form. Mirrors Haskell
+`normalize`: drops to a stride-1 contiguous cover when the size cap is
+exceeded but the residues fit in one cycle; otherwise clamps to `top`.
+Singletons are canonicalized to stride 1. The dewrap step rotates one-
+step-wrap APs to a non-wrapping representation when residues form an
+AP starting at 0. */
+normalize : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n
+normalize a =
+  if isBottom a then bottom
+  else if a.siRange == 0 then singleton a.base
+  else if fits then
+    if a.siRange == ~0 /\ a.stride == 1
+      then top
+      else dewrap a  // base already mod 2^n by bitvector arithmetic
+  else if spanWide >= mWide - 1 then top
+  else { base = a.base
+       , siRange = a.siRange * a.stride
+       , stride = 1 }
+  where
+  prod : [2*n]
+  prod = zext a.siRange * zext a.stride + zext a.stride
+  mWide : [2*n]
+  mWide = (zext (~0 : [n]) : [2*n]) + 1
+  spanWide : [2*n]
+  spanWide = zext a.siRange * zext a.stride
+  fits = prod <= mWide
+
+/** Internal: rotate a one-step-wrap SI to a non-wrapping
+representation. Applies when `(range+1)*stride == 2^n` (so the last
+residue wraps and the wrap distance equals the stride). The new base
+is `(base - stride) mod 2^n`, which is the smallest residue in the
+sorted-AP form. */
+dewrap : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n
+dewrap a =
+  if isFullCycle /\ a.base >= a.stride
+    then { base = a.base - a.stride, siRange = a.siRange, stride = a.stride }
+    else a
+  where
+  // (range+1) * stride == 2^n, computed in [n+1] to avoid overflow.
+  prod : [n+1]
+  prod = (zext a.siRange + 1) * zext a.stride
+  m_n1 : [n+1]
+  m_n1 = (zext (~0 : [n]) : [n+1]) + 1
+  isFullCycle = prod == m_n1
+
+////////////////////////////////////////////////////////////
+// Conversion to/from Arith
+
+/** Project a stride-1 SI into an Arith domain /exactly/. Mirrors
+Haskell `asArith`: returns `(False, _)` for bottom or stride > 1
+(which Arith cannot represent precisely). */
+asArith : {n} (fin n, n >= 1) => StridedInterval n -> (Bit, A::Dom n)
+asArith a =
+  if isBottom a then (False, A::top)
+  else if a.stride == 1 then (True, A::interval a.base a.siRange)
+  else (False, A::top)
+
+/** Project /any/ SI into an Arith domain by coarsening to its
+contiguous unsigned cover. Empty SIs map to Arith bottom; for stride > 1
+the result is a sound over-approximation. Mirrors Haskell `toArith`. */
+toArith : {n} (fin n, n >= 1) => StridedInterval n -> A::Dom n
+toArith a =
+  if isBottom a then A::bottom
+  // Stride-1 case is exact.
+  else if a.stride == 1 then A::interval a.base a.siRange
+  // For stride > 1 use the contiguous cover. Wrapping is preserved
+  // because Arith's interval natively supports it (sz can be such
+  // that lo + sz wraps).
+  else A::interval a.base (a.siRange * a.stride)
+
+/** Lift an Arith domain to a stride-1 SI. Mirrors Haskell `fromArith`:
+canonicalizes the full-set Arith shape to `top` and bottom to `bottom`. */
+fromArith : {n} (fin n, n >= 1) => A::Dom n -> StridedInterval n
+fromArith d =
+  if d.isBot then bottom
+  else if d.sz == ~0 then top
+  else { base = d.lo, siRange = d.sz, stride = 1 }
+
+////////////////////////////////////////////////////////////
+// Lattice operations
+
+/** Top element of the lattice: the full domain. */
+top : {n} (fin n, n >= 1) => StridedInterval n
+top = { base = 0, siRange = ~0, stride = 1 }
+
+/** Bottom element of the lattice: the empty set. */
+bottom : {n} (fin n, n >= 1) => StridedInterval n
+bottom = { base = 0, siRange = 0, stride = 0 }
+
+/** True iff this domain has no members (i.e., is `bottom`). */
+isBottom : {n} (fin n) => StridedInterval n -> Bit
+isBottom a = a.stride == 0
+
+/** Lattice join (least upper bound). Mirrors Haskell `join`: picks
+representatives whose midpoints are within `2^(n-1)` of each other
+(lifting one operand by `2^n` when not), then takes the gcd-of-strides
+cover. The lifting picks the wrap-shorter of the two arcs, matching
+`A::join`'s centroid trick. */
+join : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+join a b =
+  if isBottom a then b
+  else if isBottom b then a
+  // Stride-1 fast path: route through Arith for the canonical shape.
+  else if t1.0 /\ t2.0 then fromArith (A::join t1.1 t2.1)
+  else if r == 0 then singleton (drop`{2} lower)
+  // If `r >= 2^n` the result spans more than one full cycle and won't
+  // fit at width `[n]` — fall back to `top`. (Haskell's unbounded
+  // Integer arithmetic in `mkStridedInterval` then `normalize` reaches
+  // the same result; we have to detect the overflow explicitly.)
+  else if r >= m_n2 then top
+  else normalize { base = drop`{2} lower
+                 , siRange = drop`{2} r
+                 , stride = drop`{2} s }
+  where
+  t1 = asArith a
+  t2 = asArith b
+  // Twice each interval's midpoint, in the [n+2] representation. We
+  // need [n+2] (not [n+1]) because `ac = 2*base + range*stride` can
+  // reach `3*2^n - 3` for non-trivial inputs, and the comparisons
+  // `ac + (m-1) < bc` need an extra bit of headroom on top.
+  acBase : [n+2]
+  acBase = 2 * zext a.base + zext (a.siRange * a.stride)
+  bcBase : [n+2]
+  bcBase = 2 * zext b.base + zext (b.siRange * b.stride)
+  // m_n2 = 2^n, expressed in the [n+2] type.
+  m_n2 : [n+2]
+  m_n2 = zext (~0 : [n]) + 1
+  b1 : [n+2]
+  b1 = if acBase + (m_n2 - 1) < bcBase then zext a.base + m_n2 else zext a.base
+  b2 : [n+2]
+  b2 = if bcBase + (m_n2 - 1) < acBase then zext b.base + m_n2 else zext b.base
+  lower : [n+2]
+  lower = min b1 b2
+  upper : [n+2]
+  upper = max (b1 + zext (a.siRange * a.stride))
+              (b2 + zext (b.siRange * b.stride))
+  // Singleton inputs have stride = 1 by canonicalization, but that
+  // stride is meaningless (one-element set). Drop it from the gcd so
+  // the gap stride can be inherited.
+  s1 : [n]
+  s1 = if a.siRange == 0 then 0 else a.stride
+  s2 : [n]
+  s2 = if b.siRange == 0 then 0 else b.stride
+  s : [n+2]
+  s = gcd (zext (gcd s1 s2)) (max b1 b2 - lower)
+  // Round-up division: r = ceil((upper - lower) / s). All in [n+2] to
+  // match the widened centroid arithmetic above.
+  r : [n+2]
+  r = if s == 0 then 0 else (upper - lower + (s - 1)) / s
+
+/** Lattice meet: a sound /over/-approximation of intersection. For any
+concrete value `x`, if `x` is in both `a` and `b`, then `x` is in
+`meet a b`. When `a ⊑ b` or `b ⊑ a` the result is the smaller operand
+exactly (preserving stride); otherwise routes through `A::meet` on the
+contiguous Arith covers. Distinct from `glb`, which is an
+/under/-approximation. */
+meet : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+meet a b =
+  if isBottom a then a
+  else if isBottom b then b
+  else if isAny a then b
+  else if isAny b then a
+  else if a == b then a
+  else if leq a b then a
+  else if leq b a then b
+  else fromArith (A::meet (toArith a) (toArith b))
+
+/** Lattice ordering: every element of `a` is also in `b`. Sound under-
+approximation of subset; may report `False` for proper subsets that hold
+by wrap. Mirrors the Haskell `leq`. */
+leq : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+leq a b =
+  if isBottom a then True
+  else if isBottom b then False
+  else if isAny b then True
+  else if isSingleton a then member b a.base
+  else if a.stride == 1 /\ b.stride == 1 then A::leq (toCoverA a) (toCoverA b)
+  else if b.stride > gcd a.stride b.stride then False
+  else if ~ member b a.base then False
+  // Otherwise check every element. Bounded by `siRange + 1` from the
+  // size cap; for proof purposes we Cryptol-fold the membership over
+  // `[0..2^n)` and short-circuit at `siRange`.
+  else allMembers
+  where
+  toCoverA s = A::interval s.base s.siRange
+  // For 0 <= i <= a.siRange, check that `a.base + i * a.stride` is in b.
+  // We enumerate all 2^n indices (the full range of [n]) and
+  // short-circuit on the siRange bound.
+  indices : [2^^n][n]
+  indices = take`{2^^n} [0 ...]
+  allMembers = and [ ~ (i <= a.siRange) \/ member b (a.base + i * a.stride)
+                   | i <- indices
+                   ]
+
+/** `join` specialized to a singleton. Mirrors Haskell `unionSingleton`. */
+unionSingleton : {n} (fin n, n >= 1) => [n] -> StridedInterval n -> StridedInterval n
+unionSingleton v a = join (singleton v) a
+
+/** Greatest lower bound: a strided interval that under-approximates the
+true intersection. Exact when one operand is a singleton. Mirrors Haskell
+`glb`, including the size-cap clamp on `r` to keep the result a sound
+under-approximation. */
+glb : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+glb a b =
+  if isBottom a \/ isBottom b then bottom
+  else if isSingleton a then (if member b a.base then a else bottom)
+  else if isSingleton b then (if member a b.base then b else bottom)
+  else if a.base == b.base then build a.base
+  else if ok /\ fitsBase then build newbase
+  else bottom
+  where
+  upper = min_unsigned (intervalEnd a) (intervalEnd b)
+  s_lcm = lcm a.stride b.stride
+  // General case: solve the Diophantine equation in `Integer` to mirror
+  // the unbounded-integer Haskell helper. The eGCD iteration cap
+  // `4*n + 4` matches the Fibonacci bound on Euclidean steps for inputs
+  // bounded by `2^n`.
+  c        : Integer
+  c        = toInteger b.base - toInteger a.base
+  sld_res  = solveLinearDiophantine`{4*n + 4}
+               (toInteger a.stride) (toInteger b.stride)
+               c (toInteger a.siRange) (toInteger b.siRange)
+  ok       = sld_res.0
+  n_step   = sld_res.1
+  newbaseInt : Integer
+  newbaseInt = toInteger a.base + n_step * toInteger a.stride
+  fitsBase = 0 <= newbaseInt /\ newbaseInt <= toInteger (~0 : [n])
+  newbase  = fromInteger newbaseInt : [n]
+  // Cap `r` at the size-cap so `mkStridedInterval` below doesn't widen
+  // to `any` (which is *not* a sound under-approximation of glb).
+  build lo =
+    if s_lcm == 0 then bottom
+    else if upper < lo then bottom
+    else mkStridedInterval False lo (lo + r lo * s_lcm) s_lcm
+
+  m : [2*n]
+  m = (zext (~0 : [n]) : [2*n]) + 1
+  rFromUpper lo = (upper - lo) / s_lcm
+  rFromCap : [n]
+  rFromCap = drop`{n} ((m / zext s_lcm) - 1)
+  r lo = if rFromUpper lo <= rFromCap then rFromUpper lo else rFromCap
+
+  min_unsigned u v = if u <= v then u else v
+
+////////////////////////////////////////////////////////////
+// Arithmetic
+//
+// All arithmetic is modulo 2^n. Stride-1 paths delegate to `arithdomain`
+// to mirror the Haskell module's routing through Arith.
+
+/** Addition modulo 2^n. Mirrors Haskell `add`. The combined range
+`r = range_a*(stride_a/s) + range_b*(stride_b/s)` can exceed `2^n`
+(producing an oversized SI that `normalize` then clamps to the cover);
+we compute it in `[2*n]` so the intermediate doesn't wrap before
+`normalize` sees it. */
+add : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+add a b =
+  if isBottom a \/ isBottom b then bottom
+  else if isSingleton a then normalize { base = a.base + b.base
+                                       , siRange = b.siRange, stride = b.stride }
+  else if isSingleton b then normalize { base = a.base + b.base
+                                       , siRange = a.siRange, stride = a.stride }
+  // Stride-aware integer-AP cover anchored at `base a + base b` with
+  // stride `gcd(a.stride, b.stride)`. The cover spans `r1*s1 + r2*s2`
+  // integers — the same total span as the Arith cover — but sparser
+  // by a factor of `s`, so it's always at least as precise as routing
+  // through `A.add` on the contiguous covers. When the strided shape
+  // exceeds the size cap, `normalize` falls back to a stride-1 cover
+  // with the same span, which is exactly the Arith cover. Mirrors
+  // Haskell `add`.
+  else if rWide >= mWide then top
+  else normalize { base = a.base + b.base
+                 , siRange = drop`{n} rWide, stride = s }
+  where
+  s = gcd a.stride b.stride
+  rWide : [2*n]
+  rWide = (zext a.siRange * zext (a.stride / s)) +
+          (zext b.siRange * zext (b.stride / s))
+  mWide : [2*n]
+  mWide = (zext (~0 : [n]) : [2*n]) + 1
+
+/** Add-with-carry. `(False, _)` is `Nothing` (unknown carry-in, widens
+range by 1); `(True, b)` is `Just b`. Mirrors Haskell `adc`. */
+adc :
+  {n} (fin n, n >= 1) =>
+  StridedInterval n -> StridedInterval n -> (Bit, Bit) -> StridedInterval n
+adc a b cIn =
+  if isBottom a \/ isBottom b then bottom
+  else if cIn.0 then add a (add b (singleton cBit))
+  else join (adc a b (True, False)) (adc a b (True, True))
+  where
+  cBit : [n]
+  cBit = if cIn.1 then 1 else 0
+
+/** Negation modulo 2^n. Mirrors Haskell `negate`. */
+negate : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n
+negate a =
+  if isBottom a then bottom
+  else normalize { base = - intervalEnd a
+                 , siRange = a.siRange, stride = a.stride }
+
+/** Subtraction modulo 2^n. Mirrors Haskell `sub`.
+
+Anchors at `a.base - b.base - b.range*b.stride` (the smallest corner
+of the difference rectangle - the most negative `a_i - b_j`) and uses
+`gcd(a.stride, b.stride)` as the new stride. Going native rather than
+`add a (negate b)` matters because `negate` canonicalizes via
+`normalize`'s `dewrap` step, which dewraps `(range+1)*stride == 2^n`
+shapes to a non-wrapping anchor; that loses the rotation that
+`A::negate` picks for the contiguous cover. */
+sub : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+sub a b =
+  if isBottom a \/ isBottom b then bottom
+  else if isSingleton b then normalize { base = a.base - b.base
+                                       , siRange = a.siRange, stride = a.stride }
+  else if rWide >= mWide then top
+  else normalize { base = a.base - b.base - b.siRange * b.stride
+                 , siRange = drop`{n} rWide, stride = s }
+  where
+  s = gcd a.stride b.stride
+  rWide : [2*n]
+  rWide = (zext a.siRange * zext (a.stride / s)) +
+          (zext b.siRange * zext (b.stride / s))
+  mWide : [2*n]
+  mWide = (zext (~0 : [n]) : [2*n]) + 1
+
+/** Multiply every element by a scalar `k` modulo 2^n. Mirrors Haskell
+`scale`. The Cryptol `*` is already mod-2^n, so we don't need separate
+overflow checks — `normalize` clamps to `any` when the size cap is
+exceeded. */
+scale : {n} (fin n, n >= 1) => [n] -> StridedInterval n -> StridedInterval n
+scale k a =
+  if isBottom a then bottom
+  else if k == 0 then singleton 0
+  // When `stride * k` is a multiple of `2^n` (i.e. wraps to 0), every
+  // element scales to the same residue `base * k`; the result is a
+  // singleton. Detected via `[2*n]` widening so we don't lose the
+  // wrap.
+  else if drop`{n} sWide == 0 then singleton (a.base * k)
+  else normalize { base = a.base * k
+                 , siRange = a.siRange, stride = drop`{n} sWide }
+  where
+  sWide : [2*n]
+  sWide = zext a.stride * zext k
+
+/** Multiplication modulo 2^n. Uses the Haskell `mul`'s corner-product
+method on signed representatives: the product @(b1 + i*s1)(b2 + j*s2)@
+is bilinear in @(i, j)@ over the rectangle @[0,r1] x [0,r2]@, so its
+integer-valued extrema lie at the four corners. The result SI covers
+@[min_corner, max_corner]@ with stride = gcd of the three cross-term
+step strides. Intermediate products use wide signed bitvectors
+(@[3*n+2]@) to avoid modular overflow. */
+mul : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+mul a b =
+  if isBottom a \/ isBottom b then bottom
+  else if s > mask_w then top
+  else normalize { base = drop`{2*n+2} baseMod
+                 , siRange = if s == 0 then 0 else drop`{2*n+2} rW
+                 , stride = if s == 0 then 1 else drop`{2*n+2} s }
+  where
+  type W = 3*n + 2
+  m_w : [W]
+  m_w = (zext (~0 : [n]) : [W]) + 1
+  mask_w : [W]
+  mask_w = zext (~0 : [n])
+  smodW : [W] -> [W]
+  smodW x = if x <$ 0 then (x + k * m_w) else x - (x / m_w) * m_w
+    where k = (-(x + 1)) / m_w + 1
+  lift : StridedInterval n -> [W]
+  lift si =
+    if 2 * (zext si.base : [W]) + (zext si.siRange : [W]) * (zext si.stride : [W]) > mask_w
+      then (zext si.base : [W]) - m_w
+      else (zext si.base : [W])
+  lo1 : [W]
+  lo1 = lift a
+  lo2 : [W]
+  lo2 = lift b
+  hi1 : [W]
+  hi1 = lo1 + (zext a.siRange : [W]) * (zext a.stride : [W])
+  hi2 : [W]
+  hi2 = lo2 + (zext b.siRange : [W]) * (zext b.stride : [W])
+  ll : [W]
+  ll = lo1 * lo2
+  lh : [W]
+  lh = lo1 * hi2
+  hl : [W]
+  hl = hi1 * lo2
+  hh : [W]
+  hh = hi1 * hi2
+  sminW : [W] -> [W] -> [W]
+  sminW x y = if x <$ y then x else y
+  smaxW : [W] -> [W] -> [W]
+  smaxW x y = if x >$ y then x else y
+  cl : [W]
+  cl = sminW (sminW ll lh) (sminW hl hh)
+  ch : [W]
+  ch = smaxW (smaxW ll lh) (smaxW hl hh)
+  absW : [W] -> [W]
+  absW x = if x <$ 0 then -x else x
+  step1 : [W]
+  step1 = if a.siRange == 0 then 0 else absW ((zext a.stride : [W]) * lo2)
+  step2 : [W]
+  step2 = if b.siRange == 0 then 0 else absW ((zext b.stride : [W]) * lo1)
+  step12 : [W]
+  step12 = if a.siRange == 0 \/ b.siRange == 0 then 0
+           else (zext a.stride : [W]) * (zext b.stride : [W])
+  sRaw : [W]
+  sRaw = gcd (gcd step1 step2) step12
+  s : [W]
+  s = if sRaw == 0 then 1 else sRaw
+  baseMod : [W]
+  baseMod = smodW cl
+  rW : [W]
+  rW = if s == 0 then 0
+       else if (ch - cl) / s > mask_w then mask_w
+       else (ch - cl) / s
+
+/** Bitwise complement modulo 2^n. Mirrors Haskell `not`. */
+bvNot : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n
+bvNot a =
+  if isBottom a then bottom
+  else normalize { base = ~0 - intervalEnd a
+                 , siRange = a.siRange, stride = a.stride }
+
+////////////////////////////////////////////////////////////
+// Routed-through-Arith ops
+//
+// SI has no precise refinement for these. The Haskell module routes
+// through Arith on stride-1 inputs and falls back to `any` otherwise;
+// we do the same.
+
+udiv : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+udiv a b =
+  if isBottom a \/ isBottom b then bottom
+  else fromArith (A::udiv (toArith a) (toArith b))
+
+urem : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+urem a b =
+  if isBottom a \/ isBottom b then bottom
+  else fromArith (A::urem (toArith a) (toArith b))
+
+sdiv : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+sdiv a b =
+  if isBottom a \/ isBottom b then bottom
+  else fromArith (A::sdiv (toArith a) (toArith b))
+
+srem : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+srem a b =
+  if isBottom a \/ isBottom b then bottom
+  else fromArith (A::srem (toArith a) (toArith b))
+
+/** Left shift. When the shift amount is a singleton `k`, scales by
+`2^k` (preserving stride structure); otherwise routes through `A::shl`. */
+shl : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+shl a b =
+  if isBottom a \/ isBottom b then bottom
+  else if isSingleton b then
+    (if b.base >= `n then singleton 0
+     else scale (1 << b.base) a)
+  else fromArith (A::shl (toArith a) (toArith b))
+
+/** Logical right shift. When the shift amount is a singleton `k`,
+divides every element by `2^k` (preserving stride when the operand's
+stride is divisible by `2^k`); otherwise routes through `A::lshr`. */
+lshr : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+lshr a b =
+  if isBottom a \/ isBottom b then bottom
+  else if isSingleton b then
+    (if b.base >= `n then singleton 0
+     else lshrConst a b.base)
+  else fromArith (A::lshr (toArith a) (toArith b))
+
+/** Internal: shift @a@ right by @k@ bits, preserving stride when
+@a@ is non-wrapping and its stride is divisible by @2^k@. Mirrors
+Haskell `lshrConst`. */
+lshrConst : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> StridedInterval n
+lshrConst a k =
+  if k == 0 then a
+  // Wrapping in integer view ⇒ lose precision; fall back.
+  else if endRes < a.base then arithFallback
+  else if a.stride % shift_k == 0 then
+    normalize { base = a.base >> k
+              , siRange = a.siRange
+              , stride = a.stride / shift_k }
+  else arithFallback
+  where
+  shift_k = 1 << k
+  endRes = a.base + a.siRange * a.stride
+  arithFallback = fromArith (A::lshr (toArith a) (A::interval k 0))
+
+ashr : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> StridedInterval n
+ashr a b =
+  if isBottom a \/ isBottom b then bottom
+  else fromArith (A::ashr (toArith a) (toArith b))
+
+////////////////////////////////////////////////////////////
+// Width manipulation
+
+/** Zero-extend. Mirrors Haskell `zext`. The Haskell version splits
+wrapping intervals into the union of two non-wrapping segments; here we
+do the same by routing through Arith. */
+zextSI :
+  {n, u} (fin n, fin u, n >= 1, u >= n + 1) => StridedInterval n -> StridedInterval u
+zextSI a =
+  if isBottom a then bottom
+  // Non-wrapping: relabel directly (residues unchanged at the wider
+  // width, since they're already < 2^n <= 2^u).
+  else if endRes >= a.base then
+    { base = zext a.base, siRange = zext a.siRange, stride = zext a.stride }
+  // Wrapping: cover by the union of the two non-wrapping segments
+  // `[base, 2^n - 1]` and `[0, endRes]`, expressed at the wider width.
+  else join (range (zext a.base) (zext (~0 : [n])))
+            (range 0 (zext endRes))
+  where
+  endRes = a.base + a.siRange * a.stride
+
+/** Restrict an SI to elements in the unsigned interval `[lo, hi]`,
+preserving stride. Returns `(False, _)` when no elements fall in the
+range; otherwise `(True, result)`. Internal helper for `sextSI`;
+assumes `0 <= lo <= hi < 2^n`.
+
+Mirrors Haskell `clipUnsigned`. We use `Integer` for the index/residue
+arithmetic so that `i*stride` doesn't wrap. */
+clipUnsigned :
+  {n} (fin n, n >= 1) =>
+  StridedInterval n -> [n] -> [n] -> (Bit, StridedInterval n)
+clipUnsigned a lo hi =
+  if isBottom a then (False, bottom)
+  else if preBit /\ postBit then (True, join pre post)
+  else if preBit then (True, pre)
+  else if postBit then (True, post)
+  else (False, bottom)
+  where
+  s : Integer
+  s = toInteger a.stride
+  m : Integer
+  m = 2 ^^ (`n : Integer)
+  rng : Integer
+  rng = toInteger a.siRange
+  b : Integer
+  b = toInteger a.base
+  loI : Integer
+  loI = toInteger lo
+  hiI : Integer
+  hiI = toInteger hi
+  // First wrap-around index: smallest `i` with `b + i*s >= m`. If this
+  // exceeds `rng`, the SI doesn't wrap.
+  iWrap = ceilDivPosI (m - b) s
+  // Pre-wrap segment: `i in [0, min (iWrap - 1) rng]`, residues
+  // `b, b+s, ..., b + i*s` (no wrap).
+  preEnd = if iWrap - 1 < rng then iWrap - 1 else rng
+  preResult = clipSegment 0 preEnd b
+  preBit = preResult.0
+  pre    = preResult.1
+  // Post-wrap segment: `i in [iWrap, rng]`, residues start at
+  // `b + iWrap*s - m` and march by `s`.
+  postResult =
+    if iWrap > rng then (False, bottom)
+    else clipSegment iWrap rng (b + iWrap * s - m)
+  postBit = postResult.0
+  post    = postResult.1
+  // Clip a contiguous AP segment to `[loI, hiI]`. The set of
+  // qualifying `i`s in `[iLo, iHi]` forms a contiguous integer range.
+  clipSegment : Integer -> Integer -> Integer -> (Bit, StridedInterval n)
+  clipSegment iLo iHi startBase =
+    if iLo > iHi then (False, bottom)
+    else if endRes < loI then (False, bottom)        // entirely below
+    else if startBase > hiI then (False, bottom)     // entirely above
+    else if firstI <= lastI then
+      (True, { base = fromInteger ((b + firstI * s) % m)
+             , siRange = fromInteger (lastI - firstI)
+             , stride = a.stride })
+    else (False, bottom)
+    where
+    endRes = startBase + (iHi - iLo) * s
+    firstI = sIntegerMax iLo (iLo + ceilDivPosI (loI - startBase) s)
+    lastI  = sIntegerMin iHi (iLo + (hiI - startBase) / s)
+  // Ceiling division by a positive divisor; returns 0 when `x <= 0`.
+  ceilDivPosI : Integer -> Integer -> Integer
+  ceilDivPosI x y = if x <= 0 then 0 else (x + y - 1) / y
+  sIntegerMin x y = if x < y then x else y
+  sIntegerMax x y = if x > y then x else y
+
+/** Sign-extend. Mirrors Haskell `sext` exactly, including the
+straddling/wrapping case where the SI is split at the sign boundary
+into a non-negative part and a negative part (each with stride
+preserved by `clipUnsigned`), and the negative part is shifted by the
+sign-extension amount. */
+sextSI :
+  {n, u} (fin n, fin u, n >= 1, u >= n + 1) => StridedInterval n -> StridedInterval u
+sextSI a =
+  if isBottom a then bottom
+  // Non-wrapping, all non-negative: relabel at the new width.
+  else if endRes >= a.base /\ endRes < half then
+    { base = zext a.base, siRange = zext a.siRange, stride = zext a.stride }
+  // Non-wrapping, all negative: shift the base into the sign-extended range.
+  else if endRes >= a.base /\ a.base >= half then
+    { base = (zext a.base) + signExt
+           , siRange = zext a.siRange
+           , stride = zext a.stride }
+  // Straddles the sign boundary or wraps: split via `clipUnsigned` into
+  // non-negative `[0, half-1]` and negative `[half, m_old-1]` parts,
+  // shift the negative part by `signExt`, and join.
+  else if posPart /\ negPart then join (widen pos) (shiftedNeg neg)
+  else if posPart then widen pos
+  else if negPart then shiftedNeg neg
+  else bottom
+  where
+  endRes = a.base + a.siRange * a.stride
+  // half = 2^(n-1) (the signed midpoint of [n]).
+  half : [n]
+  half = 1 << (`n - 1 : [n])
+  signExt : [u]
+  signExt = (~0 : [u]) - (zext (~0 : [n])) // = 2^u - 2^n
+  posResult = clipUnsigned a 0 (half - 1)
+  negResult = clipUnsigned a half (~0 : [n])
+  posPart   = posResult.0
+  pos       = posResult.1
+  negPart   = negResult.0
+  neg       = negResult.1
+  // Widen an SI from [n] to [u] (zero-extending all fields).
+  widen : StridedInterval n -> StridedInterval u
+  widen s =
+    { base = zext s.base, siRange = zext s.siRange, stride = zext s.stride }
+  // Widen and add `signExt` to the base, shifting the negative segment
+  // into the sign-extended range of `[u]`.
+  shiftedNeg : StridedInterval n -> StridedInterval u
+  shiftedNeg s =
+    { base = zext s.base + signExt
+    , siRange = zext s.siRange
+    , stride = zext s.stride }
+
+/** Truncate to a strictly narrower width. Mirrors the Haskell
+`trunc` shape: relabel when in-range; cover all residues when stride
+divides the modulus; otherwise widen to `any`. */
+truncSI :
+  {n, v} (fin n, fin v, v >= 1, n >= v + 1) => StridedInterval n -> StridedInterval v
+truncSI a =
+  if isBottom a then bottom
+  else if isAny a then top
+  // Already fits the size cap at the new width `(range+1)*stride <= m_v`:
+  // relabel and let `normalize` canonicalize. Computed in `[2*n]` to
+  // avoid overflow in the multiplication.
+  else if ((zext a.siRange + 1) * zext a.stride : [2*n]) <= zext m then
+    normalize { base = drop`{n - v} base_v_n
+              , siRange = drop`{n - v} a.siRange
+              , stride = drop`{n - v} a.stride }
+  // Stride divides modulus: every residue class is hit.
+  else if a.stride != 0 /\ m % a.stride == 0
+       then if a.stride == m
+              then singleton (drop`{n - v} base_v_n)
+              else normalize
+                   { base = drop`{n - v} ((base_v_n
+                              + a.stride * ceilDivU (m - base_v_n) a.stride) % m)
+                   , siRange = drop`{n - v} ((m / a.stride) - 1)
+                   , stride = drop`{n - v} a.stride }
+  else top
+  where
+  // `m = 2^v`, computed at width `[n]` (fits because `n > v`).
+  m : [n]
+  m = (zext (~0 : [v]) : [n]) + 1
+  mMinus1 : [n]
+  mMinus1 = m - 1
+  base_v_n : [n]
+  base_v_n = a.base % m
+  ceilDivU : [n] -> [n] -> [n]
+  ceilDivU x y = (x + y - 1) / y
+
+/** Concatenation. The result is `{a * 2^v + b | a ∈ a_dom, b ∈ b_dom}`.
+When `b` is a singleton, the high bits inherit `a`'s stride scaled by
+`2^v`. When `a` is a singleton and `b` is non-wrapping, the high bits
+are constant and `b`'s shape carries through. Otherwise routes through
+`A::concat` on the contiguous covers. Mirrors Haskell `concatSI`. */
+concatSI :
+  {u, v} (fin u, fin v, u >= 1, v >= 1) =>
+  StridedInterval u -> StridedInterval v -> StridedInterval (u + v)
+concatSI a b =
+  if isBottom a \/ isBottom b then bottom
+  else if isSingleton b then
+    // {a_i * 2^v + bv}: stride scales by 2^v, range preserved.
+    normalize { base = (zext a.base) * shift_v + (zext b.base : [u + v])
+              , siRange = zext a.siRange
+              , stride = (zext a.stride) * shift_v }
+  else if isSingleton a /\ b.base + b.siRange * b.stride >= b.base then
+    // {av * 2^v + b_j} with non-wrapping b: shift b's shape.
+    normalize { base = (zext a.base) * shift_v + (zext b.base : [u + v])
+              , siRange = zext b.siRange
+              , stride = zext b.stride }
+  else fromArith (A::concat (toArith a) (toArith b))
+  where
+  shift_v : [u + v]
+  shift_v = 1 << (`v : [u + v])
+
+////////////////////////////////////////////////////////////
+// Destructors
+
+/** Inclusive unsigned bounds. For wrapping or `any` SIs, returns
+(0, ~0). Mirrors Haskell `ubounds`. */
+ubounds : {n} (fin n, n >= 1) => StridedInterval n -> ([n], [n])
+ubounds a =
+  if isBottom a then (0, ~0)
+  else if isAny a then (0, ~0)
+  else if endRes >= a.base then (a.base, endRes)
+  else (0, ~0)
+  where
+  endRes = a.base + a.siRange * a.stride
+
+/** Equality test. Mirrors Haskell `eq`. The first component is a
+"definite" flag; when `True` the second is the answer. */
+eq : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> (Bit, Bit)
+eq a b =
+  if isSingleton a /\ isSingleton b then (True, a.base == b.base)
+  else if ~ domainsOverlap a b then (True, False)
+  else (False, False)
+
+/** Conservative overlap predicate. Mirrors Haskell `domainsOverlap`.
+Adds a residue-class disjointness check: if `(base a - base b) mod
+gcd(stride a, stride b)` is non-zero and neither operand wraps, the
+sets are integer-disjoint, so they're modular-disjoint too. The residue
+check is computed in `[2*n]` to avoid the difference wrapping mod 2^n. */
+domainsOverlap : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+domainsOverlap a b =
+  if isBottom a \/ isBottom b then False
+  else if isAny a \/ isAny b then True
+  else if g != 0 /\ residueDiff != 0 /\ ~ wraps a /\ ~ wraps b
+       then False
+  else A::overlap (toArith a) (toArith b)
+  where
+  g : [2*n]
+  g = zext (gcd a.stride b.stride)
+  // Compare integer differences |aBase - bBase| mod g, widening to
+  // [2*n] so the difference doesn't wrap.
+  aBase : [2*n]
+  aBase = zext a.base
+  bBase : [2*n]
+  bBase = zext b.base
+  residueDiff = if aBase >= bBase then (aBase - bBase) % g
+                                  else (bBase - aBase) % g
+  wraps si = si.base + si.siRange * si.stride < si.base
+
+////////////////////////////////////////////////////////////
+// Correctness properties: invariant postconditions
+
+correct_proper_bottom : {n} (fin n, n >= 1) => Bit
+correct_proper_bottom = proper`{n} bottom
+
+correct_proper_singleton : {n} (fin n, n >= 1) => [n] -> Bit
+correct_proper_singleton v = proper (singleton v)
+
+correct_proper_top : {n} (fin n, n >= 1) => Bit
+correct_proper_top = proper`{n} top
+
+correct_proper_mkStridedInterval :
+  {n} (fin n, n >= 1) => Bit -> [n] -> [n] -> [n] -> Bit
+correct_proper_mkStridedInterval roundUp lo hi s =
+  proper (mkStridedInterval roundUp lo hi s)
+
+correct_proper_range : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+correct_proper_range lo hi = proper (range lo hi)
+
+correct_proper_join : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_join a b = proper a ==> proper b ==> proper (join a b)
+
+correct_proper_unionSingleton :
+  {n} (fin n, n >= 1) => [n] -> StridedInterval n -> Bit
+correct_proper_unionSingleton v a = proper a ==> proper (unionSingleton v a)
+
+correct_proper_glb : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_glb a b = proper a ==> proper b ==> proper (glb a b)
+
+correct_proper_add : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_add a b = proper a ==> proper b ==> proper (add a b)
+
+correct_proper_adc :
+  {n} (fin n, n >= 1) =>
+  StridedInterval n -> StridedInterval n -> (Bit, Bit) -> Bit
+correct_proper_adc a b c = proper a ==> proper b ==> proper (adc a b c)
+
+correct_proper_sub : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_sub a b = proper a ==> proper b ==> proper (sub a b)
+
+correct_proper_negate : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_proper_negate a = proper a ==> proper (negate a)
+
+correct_proper_scale : {n} (fin n, n >= 1) => [n] -> StridedInterval n -> Bit
+correct_proper_scale k a = proper a ==> proper (scale k a)
+
+correct_proper_mul : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_mul a b = proper a ==> proper b ==> proper (mul a b)
+
+correct_proper_not : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_proper_not a = proper a ==> proper (bvNot a)
+
+correct_proper_shl : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_shl a b = proper a ==> proper b ==> proper (shl a b)
+
+correct_proper_lshr : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_lshr a b = proper a ==> proper b ==> proper (lshr a b)
+
+correct_proper_ashr : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_ashr a b = proper a ==> proper b ==> proper (ashr a b)
+
+correct_proper_udiv : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_udiv a b = proper a ==> proper b ==> proper (udiv a b)
+
+correct_proper_urem : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_urem a b = proper a ==> proper b ==> proper (urem a b)
+
+correct_proper_sdiv : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_sdiv a b = proper a ==> proper b ==> proper (sdiv a b)
+
+correct_proper_srem : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+correct_proper_srem a b = proper a ==> proper b ==> proper (srem a b)
+
+correct_proper_zext :
+  {n, u} (fin n, fin u, n >= 1, u >= n + 1) => StridedInterval n -> Bit
+correct_proper_zext a = proper a ==> proper (zextSI`{n, u} a)
+
+correct_proper_sext :
+  {n, u} (fin n, fin u, n >= 1, u >= n + 1) => StridedInterval n -> Bit
+correct_proper_sext a = proper a ==> proper (sextSI`{n, u} a)
+
+correct_proper_trunc :
+  {n, v} (fin n, fin v, v >= 1, n >= v + 1) => StridedInterval n -> Bit
+correct_proper_trunc a = proper a ==> proper (truncSI`{n, v} a)
+
+correct_proper_concat :
+  {u, v} (fin u, fin v, u >= 1, v >= 1) =>
+  StridedInterval u -> StridedInterval v -> Bit
+correct_proper_concat a b = proper a ==> proper b ==> proper (concatSI a b)
+
+////////////////////////////////////////////////////////////
+// Correctness properties: helpers (eGCD, ceilDivPos, floorDivPos,
+// solveLinearDiophantine). These pin down the algebraic spec of the
+// internals that `glb` depends on. The corresponding macaw-side bug
+// (an incorrect `t` and a buggy `ceil_quot`) was caught by direct
+// helper tests after the integrated `glb`-level properties missed it
+// for years; these are the Cryptol equivalents.
+
+correct_eGCD_bezout : {k} (fin k, k >= 1) => [k] -> [k] -> Bit
+correct_eGCD_bezout aBits bBits =
+  egcd_res.1 * a + egcd_res.2 * b == egcd_res.0
+  where
+  a = toSignedInteger aBits
+  b = toSignedInteger bBits
+  egcd_res = eGCD`{4*k + 4} a b
+
+correct_eGCD_nonNegative : {k} (fin k, k >= 1) => [k] -> [k] -> Bit
+correct_eGCD_nonNegative aBits bBits = ~ ((eGCD`{4*k + 4} a b).0 < 0)
+  where
+  a = toSignedInteger aBits
+  b = toSignedInteger bBits
+
+correct_ceilDivPos : {k} (fin k, k >= 1) => [k] -> [k] -> Bit
+correct_ceilDivPos xBits yBits =
+  y > 0 ==> q * y >= x /\ (q - 1) * y < x
+  where
+  x = toSignedInteger xBits
+  y = toSignedInteger yBits
+  q = ceilDivPos x y
+
+correct_floorDivPos : {k} (fin k, k >= 1) => [k] -> [k] -> Bit
+correct_floorDivPos xBits yBits =
+  y > 0 ==> q * y <= x /\ (q + 1) * y > x
+  where
+  x = toSignedInteger xBits
+  y = toSignedInteger yBits
+  q = floorDivPos x y
+
+correct_sld_sound :
+  {k} (fin k, k >= 1) =>
+  [k] -> [k] -> [k] -> [k] -> [k] -> [k] -> Bit
+correct_sld_sound aBits bBits aMaxBits bMaxBits x0Bits y0Bits =
+  a > 0 ==> b > 0 ==> a_max >= 0 ==> b_max >= 0 ==>
+  0 <= x0 ==> x0 <= a_max ==>
+  0 <= y0 ==> y0 <= b_max ==>
+  c != 0 ==>
+  res.0 /\
+  (0 <= res.1 /\ res.1 <= a_max /\
+   0 <= res.2 /\ res.2 <= b_max /\
+   a * res.1 - b * res.2 == c)
+  where
+  a     = toSignedInteger aBits
+  b     = toSignedInteger bBits
+  a_max = toSignedInteger aMaxBits
+  b_max = toSignedInteger bMaxBits
+  x0    = toSignedInteger x0Bits
+  y0    = toSignedInteger y0Bits
+  c     = a * x0 - b * y0
+  res   = solveLinearDiophantine`{4*k + 4} a b c a_max b_max
+
+/** Reinterpret a bitvector as a signed integer. Used to lift universal
+quantification over bitvectors into universal quantification over
+integers in a bounded range, while retaining the `:prove` exhaustive
+search Cryptol does over bitvector domains. */
+toSignedInteger : {k} (fin k, k >= 1) => [k] -> Integer
+toSignedInteger v =
+  if v @ 0 then toInteger v - 2 ^^ (`k : Integer)
+           else toInteger v
+
+////////////////////////////////////////////////////////////
+// Correctness properties: size-cap algebraic justifications
+//
+// The size cap `(siRange + 1) * stride <= 2^n` is a sufficient condition
+// for the residues `(base + i * stride) mod 2^n` to be pairwise distinct
+// for `0 <= i <= siRange`, and under that cap the simple `member`
+// formula coincides with the defining set. These are the Cryptol
+// counterparts of the Haskell test-suite properties of the same names.
+
+/** Holds when the size cap (siRange + 1) * stride <= 2^n is satisfied.
+Mirrors the `(r + 1) * s <= m` precondition in the Haskell tests; we
+widen to [n+1] to avoid wrap when computing the product. */
+sizeCapHolds : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+sizeCapHolds r s = s >= 1 /\ ((zext r * zext s + zext s) : [2*n]) <= zext (~0 : [n]) + 1
+
+/** Algebraic justification of the size cap: when (r + 1) * s <= 2^n,
+the residues @(b + i * s) mod 2^n@ for @0 <= i <= r@ are pairwise
+distinct. We express "pairwise" as a universal over two indices i, j;
+the conclusion @i == j@ then follows from equal residues. */
+correct_size_cap_distinct :
+  {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n] -> [n] -> Bit
+correct_size_cap_distinct b r s i j =
+  sizeCapHolds`{n} r s ==>
+  i <= r ==> j <= r ==>
+  b + i * s == b + j * s ==>
+  i == j
+
+/** Forward direction of the simple-`member` formula: when the size cap
+holds, any `x` whose offset is divisible by `s` and within `r` strides
+of `b` lies in the defining set @{ b + i * s | 0 <= i <= r }@. The
+witness index is @(x - b) / s@. */
+correct_size_cap_simple_member_forward :
+  {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n] -> Bit
+correct_size_cap_simple_member_forward b r s x =
+  sizeCapHolds`{n} r s ==>
+  s != 0 ==>
+  d % s == 0 ==>
+  d / s <= r ==>
+  i <= r /\ b + i * s == x
+  where
+  d = x - b
+  i = d / s
+
+/** Backward direction: when the size cap holds, every member of the
+defining set @{ b + i * s | 0 <= i <= r }@ satisfies the simple-`member`
+formula. Together with the forward direction this pins the formula to
+the set's characteristic function. */
+correct_size_cap_simple_member_backward :
+  {n} (fin n, n >= 1) => [n] -> [n] -> [n] -> [n] -> Bit
+correct_size_cap_simple_member_backward b r s i =
+  sizeCapHolds`{n} r s ==>
+  s != 0 ==>
+  i <= r ==>
+  d % s == 0 /\ d / s <= r
+  where
+  x = b + i * s
+  d = x - b
+
+////////////////////////////////////////////////////////////
+// Correctness properties: predicates
+
+correct_singleton : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+correct_singleton v x = member (singleton v) x == (x == v)
+
+correct_top : {n} (fin n, n >= 1) => [n] -> Bit
+correct_top x = member`{n} top x
+
+correct_isSingleton : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+correct_isSingleton a x =
+  proper a ==> isSingleton a ==> member a x == (x == a.base)
+
+correct_domainsOverlap : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+correct_domainsOverlap a b x =
+  proper a ==> proper b ==> member a x ==> member b x ==> domainsOverlap a b
+
+////////////////////////////////////////////////////////////
+// Correctness properties: lattice operations
+
+correct_join : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+correct_join a b x =
+  proper a ==> proper b ==>
+    (member a x \/ member b x) ==> member (join a b) x
+
+correct_meet : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+correct_meet a b x =
+  proper a ==> proper b ==>
+    (member a x /\ member b x) ==> member (meet a b) x
+
+correct_leq : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+correct_leq a b x =
+  proper a ==> proper b ==>
+    (leq a b /\ member a x) ==> member b x
+
+correct_unionSingleton : {n} (fin n, n >= 1) => [n] -> StridedInterval n -> Bit
+correct_unionSingleton v a = proper a ==> member (unionSingleton v a) v
+
+correct_glb : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+correct_glb a b x =
+  proper a ==> proper b ==> member (glb a b) x ==> (member a x /\ member b x)
+
+correct_glb_singleton_left :
+  {n} (fin n, n >= 1) => [n] -> StridedInterval n -> Bit
+correct_glb_singleton_left v a =
+  proper a ==> member a v ==> member (glb (singleton v) a) v
+
+correct_glb_singleton_right :
+  {n} (fin n, n >= 1) => [n] -> StridedInterval n -> Bit
+correct_glb_singleton_right v a =
+  proper a ==> member a v ==> member (glb a (singleton v)) v
+
+////////////////////////////////////////////////////////////
+// Correctness properties: lattice laws
+
+join_commutative : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+join_commutative a b x =
+  proper a ==> proper b ==>
+    member (join a b) x == member (join b a) x
+
+join_idempotent : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+join_idempotent a x =
+  proper a ==> member (join a a) x == member a x
+
+meet_commutative : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> Bit
+meet_commutative a b x =
+  proper a ==> proper b ==>
+    member (meet a b) x == member (meet b a) x
+
+meet_idempotent : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+meet_idempotent a x =
+  proper a ==> member (meet a a) x == member a x
+
+join_top : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+join_top a x =
+  proper a ==> member (join a top) x
+
+join_bottom : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+join_bottom a x =
+  proper a ==> member (join a bottom) x == member a x
+
+meet_top : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+meet_top a x =
+  proper a ==> member (meet a top) x == member a x
+
+meet_bottom : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+meet_bottom a x =
+  proper a ==> ~ member (meet a bottom) x
+
+leq_reflexive : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+leq_reflexive a = proper a ==> leq a a
+
+join_upper_bound : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+join_upper_bound a b = proper a ==> proper b ==> leq a (join a b)
+
+join_proper : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+join_proper a b = proper a ==> proper b ==> proper (join a b)
+
+meet_proper : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> Bit
+meet_proper a b = proper a ==> proper b ==> proper (meet a b)
+
+////////////////////////////////////////////////////////////
+// Correctness properties: width manipulation
+
+correct_zext :
+  {n, u} (fin n, fin u, n >= 1, u >= n + 1) => StridedInterval n -> [n] -> Bit
+correct_zext a x =
+  proper a ==> member a x ==>
+    member (zextSI`{n, u} a) (zext x : [u])
+
+correct_trunc :
+  {n, v} (fin n, fin v, v >= 1, n >= v + 1) => StridedInterval n -> [n] -> Bit
+correct_trunc a x =
+  proper a ==> member a x ==>
+    member (truncSI`{n, v} a) (drop`{n - v} x)
+
+////////////////////////////////////////////////////////////
+// Correctness properties: arithmetic
+//
+// All arithmetic is modulo 2^n. The Cryptol bitvector arithmetic is
+// already modular at width n, so `x + y` here is `(x + y) mod 2^n`.
+
+correct_add : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> [n] -> Bit
+correct_add a b x y =
+  proper a ==> proper b ==> member a x ==> member b y ==>
+  member (add a b) (x + y)
+
+correct_adc :
+  {n} (fin n, n >= 1) =>
+  StridedInterval n -> StridedInterval n -> (Bit, Bit) -> [n] -> [n] -> Bit
+correct_adc a b cIn x y =
+  proper a ==> proper b ==> member a x ==> member b y ==>
+  if cIn.0
+    then member (adc a b cIn) (x + y + (if cIn.1 then 1 else 0))
+    else member (adc a b cIn) (x + y) /\
+         member (adc a b cIn) (x + y + 1)
+
+correct_sub : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> [n] -> Bit
+correct_sub a b x y =
+  proper a ==> proper b ==> member a x ==> member b y ==>
+  member (sub a b) (x - y)
+
+correct_negate : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+correct_negate a x =
+  proper a ==> member a x ==> member (negate a) (- x)
+
+correct_scale : {n} (fin n, n >= 1) => [n] -> StridedInterval n -> [n] -> Bit
+correct_scale k a x =
+  proper a ==> member a x ==> member (scale k a) (k * x)
+
+correct_mul : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> [n] -> Bit
+correct_mul a b x y =
+  proper a ==> proper b ==> member a x ==> member b y ==>
+  member (mul a b) (x * y)
+
+correct_not : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+correct_not a x =
+  proper a ==> member a x ==> member (bvNot a) (~ x)
+
+correct_shl : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> [n] -> Bit
+correct_shl a b x k =
+  proper a ==> proper b ==> member a x ==> member b k ==>
+  member (shl a b) (x << k)
+
+correct_lshr : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> [n] -> Bit
+correct_lshr a b x k =
+  proper a ==> proper b ==> member a x ==> member b k ==>
+  member (lshr a b) (x >> k)
+
+correct_ashr : {n} (fin n, n >= 1) => StridedInterval n -> StridedInterval n -> [n] -> [n] -> Bit
+correct_ashr a b x k =
+  proper a ==> proper b ==> member a x ==> member b k ==>
+  member (ashr a b) (x >>$ k)
+
+////////////////////////////////////////////////////////////
+// Correctness properties: destructors
+
+correct_size : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_size a = proper a ==> ~ isBottom a ==> size a == a.siRange + 1
+
+correct_ubounds : {n} (fin n, n >= 1) => StridedInterval n -> [n] -> Bit
+correct_ubounds a x =
+  proper a ==> member a x ==>
+    (ubounds a).0 <= x /\ x <= (ubounds a).1
+
+////////////////////////////////////////////////////////////
+// Correctness properties: bottom edge cases
+
+correct_glb_bottom_left : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_glb_bottom_left a = proper a ==> isBottom (glb bottom a)
+
+correct_glb_bottom_right : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_glb_bottom_right a = proper a ==> isBottom (glb a bottom)
+
+correct_add_bottom_left : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_add_bottom_left a = proper a ==> isBottom (add bottom a)
+
+correct_add_bottom_right : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_add_bottom_right a = proper a ==> isBottom (add a bottom)
+
+correct_mul_bottom_left : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_mul_bottom_left a = proper a ==> isBottom (mul bottom a)
+
+correct_mul_bottom_right : {n} (fin n, n >= 1) => StridedInterval n -> Bit
+correct_mul_bottom_right a = proper a ==> isBottom (mul a bottom)
+
+////////////////////////////////////////////////////////////
+// Property witnesses for default proof bit widths.
+
+property pe   = correct_proper_bottom`{8}
+property ps   = correct_proper_singleton`{8}
+property pany = correct_proper_top`{8}
+property pmk  = correct_proper_mkStridedInterval`{8}
+property pr   = correct_proper_range`{8}
+property plu  = correct_proper_join`{8}
+property plus = correct_proper_unionSingleton`{8}
+property pa   = correct_proper_add`{8}
+property pn   = correct_proper_negate`{8}
+property psu  = correct_proper_sub`{8}
+property psc  = correct_proper_scale`{8}
+property pco  = correct_proper_not`{8}
+property psh  = correct_proper_shl`{8}
+property plsh = correct_proper_lshr`{8}
+property pash = correct_proper_ashr`{8}
+property pud  = correct_proper_udiv`{8}
+property pur  = correct_proper_urem`{8}
+property psd  = correct_proper_sdiv`{8}
+property psr  = correct_proper_srem`{8}
+// `glb` involves the Diophantine solver, which is significantly more
+// expensive to discharge than the simpler arithmetic ops.
+property pglb = correct_proper_glb`{4}
+
+// Helper-level properties. The helpers themselves work in `Integer`,
+// so the bit width `k` only controls the `:prove` exhaustive-search
+// quantification range over `[k]` lifted to `Integer`. The eGCD
+// iteration cap is `4*k + 4` — generous for the Fibonacci bound on
+// Euclidean steps for inputs in `[-2^(k-1), 2^(k-1) - 1]`.
+// `correct_eGCD_bezout` is slow (~2.5 min in :prove): the unbounded
+// Integer Bezout coefficients blow up the SMT problem.
+property ebez = correct_eGCD_bezout`{4}
+property enng = correct_eGCD_nonNegative`{4}
+property cdp  = correct_ceilDivPos`{4}
+property fdp  = correct_floorDivPos`{4}
+// `solveLinearDiophantine` proof at width 2: the helper operates over
+// unbounded `Integer`; `4*2 + 4 = 12` iterations cover all width-2 inputs.
+property sld  = correct_sld_sound`{2}
+
+property cs   = correct_singleton`{8}
+property ct   = correct_top`{8}
+property cis  = correct_isSingleton`{8}
+property cb   = correct_ubounds`{8}
+property cdo  = correct_domainsOverlap`{8}
+property csz  = correct_size`{8}
+property cus  = correct_unionSingleton`{4}
+// `correct_glb` at width 3: the Integer Diophantine solver makes width
+// 4 intractable (~10+ min); width 3 completes in ~50s.
+property cgl  = correct_glb`{3}
+property cgsl = correct_glb_singleton_left`{8}
+property cgsr = correct_glb_singleton_right`{8}
+property ca   = correct_add`{4}
+property cn   = correct_negate`{8}
+property csu  = correct_sub`{4}
+property csc  = correct_scale`{4}
+property cco  = correct_not`{8}
+property csh  = correct_shl`{4}
+property cael = correct_add_bottom_left`{8}
+property caer = correct_add_bottom_right`{8}
+property cgel = correct_glb_bottom_left`{8}
+property cger = correct_glb_bottom_right`{8}
+
+// Properties for `mul`/`adc`. These use the same iterative gcd as
+// `add`, so they share the width-4 budget for soundness.
+property pmul = correct_proper_mul`{4}
+property padc = correct_proper_adc`{4}
+property cm   = correct_mul`{4}
+property cadc = correct_adc`{4}
+property cmel = correct_mul_bottom_left`{8}
+property cmer = correct_mul_bottom_right`{8}
+// Lattice laws.
+property cjn = correct_join`{4}
+property cmt = correct_meet`{4}
+property clq = correct_leq`{4}
+property jcm = join_commutative`{4}
+property jid = join_idempotent`{4}
+property mcm = meet_commutative`{4}
+property mid = meet_idempotent`{4}
+property jtp = join_top`{4}
+property jbt = join_bottom`{4}
+property mtp = meet_top`{4}
+property mbt = meet_bottom`{4}
+property lqr = leq_reflexive`{4}
+property jub = join_upper_bound`{4}
+property jpr = join_proper`{4}
+property mpr = meet_proper`{4}
+// Width manipulation.
+property pzd  = correct_proper_zext`{4, 8}
+property ptd  = correct_proper_trunc`{8, 4}
+property psed = correct_proper_sext`{4, 8}
+property czd  = correct_zext`{4, 8}
+property ctd  = correct_trunc`{8, 4}
+
+// Size-cap algebraic justifications. The Haskell test-suite versions of
+// these run as randomized properties; here they are exhaustively proven
+// at small widths, which is what the Cryptol module's role calls for.
+// Width 4 keeps the 4-quantifier `correct_size_cap_distinct` proof
+// tractable (4^5 = 1024 cases per residue equality).
+property csscd  = correct_size_cap_distinct`{4}
+property csscmf = correct_size_cap_simple_member_forward`{4}
+property csscmb = correct_size_cap_simple_member_backward`{4}

--- a/what4-domains/src/What4/Domains/BV/Arith.hs
+++ b/what4-domains/src/What4/Domains/BV/Arith.hs
@@ -4,8 +4,32 @@ Copyright   : (c) Galois Inc, 2019-2020
 License     : BSD3
 Maintainer  : huffman@galois.com
 
-Provides an interval-based implementation of bitvector abstract
-domains.
+Provides an interval-based implementation of bitvector abstract domains.
+
+A 'Domain' represents a /contiguous/ interval modulo @2^w@: every
+non-empty domain has the form @{ (lo + i) mod 2^w | 0 <= i <= sz }@.
+Wrapping intervals are first-class — when @lo + sz >= 2^w@ the set
+straddles the modulus.
+
+== Comparison to "What4.Domains.BV.StridedInterval"
+
+"What4.Domains.BV.StridedInterval" generalizes this module by adding a
+stride to the interval shape, representing
+@{ (base + i * stride) mod 2^w | 0 <= i <= range }@.
+
+* On stride-1 inputs, both modules represent the same sets and produce
+  the same results: 'StridedInterval' delegates its stride-1 paths to
+  this module, so the agreement is by construction. The differential
+  test suite asserts it on every shared operation.
+
+* On strided sets — e.g. @{0, 4, 8, 12}@ at @w = 8@ — only
+  'StridedInterval' is precise; this module would over-approximate to
+  the contiguous cover @[0, 12]@.
+
+Use this module when you only need contiguous intervals (smaller
+representation, simpler ops, no Diophantine-solver overhead in 'glb');
+reach for 'StridedInterval' when stride information matters for
+precision.
 -}
 
 {-# LANGUAGE DataKinds #-}
@@ -60,6 +84,7 @@ module What4.Domains.BV.Arith
   , ashr
     -- ** Arithmetic
   , add
+  , sub
   , negate
   , scale
   , mul
@@ -74,6 +99,15 @@ module What4.Domains.BV.Arith
   , sremSmtlib
     -- ** Bitwise
   , What4.Domains.BV.Arith.not
+  , What4.Domains.BV.Arith.and
+  , What4.Domains.BV.Arith.or
+  , What4.Domains.BV.Arith.xor
+    -- ** Rotates
+  , rol
+  , ror
+    -- ** Conversion to\/from "What4.Domains.BV.Bitwise"
+  , toBitwise
+  , fromBitwise
 
   -- * Correctness properties
   , genDomain
@@ -111,6 +145,7 @@ module What4.Domains.BV.Arith
   , correct_trunc
   , correct_select
   , correct_add
+  , correct_sub
   , correct_neg
   , correct_mul
   , correct_scale
@@ -125,15 +160,22 @@ module What4.Domains.BV.Arith
   , correct_sdivSmtlib
   , correct_sremSmtlib
   , correct_not
+  , correct_and
+  , correct_or
+  , correct_xor
   , correct_shl
   , correct_lshr
   , correct_ashr
+  , correct_rol
+  , correct_ror
   , correct_eq
   , correct_ult
   , correct_slt
   , correct_isUltSumCommonEquiv
   , correct_unknowns
   , correct_bitbounds
+  , correct_toBitwise
+  , correct_fromBitwise
   ) where
 
 import qualified Data.Bits as Bits
@@ -146,6 +188,7 @@ import qualified Prelude
 import           Prelude hiding (any, concat, negate, and, or, not)
 
 import qualified What4.Domains.Arithmetic as Arith
+import qualified What4.Domains.BV.Bitwise as B
 import           What4.Domains.Verification ( Property, property, (==>), Gen, chooseInteger )
 
 --------------------------------------------------------------------------------
@@ -638,6 +681,11 @@ add a b =
         BVDInterval mask bl bw ->
           interval mask (al + bl) (aw + bw)
 
+-- | /O(w)/. Subtraction.
+sub :: (1 <= w) => Domain w -> Domain w -> Domain w
+sub a b = add a (negate b)
+{-# INLINE sub #-}
+
 negate :: (1 <= w) => Domain w -> Domain w
 negate a =
   case a of
@@ -866,6 +914,69 @@ not a =
       BVDInterval mask (complement ah .&. mask) aw
       where ah = al + aw
 
+-- | /O(w)/. Bitwise AND. Converts both operands to the
+-- 'What4.Domains.BV.Bitwise' domain, applies 'B.and', and converts
+-- back.
+and :: Domain w -> Domain w -> Domain w
+and a b
+  | isBottom a || isBottom b = a
+  | otherwise = fromBitwise mask (B.and (toBitwise mask a) (toBitwise mask b))
+  where mask = bvdMask a
+{-# INLINE and #-}
+
+-- | /O(w)/. Bitwise OR. Converts both operands to the
+-- 'What4.Domains.BV.Bitwise' domain, applies 'B.or', and converts
+-- back.
+or :: Domain w -> Domain w -> Domain w
+or a b
+  | isBottom a || isBottom b = if isBottom a then b else a
+  | otherwise = fromBitwise mask (B.or (toBitwise mask a) (toBitwise mask b))
+  where mask = bvdMask a
+{-# INLINE or #-}
+
+-- | /O(w)/. Bitwise XOR. Converts both operands to the
+-- 'What4.Domains.BV.Bitwise' domain, applies 'B.xor', and converts
+-- back.
+xor :: Domain w -> Domain w -> Domain w
+xor a b
+  | isBottom a || isBottom b = if isBottom a then b else a
+  | otherwise = fromBitwise mask (B.xor (toBitwise mask a) (toBitwise mask b))
+  where mask = bvdMask a
+{-# INLINE xor #-}
+
+-- | Convert an Arith domain to a Bitwise domain.
+toBitwise :: Integer -> Domain w -> B.Domain w
+toBitwise mask a =
+  let (lo, hi) = bitbounds a
+  in B.interval mask lo hi
+{-# INLINE toBitwise #-}
+
+-- | Convert a Bitwise domain back to an Arith domain.
+fromBitwise :: Integer -> B.Domain w -> Domain w
+fromBitwise mask bw =
+  let (lo, hi) = B.ubounds bw
+  in if hi - lo >= mask then BVDAny mask
+     else interval mask lo (hi - lo)
+{-# INLINE fromBitwise #-}
+
+-- | /O(w²)/. Rotate left. Converts to the 'What4.Domains.BV.Bitwise'
+-- domain, applies 'B.rolAbstract', and converts back.
+rol :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+rol w a b
+  | isBottom a || isBottom b = a
+  | otherwise = fromBitwise mask (B.rolAbstract w (toBitwise mask a) (toBitwise mask b))
+  where mask = bvdMask a
+{-# INLINE rol #-}
+
+-- | /O(w²)/. Rotate right. Converts to the 'What4.Domains.BV.Bitwise'
+-- domain, applies 'B.rorAbstract', and converts back.
+ror :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+ror w a b
+  | isBottom a || isBottom b = a
+  | otherwise = fromBitwise mask (B.rorAbstract w (toBitwise mask a) (toBitwise mask b))
+  where mask = bvdMask a
+{-# INLINE ror #-}
+
 -- | Return bitwise bounds for domain (i.e. logical AND of all
 -- possible values, paired with logical OR of all possible values).
 bitbounds :: Domain w -> (Integer, Integer)
@@ -1058,11 +1169,23 @@ correct_select i n (a, x) = member a x ==> pmember n (select i n a) y
 correct_add :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
 correct_add n (a,x) (b,y) = member a x ==> member b y ==> pmember n (add a b) (x + y)
 
+correct_sub :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_sub n (a,x) (b,y) = member a x ==> member b y ==> pmember n (sub a b) (x - y)
+
 correct_neg :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
 correct_neg n (a,x) = member a x ==> pmember n (negate a) (Prelude.negate x)
 
 correct_not :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
 correct_not n (a,x) = member a x ==> pmember n (not a) (complement x)
+
+correct_and :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_and n (a,x) (b,y) = member a x ==> member b y ==> pmember n (and a b) (x .&. y)
+
+correct_or :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_or n (a,x) (b,y) = member a x ==> member b y ==> pmember n (or a b) (x .|. y)
+
+correct_xor :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_xor n (a,x) (b,y) = member a x ==> member b y ==> pmember n (xor a b) (x `Bits.xor` y)
 
 correct_mul :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
 correct_mul n (a,x) (b,y) = member a x ==> member b y ==> pmember n (mul a b) (x * y)
@@ -1170,6 +1293,16 @@ correct_ashr n (a,x) (b,y) = member a x ==> member b y ==> pmember n (ashr n a b
   where
   z = (toSigned n x) `shiftR` fromInteger (min (intValue n) y)
 
+correct_rol :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_rol n (a,x) (b,y) = member a x ==> member b y ==> pmember n (rol n a b) z
+  where
+  z = Arith.rotateLeft n x y
+
+correct_ror :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_ror n (a,x) (b,y) = member a x ==> member b y ==> pmember n (ror n a b) z
+  where
+  z = Arith.rotateRight n x y
+
 correct_eq :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
 correct_eq n (a,x) (b,y) =
   member a x ==> member b y ==>
@@ -1218,3 +1351,11 @@ correct_bitbounds n (a,x) =
   where
   x' = toUnsigned n x
   (lo, hi) = bitbounds a
+
+correct_toBitwise :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_toBitwise _n (a, x) =
+  member a x ==> B.member (toBitwise (bvdMask a) a) x
+
+correct_fromBitwise :: (1 <= n) => NatRepr n -> (B.Domain n, Integer) -> Property
+correct_fromBitwise _n (bw, x) =
+  B.member bw x ==> member (fromBitwise (B.bvdMask bw) bw) x

--- a/what4-domains/src/What4/Domains/BV/StridedInterval.hs
+++ b/what4-domains/src/What4/Domains/BV/StridedInterval.hs
@@ -1,0 +1,2562 @@
+{-|
+Module      : What4.Domains.BV.StridedInterval
+Copyright   : (c) Galois, Inc 2026
+License     : BSD3
+Maintainer  : langston@galois.com
+
+A strided interval domain @{ (base + i * stride) mod 2^w | 0 <= i <= range }@
+over fixed-width bitvectors. The empty set is encoded by @stride = 0@
+(see 'StridedInterval').
+
+== Visualization
+
+The diagrams below show the represented set as one cell per bitvector
+value across @[0, 2^w)@; @*@ marks a member, @.@ a non-member. The
+outer brackets are the modulus boundary - values fall off the right
+end and reappear on the left.
+
+At @w = 4@:
+
+@
+[****************]   'top' (the full set)
+[................]   'bottom' (the empty set)
+[..*****.........]   stride 1, base 2,  range 4: {2,3,4,5,6}
+[..*.*.*.*.......]   stride 2, base 2,  range 3: {2,4,6,8}
+[*...*...*...*...]   stride 4, base 0,  range 3: {0,4,8,12}
+[**............**]   stride 1, base 14, range 3: {14,15,0,1}   (wraps)
+[*...........*.*.]   stride 2, base 12, range 2: {12,14,0}     (wraps)
+@
+
+== Width invariant
+
+Every public 'StridedInterval' is /proper/. The empty case is encoded by
+@stride = 0@ (with @base = 0@ and @range = 0@). The non-empty case
+satisfies
+
+* @0 <= base < 2^w@,
+* @stride >= 1@,
+* @range >= 0@,
+* @(range + 1) * stride <= 2^w@ (the /size cap/), and
+* @range == 0@ implies @stride == 1@ (singletons are canonical).
+
+Note that this admits intervals that wrap modulo @2^w@: for @w = 8@, the SI
+@base = 250, range = 3, stride = 2@ represents @{250, 252, 254, 0}@.
+
+=== Why the size cap?
+
+The size cap @(range + 1) * stride <= 2^w@ is a /sufficient/ condition for
+the @range + 1@ residues @(base + i * stride) mod 2^w@ to be pairwise
+distinct: if @0 <= i < j <= range@, then @(j - i) * stride@ lies in
+@(0, 2^w)@ and so cannot be a multiple of @2^w@.
+
+It is /not the tightest/ such bound - that would be
+@range + 1 <= 2^w \/ gcd(stride, 2^w)@ - but the size-cap form is simpler:
+it makes 'member' a single mod-then-divide check, makes 'size' literally
+@range + 1@, and lets every operation post-check the result without any
+@gcd(_, 2^w)@ bookkeeping. The shapes excluded by the cap (large stride
+combined with @range@ near @2^w@) cover almost all of @[0, 2^w)@ and the
+sound move for them is 'top' anyway. The bvdomain test suite has algebraic
+justifications under @correct_size_cap_*@.
+
+The invariant is checked by 'proper' and verified as a postcondition of
+every operation by the @correct_proper_*@ properties below.
+
+== Comparison to "What4.Domains.BV.Arith"
+
+Both modules implement an /interval/ abstract domain over fixed-width
+bitvectors with native support for wrapping intervals. The key difference
+is that "What4.Domains.BV.Arith" represents only contiguous (stride-1)
+intervals, while this module also supports non-trivial strides.
+
+Concretely:
+
+* On stride-1 intervals, the two domains represent exactly the same sets
+  and 'join'\/'add'\/'mul'\/etc.\ produce results that round-trip
+  identically. Internally, the stride-1 paths in this module delegate to
+  "What4.Domains.BV.Arith" so this is true /by construction/, and the
+  differential test suite asserts it on every shared operation.
+
+* On strided sets - e.g. @{0, 4, 8, 12}@ at @w = 8@ - only this module is
+  precise; "What4.Domains.BV.Arith" would over-approximate to the
+  contiguous cover @[0, 12]@.
+
+* When a strided result would overflow the size cap, this module
+  conservatively falls back to 'top' rather than dropping to a stride-1
+  cover. (A future refinement could match Arith's contiguous cover in
+  those cases.)
+
+The upshot: this domain matches "What4.Domains.BV.Arith" exactly on
+stride-1 inputs, and is strictly more precise when strides are non-trivial.
+
+== Lattice operations and 'glb'
+
+The lattice operations 'top', 'bottom', 'join', 'meet', 'leq' satisfy
+the standard lattice laws (proven as 'join_commutative',
+'join_idempotent', etc., below) and 'meet' is a sound /over/-approximation
+of the intersection: every concrete value in both operands is also in
+@meet a b@.
+
+'glb' is a different function - a strided-interval /under/-approximation
+of the intersection, exact when one operand is a singleton or both have
+matching strides, but generally a strict subset of the true intersection.
+Use 'glb' for path-condition refinement (where dropping witnesses is
+acceptable but inventing them is not); use 'meet' when you need a sound
+lattice meet (where preserving witnesses is required).
+-}
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module What4.Domains.BV.StridedInterval
+  ( StridedInterval (..)
+    -- * Constructors
+  , singleton
+  , mkStridedInterval
+  , range
+  , fromAscEltList
+    -- * Predicates
+  , proper
+  , asSingleton
+  , isAny
+  , member
+  , pmember
+  , domainsOverlap
+    -- * Destructors
+  , toList
+  , size
+  , ubounds
+  , sbounds
+  , bitbounds
+  , unknowns
+    -- * Comparisons
+  , eq
+  , ult
+  , slt
+    -- * Lattice operations
+  , top
+  , bottom
+  , isBottom
+  , join
+  , meet
+  , leq
+  , unionSingleton
+  , glb
+    -- * Width manipulation
+  , trunc
+  , zext
+  , sext
+  , concat
+  , select
+  , normalize
+    -- * Arithmetic
+  , add
+  , adc
+  , sub
+  , negate
+  , scale
+  , mul
+  , udiv
+  , urem
+  , sdiv
+  , srem
+  , not
+  , and
+  , or
+  , xor
+    -- * Shifts
+  , shl
+  , lshr
+  , ashr
+    -- * Rotates
+  , rol
+  , ror
+    -- * Conversion to\/from "What4.Domains.BV.Arith"
+  , asArith
+  , toArith
+  , fromArith
+  , viaArith
+    -- * Correctness properties
+
+    -- ** Generators
+  , genDomain
+  , genElement
+  , genPair
+    -- ** Invariant postconditions
+  , correct_proper_bottom
+  , correct_proper_top
+  , correct_proper_singleton
+  , correct_proper_mkStridedInterval
+  , correct_proper_range
+  , correct_proper_fromAscEltList
+  , correct_proper_join
+  , correct_proper_unionSingleton
+  , correct_proper_glb
+  , correct_proper_add
+  , correct_proper_adc
+  , correct_proper_sub
+  , correct_proper_negate
+  , correct_proper_scale
+  , correct_proper_mul
+  , correct_proper_udiv
+  , correct_proper_urem
+  , correct_proper_sdiv
+  , correct_proper_srem
+  , correct_proper_not
+  , correct_proper_and
+  , correct_proper_or
+  , correct_proper_xor
+  , correct_proper_shl
+  , correct_proper_lshr
+  , correct_proper_ashr
+  , correct_proper_rol
+  , correct_proper_ror
+  , correct_proper_concat
+  , correct_proper_select
+  , correct_proper_trunc
+  , correct_proper_zext
+  , correct_proper_sext
+    -- ** Predicates
+  , correct_member_toList
+  , correct_toList_member
+  , correct_asSingleton
+  , correct_domainsOverlap
+  , correct_domainsOverlap_bottom
+    -- ** Lattice operations
+  , correct_join
+  , correct_meet
+  , correct_leq
+  , correct_unionSingleton
+  , correct_glb
+  , correct_glb_singleton_left
+  , correct_glb_singleton_right
+    -- *** Lattice laws
+  , join_commutative
+  , join_idempotent
+  , meet_commutative
+  , meet_idempotent
+  , join_top
+  , join_bottom
+  , meet_top
+  , meet_bottom
+  , leq_reflexive
+  , join_upper_bound
+  , join_proper
+  , meet_proper
+    -- ** Width manipulation
+  , correct_concat
+  , correct_select
+  , correct_trunc
+  , correct_zext
+  , correct_sext
+    -- ** Arithmetic
+  , correct_add
+  , correct_adc
+  , correct_sub
+  , correct_negate
+  , correct_scale
+  , correct_mul
+  , correct_udiv
+  , correct_urem
+  , correct_sdiv
+  , correct_srem
+  , correct_not
+  , correct_and
+  , correct_or
+  , correct_xor
+  , correct_shl
+  , correct_lshr
+  , correct_ashr
+  , correct_rol
+  , correct_ror
+    -- ** Destructors
+  , correct_size
+  , correct_ubounds
+  , correct_ubounds_bottom
+  , correct_sbounds
+  , correct_bitbounds
+  , correct_unknowns
+  , correct_eq
+  , correct_ult
+  , correct_slt
+    -- ** Bottom edge cases
+  , correct_glb_bottom_left
+  , correct_glb_bottom_right
+  , correct_add_bottom_left
+  , correct_add_bottom_right
+  , correct_mul_bottom_left
+  , correct_mul_bottom_right
+  ) where
+
+import           Control.Exception (assert)
+import qualified Data.Bits as Bits
+import qualified Data.Foldable as Fold
+import           Data.Parameterized.NatRepr
+import           GHC.TypeNats (Nat)
+import           Prelude hiding (and, concat, negate, not, or, span)
+import qualified Prelude
+
+import qualified What4.Domains.BV.Arith as A
+import qualified What4.Domains.BV.Bitwise as B
+import           What4.Domains.BV.StridedInterval.Internal
+                   (solveLinearDiophantine)
+import qualified What4.Domains.Arithmetic as Arith
+import           What4.Domains.Verification
+                   ( Property, property, (==>), Gen
+                   , chooseInt, chooseInteger, getSize
+                   )
+
+-- ---------------------------------------------------------------------------
+-- Data type and instances
+
+-- | Canonical strided-interval domain element. See module-level haddock
+-- for the width invariant; use 'proper' to check it.
+--
+-- The type parameter @w@ is phantom — the bitvector width is encoded in
+-- 'siMask' (which caches @2^w - 1@). This mirrors the design of
+-- 'What4.Domains.BV.Arith.Domain'.
+--
+-- The empty set ('bottom') is encoded by @stride = 0@; the @stride >= 1@
+-- invariant on non-empty SIs leaves @stride = 0@ free for this purpose.
+-- All other operations should treat @stride = 0@ as a sentinel and not
+-- inspect 'base' or 'siRange' on it.
+data StridedInterval (w :: Nat) =
+  StridedInterval { siMask  :: !Integer   -- ^ Caches @2^w - 1@.
+                  , base    :: !Integer
+                  , siRange :: !Integer  -- ^ size - 1; only meaningful when @stride > 0@
+                  , stride  :: !Integer  -- ^ @0@ encodes empty; otherwise @>= 1@
+                  }
+
+instance Eq (StridedInterval w) where
+  si1 == si2 =
+    base si1 == base si2 &&
+    siRange si1 == siRange si2 &&
+    stride si1 == stride si2
+
+instance Show (StridedInterval w) where
+  show si
+    | isBottom si               = "[]"
+    | Just s <- asSingleton si = "[" ++ show s ++ "]"
+    | otherwise                =
+        "[" ++ show (base si) ++
+        ", +" ++ show (stride si) ++
+        " .. (" ++ show (siRange si + 1) ++ " elts)]"
+
+-- | /O(1)/. Cardinality of the SI; @0@ for empty.
+size :: StridedInterval w -> Integer
+size si
+  | isBottom si = 0
+  | otherwise  = siRange si + 1
+
+-- | Modulus @2^w@ at the SI's declared width.
+modulus :: StridedInterval w -> Integer
+modulus si = siMask si + 1
+
+-- | Check that a mask has the form @2^w - 1@ (all low bits set).
+validMask :: Integer -> Bool
+validMask mask = mask >= 0 && Arith.isPow2Integer (mask + 1)
+{-# INLINE validMask #-}
+
+-- | Mask an integer to unsigned range: @x .&. (2^w - 1)@.
+maskUnsigned :: Integer -> Integer -> Integer
+maskUnsigned mask x = assert (validMask mask) $ x Bits..&. mask
+{-# INLINE maskUnsigned #-}
+
+-- | Interpret a masked integer as a signed value.
+maskSigned :: Integer -> Integer -> Integer
+maskSigned mask x = assert (validMask mask) $
+  let halfMod = (mask + 1) `Bits.shiftR` 1
+      xu = x Bits..&. mask
+  in if xu Bits..&. halfMod /= 0
+     then xu - (mask + 1)
+     else xu
+{-# INLINE maskSigned #-}
+
+-- | Distance from first to last residue: @range * stride@.
+-- Only meaningful on non-empty SIs.
+span :: StridedInterval w -> Integer
+span si = assert (stride si /= 0) $ siRange si * stride si
+{-# INLINE span #-}
+
+-- | Whether the SI's residues fit within one modular cycle without
+-- aliasing: @(range + 1) * stride <= 2^w@.
+fitsCap :: StridedInterval w -> Bool
+fitsCap si = span si + stride si <= modulus si
+{-# INLINE fitsCap #-}
+
+-- ---------------------------------------------------------------------------
+-- Invariant
+
+-- | /O(1)/. Check the width invariant. See module-level haddock.
+proper :: StridedInterval w -> Bool
+proper si
+  | isBottom si =
+      siRange si == 0 && base si == 0 && stride si == 0
+  | otherwise =
+      stride si >= 1
+      && siRange si >= 0
+      && 0 <= base si
+      && base si <= siMask si
+      && fitsCap si
+      -- The "full set" is canonicalized to the 'top' shape (base = 0),
+      -- so any other base with size m is not proper.
+      && Prelude.not (siRange si == siMask si && base si /= 0)
+      -- Singletons are canonicalized to stride 1 (the constructor's choice).
+      && Prelude.not (siRange si == 0 && stride si /= 1)
+
+-- | /O(1)/. Force a non-canonical interval into the closest canonical
+-- overapproximation.
+--
+-- Operations that build raw intermediates may produce SIs whose base
+-- exceeds @m@ or whose span exceeds the modulus. 'normalize' reduces
+-- these to proper form, choosing the tightest representable
+-- over-approximation when necessary.
+--
+-- === Cases (4-bit, m = 16)
+--
+-- __Already fits__ (@(range+1)*stride <= m@): fold @base mod m@, then
+-- 'dewrap' if the residues wrap once.
+--
+-- @
+-- input  (base 18, range 2, stride 3):  {18, 21, 24}  ≡ mod 16  {2, 5, 8}
+-- output (base  2, range 2, stride 3):  [..*..*..*....]
+--                                        0123456789…
+-- @
+--
+-- __Full set__ (@range+1 == m, stride == 1@): collapse to 'top'.
+--
+-- @
+-- input  (base 5, range 15, stride 1):  all 16 values
+-- output top
+-- @
+--
+-- __Spans full cycle__ (@range*stride >= m-1@): also 'top'.
+--
+-- @
+-- input  (base 0, range 5, stride 4):   {0,4,8,12,16,20} mod 16 = {0,4,8,12,0,4}
+-- output top                            (repeats ⇒ covers everything conservatively)
+-- @
+--
+-- __Cap overflow__ (@(range+1)*stride > m@ but not a full cycle): drop
+-- to the contiguous (stride-1) cover of the residues.
+--
+-- @
+-- input  (base 1, range 9, stride 2):   {1,3,5,…,19}  20 values, 10*2 > 16
+-- output (base 1, range 18, stride 1):  contiguous cover [1, 19 mod 16] = [1, 3]
+--                                        ⇒ wraps: [1..15] ∪ [0..3]
+-- @
+normalize :: StridedInterval w -> StridedInterval w
+normalize si
+  | isBottom si = bottom (siMask si)
+  | siRange si == 0 = singleton (siMask si) (base si)
+  | fitsCap si =
+      -- Already fits the size cap. Canonicalize "full set" shapes to
+      -- 'top', and fold base mod m for everything else. When the
+      -- folded representation wraps the modulus (last residue < first),
+      -- try to rotate to a non-wrapping integer-AP representation —
+      -- this only succeeds when the sorted residues themselves form
+      -- an AP with the same stride.
+      if siRange si == siMask si && stride si == 1
+        then top (siMask si)
+        else dewrap si { base = base si `mod` m }
+  | span si >= siMask si = top (siMask si)
+  | otherwise =
+      -- Cap-overflow: drop to the stride-1 contiguous cover. The set
+      -- @{(base + i*stride) mod m | i in [0, range]}@ is contained in
+      -- the contiguous interval starting at @base@ with width
+      -- @range*stride@.
+      StridedInterval { siMask = siMask si
+                      , base = base si `mod` m
+                      , siRange = span si
+                      , stride = 1 }
+  where
+    m = modulus si
+
+-- | Internal: when an SI's residues form a non-wrapping integer-AP
+-- with the same stride after rotation, rewrite the SI in that form.
+-- Otherwise leave the wrapping representation alone.
+--
+-- @
+-- input  (base 4, range 3, stride 4):    [....*...*...*...]   {4,8,12,0}   wraps once
+-- output (base 0, range 3, stride 4):    [*...*...*...*...]   {0,4,8,12}   non-wrapping
+-- @
+--
+-- This applies when @(range+1)*stride == m@: exactly one residue wraps
+-- (the last one), and the wrap distance equals the stride, so the
+-- sorted residues form an AP with the same stride starting at
+-- @(base - stride) mod m@. The set is unchanged; only the
+-- representation rotates.
+dewrap :: StridedInterval w -> StridedInterval w
+dewrap si
+  | span si + stride si == m
+  , base si >= stride si =
+      si { base = base si - stride si }
+  | otherwise = si
+  where
+    !m = modulus si
+
+-- ---------------------------------------------------------------------------
+-- Constructors
+
+-- | /O(1)/. The singleton interval @{v mod 2^w}@. The first argument
+-- is the mask @2^w - 1@.
+singleton ::
+  Integer ->
+  Integer ->
+  StridedInterval w
+singleton mask v = assert (validMask mask) $
+  StridedInterval { siMask = mask, base = maskUnsigned mask v, siRange = 0, stride = 1 }
+
+-- | /O(1)/. @range w lo hi@ returns the contiguous (stride-1) interval
+-- containing every bitvector formed from the @w@ low order bits of some
+-- @i@ in @[lo, hi]@. Mirrors 'What4.Domains.BV.Arith.range'.
+range :: NatRepr w -> Integer -> Integer -> StridedInterval w
+range w lo hi = fromArith (maxUnsigned w) (A.range w lo hi)
+
+-- | /O(1)/. @mkStridedInterval mask roundUp lo hi s@ constructs the
+-- strided interval starting at @lo@, stride @s@, whose largest element
+-- is at most @hi@. When @roundUp@ is true the actual upper bound is
+-- rounded up to @lo + r * s@ where @r = ceil((hi - lo) / s)@; otherwise
+-- it is rounded down. The result is normalized:
+-- out-of-range inputs are truncated (possibly to 'top') via 'normalize'.
+-- The first argument is the mask @2^w - 1@.
+mkStridedInterval ::
+  Integer ->
+  Bool ->
+  Integer ->
+  Integer ->
+  Integer ->
+  StridedInterval w
+mkStridedInterval mask roundUp lo hi s = assert (validMask mask) $ assert (s >= 0) go
+  where
+    go | hi < lo   = bottom mask
+       | s == 0    = singleton mask lo
+       | r == 0    = singleton mask lo
+       | otherwise =
+           normalize StridedInterval { siMask = mask, base = lo
+                                     , siRange = r, stride = s }
+    r | roundUp   = ((hi - lo) + (s - 1)) `div` s
+      | otherwise = (hi - lo) `div` s
+
+-- | /O(n * log(2^w)) = O(n * w)/ in the input list length @n@ (each
+-- element contributes a gcd update). Build a strided interval covering
+-- every element of an ascending, distinct list. Mirrors
+-- 'What4.Domains.BV.Arith.fromAscEltList' on stride-1 inputs but
+-- preserves the stride when the elements form an arithmetic progression.
+fromAscEltList ::
+  Fold.Foldable t =>
+  NatRepr w ->
+  t Integer ->
+  StridedInterval w
+fromAscEltList w vs =
+  -- Accumulate (first, min, max, gcd-of-(v - first)) across all elements.
+  -- The stride is the gcd of (v - first); this equals the gcd of (v - lo)
+  -- because the Z-module generated by {v_i - x} is invariant under
+  -- translation of x.
+  case Fold.foldl' step Nothing vs of
+    Nothing -> bottom mask
+    Just (_first, lo, hi, s) -> mkStridedInterval mask True lo hi s
+  where
+    mask = maxUnsigned w
+    step Nothing v =
+      let v' = maskUnsigned mask v
+      in Just (v', v', v', 0)
+    step (Just (first, lo, hi, g)) v =
+      let v' = maskUnsigned mask v
+      in Just (first, min lo v', max hi v', gcd g (v' - first))
+
+-- ---------------------------------------------------------------------------
+-- Conversion to\/from Arith
+
+-- | /O(1)/. Project a stride-1 SI into a "What4.Domains.BV.Arith"
+-- 'A.Domain' /exactly/. Returns 'Nothing' for empty SIs (which Arith
+-- cannot represent) and for SIs with stride > 1 (which Arith cannot
+-- represent precisely).
+--
+-- Use this when you need a faithful round-trip; use 'toArith' when you
+-- just want a sound contiguous cover.
+asArith :: StridedInterval w -> Maybe (A.Domain w)
+asArith si
+  | isBottom si = Nothing
+  | stride si == 1 =
+      let !mask = siMask si
+      in if siRange si == mask
+           then Just (A.BVDAny mask)
+           else Just (A.BVDInterval mask (base si) (siRange si))
+  | otherwise = Nothing
+
+-- | /O(1)/. Project /any/ SI into a "What4.Domains.BV.Arith" 'A.Domain'.
+-- Empty SIs map to 'A.bottom'. For stride > 1 SIs the result is the
+-- smallest contiguous cover, a sound over-approximation; for stride-1
+-- SIs it is exact (Arith's @BVDInterval@ encoding directly mirrors
+-- SI's @base@/@siRange@).
+--
+-- Use this when handing an SI to an Arith-only operation (e.g. 'udiv').
+toArith :: StridedInterval w -> A.Domain w
+toArith si
+  | isBottom si = A.BVDInterval (siMask si) 0 (-1)
+  | otherwise =
+      let !mask = siMask si
+          !sz   = span si
+      in if sz >= mask
+           then A.BVDAny mask
+           else A.BVDInterval mask (base si) sz
+
+-- | /O(1)/. Lift a "What4.Domains.BV.Arith" domain to a stride-1
+-- 'StridedInterval'. Always succeeds. The result represents the same
+-- set: 'A.bottom' maps to 'bottom', 'A.top' to 'top', and contiguous
+-- intervals to stride-1 SIs.
+fromArith :: Integer -> A.Domain w -> StridedInterval w
+fromArith mask d = assert (validMask mask) $
+  case d of
+    _ | A.isBottom d -> bottom mask
+    A.BVDAny _ -> top mask
+    A.BVDInterval _ lo sz
+      | sz >= mask -> top mask
+      | otherwise ->
+          StridedInterval { siMask = mask
+                          , base = lo Bits..&. mask
+                          , siRange = sz
+                          , stride = 1
+                          }
+
+-- | /O(f)/ where @f@ is the cost of the supplied Arith operation. Runs
+-- a unary Arith operation on the contiguous cover of an SI. For
+-- stride-1 inputs this is exact; for stride > 1 inputs it widens to
+-- the 'ubounds' cover (sound over-approximation).
+viaArith ::
+  NatRepr w ->
+  StridedInterval w ->
+  (A.Domain w -> A.Domain w) ->
+  StridedInterval w
+viaArith w si f
+  | isBottom si = bottom (maxUnsigned w)
+  | otherwise = fromArith (maxUnsigned w) (f (toArith si))
+
+-- ---------------------------------------------------------------------------
+-- Predicates
+
+-- | /O(1)/. Returns 'True' if this domain has no members (i.e., is 'bottom').
+isBottom :: StridedInterval w -> Bool
+isBottom si = stride si == 0
+
+-- | /O(1)/. Returns 'True' if this domain represents every bitvector
+-- of width @w@.
+isAny :: StridedInterval w -> Bool
+isAny si = base si == 0 && siRange si == siMask si && stride si == 1
+
+-- | /O(1)/. @member si x@: true iff @x mod 2^w@ is one of the residues
+-- of @si@. Argument order matches 'What4.Domains.BV.Arith.member'.
+member :: StridedInterval w -> Integer -> Bool
+member si _ | isBottom si = False
+member si n =
+  let !m = modulus si
+      !x = n `mod` m
+      !d = (x - base si) `mod` m
+      !s = stride si
+      !aligned = s == 1 || d `mod` s == 0
+  in aligned && d `div` s <= siRange si
+
+-- | /O(1)/. Check that a domain is proper, and that the given value is
+-- a member. Mirrors 'What4.Domains.BV.Arith.pmember'.
+pmember :: NatRepr w -> StridedInterval w -> Integer -> Bool
+pmember _ si x = proper si && member si x
+
+-- | /O(1)/. Return the value if this is a singleton. Mirrors
+-- 'What4.Domains.BV.Arith.asSingleton'.
+asSingleton :: StridedInterval w -> Maybe Integer
+asSingleton si
+  | isBottom si = Nothing
+  | siRange si == 0 = Just (base si)
+  | otherwise = Nothing
+
+-- | /O(w)/. A conservative overlap predicate: returns 'False' only
+-- when the residue sets of @a@ and @b@ are provably disjoint. May
+-- report 'True' for non-overlapping operands. Always preserves
+-- witnesses.
+--
+-- The cost is /O(log(min(stride a, stride b))) = O(log(2^w)) = O(w)/
+-- for the gcd of strides; otherwise /O(1)/.
+domainsOverlap ::
+  StridedInterval w ->
+  StridedInterval w ->
+  Bool
+domainsOverlap a b
+  | isBottom a || isBottom b = False
+  | isAny a || isAny b = True
+  -- Residue-class disjointness: if @(base a - base b)@ is not a
+  -- multiple of @gcd(stride a, stride b)@, no @i@ and @j@ make
+  -- @base a + i * stride a = base b + j * stride b@ over the
+  -- integers, so the unsigned (non-wrapping) sets are disjoint.
+  -- Wrapping operands can still overlap, so this only implies
+  -- disjointness when both sets are non-wrapping.
+  | g <- gcd (stride a) (stride b)
+  , (base a - base b) `mod` g /= 0
+  , Prelude.not (wraps a)
+  , Prelude.not (wraps b)
+  = False
+  | otherwise = A.domainsOverlap (toArith a) (toArith b)
+  where
+    wraps si =
+      let !m = modulus si
+          !endRes = (base si + span si) `mod` m
+      in endRes < base si
+
+-- ---------------------------------------------------------------------------
+-- Lattice operations
+
+-- | /O(1)/. Top element of the lattice: represents all bitvectors of width @w@.
+-- The argument is the mask @2^w - 1@.
+top :: Integer -> StridedInterval w
+top mask = assert (validMask mask) $
+  StridedInterval { siMask = mask, base = 0, siRange = mask, stride = 1 }
+{-# INLINE top #-}
+
+-- | /O(1)/. Bottom element of the lattice: represents the empty set of
+-- bitvectors. Encoded as @stride = 0@ (the @stride >= 1@ invariant on
+-- non-empty SIs leaves this slot free). The argument is the mask @2^w - 1@.
+bottom :: Integer -> StridedInterval w
+bottom mask = assert (validMask mask) $
+  StridedInterval { siMask = mask, base = 0, siRange = 0, stride = 0 }
+{-# INLINE bottom #-}
+
+-- | /O(w)/. Lattice join (least upper bound). Mirrors
+-- 'What4.Domains.BV.Arith.join'. On strided inputs, picks
+-- representatives whose midpoints are within @2^(w-1)@ of each other
+-- (lifting one operand by @2^w@ when not), then takes the
+-- gcd-of-strides cover. This matches the wrap-shorter arc that
+-- 'A.join' produces for stride-1 inputs.
+--
+-- @
+-- a:       [..***...........]   base 2, range 2, stride 1: {2,3,4}
+-- b:       [........***.....]   base 8, range 2, stride 1: {8,9,10}
+-- 'join':  [..*********.....]   base 2, range 8, stride 1: {2..10}
+-- @
+--
+-- The cost is /O(log(min(stride si1, stride si2))) = O(log(2^w)) =
+-- O(w)/ for the gcd of the operand strides; the rest is /O(1)/.
+join ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+join s t | isBottom s = t
+join s t | isBottom t = s
+join si1 si2 =
+  -- Twice each interval's midpoint, in the integer representation
+  -- (avoids fractions). When the two midpoints are more than 2^(w-1)
+  -- apart we lift the smaller-midpoint operand by 2^w to put it on
+  -- the "other side" - same trick as 'A.join'.
+  let !m = modulus si1
+      !ac = 2 * base si1 + span si1
+      !bc = 2 * base si2 + span si2
+      !b1' = if ac + (m - 1) < bc then base si1 + m else base si1
+      !b2' = if bc + (m - 1) < ac then base si2 + m else base si2
+      !lower = min b1' b2'
+      !upper = max (b1' + span si1)
+                   (b2' + span si2)
+      -- Singleton inputs have stride = 1 by canonicalization, but that
+      -- stride is meaningless (a singleton has only one element). Drop
+      -- it from the gcd so the join can pick up the gap stride.
+      !s1 = if siRange si1 == 0 then 0 else stride si1
+      !s2 = if siRange si2 == 0 then 0 else stride si2
+      !gap = max b1' b2' - lower
+  in mkStridedInterval (siMask si1) True lower upper
+                       (gcd (gcd s1 s2) gap)
+
+-- | /O(w)/. Specialization of 'join' when one operand is a singleton.
+-- The new element extends the SI's range by the gap to the nearest
+-- endpoint, with the new stride being the gcd of the existing stride
+-- and that gap.
+--
+-- @
+-- si:                  [..*.*.*.........]   base 2,  range 2, stride 2: {2,4,6}
+-- 's = 10':            [..........*.....]                                {10}
+-- 'unionSingleton':    [..*.*.*.*.*.....]   base 2,  range 4, stride 2: {2,4,6,8,10}
+-- @
+--
+-- Picks up the gap stride when it agrees with the existing stride
+-- (@gcd(2, 10 - 2) = 2@). When the gap is coprime with the stride,
+-- the result drops to stride 1.
+--
+-- The cost is /O(log(stride si)) = O(log(2^w)) = O(w)/ for the gcd;
+-- otherwise /O(1)/.
+unionSingleton ::
+  (1 <= w) =>
+  Integer ->
+  StridedInterval w ->
+  StridedInterval w
+unionSingleton s si
+  | isBottom si = singleton (siMask si) s
+  | member si s = si
+  | Just s' <- asSingleton si =
+      let lo = min s s'
+          hi = max s s'
+      in mkStridedInterval (siMask si) True lo hi (hi - lo)
+  | otherwise =
+      let !si_upper = base si + span si
+      in if s < base si
+         then go s si_upper (base si)
+         else go (base si) (max s si_upper) s
+  where
+    go lo hi to_contain =
+      mkStridedInterval (siMask si) True lo hi
+                        (gcd (stride si) (to_contain - lo))
+
+-- | /O(w)/. Lattice meet: a sound /over/-approximation of the
+-- intersection of two domains. For any concrete value @x@, if @x@ is
+-- a member of both @a@ and @b@, then @x@ is a member of @meet a b@.
+--
+-- When @a ⊑ b@ or @b ⊑ a@ the result is the smaller operand exactly
+-- (stride preserved). Otherwise routes through 'A.meet' on the
+-- contiguous unsigned covers, which gives a stride-1 result.
+meet ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+meet a _ | isBottom a = a
+meet _ b | isBottom b = b
+meet a b | isAny a = b
+meet a b | isAny b = a
+meet a b | a == b = a
+meet a b | leq a b = a
+meet a b | leq b a = b
+meet a b = fromArith (siMask a) (A.meet (toArith a) (toArith b))
+
+-- | /O(w)/. Lattice ordering: @leq si1 si2@ returns 'True' iff every
+-- concrete value represented by @si1@ is also represented by @si2@.
+--
+-- == Algebraic reasoning
+--
+-- Let @c = (base si1 - base si2) mod m@. Element @i@ of @si1@ lies in
+-- @si2@ iff @d_i = (c + i*s1) mod m@ is a multiple of @s2@ in
+-- @[0, r2*s2]@. The size cap @(r1+1)*s1 <= m@ implies the AP
+-- @c, c+s1, ..., c+r1*s1@ wraps mod @m@ at most once, splitting the
+-- indices @[0, r1]@ into a pre-wrap and a post-wrap segment.
+--
+-- For each segment to lie in @si2@:
+--
+-- * Its starting offset must be a multiple of @s2@ (residue
+--   condition).
+-- * If the segment has more than one element, @s2@ must divide @s1@
+--   (so consecutive elements stay in the same residue class).
+-- * The segment's largest offset must be at most @r2*s2@ (range
+--   condition).
+--
+-- Each check is /O(1)/ in arithmetic; the @gcd@-free formulation runs
+-- in /O(w)/ on width-@w@ inputs.
+leq ::
+  StridedInterval w ->
+  StridedInterval w ->
+  Bool
+leq si1 _ | isBottom si1 = True
+leq _ si2 | isBottom si2 = False
+leq si1 si2
+  | isAny si2 = True
+  | Just s <- asSingleton si1 = member si2 s
+  | otherwise =
+      let !m  = modulus si1
+          !s1 = stride si1
+          !s2 = stride si2
+          !r1 = siRange si1
+          !r2 = siRange si2
+          !c  = (base si1 - base si2) `mod` m
+          -- iWrap: smallest @i >= 1@ such that @c + i*s1 >= m@. Below
+          -- @iWrap@ the integer-AP doesn't wrap; at @iWrap@ and beyond it
+          -- has wrapped exactly once.
+          !iWrap = ((m - c) + s1 - 1) `div` s1
+          !wraps = iWrap <= r1
+          !preR = if wraps then iWrap - 1 else r1
+          !postBase = c + iWrap * s1 - m
+          !postR = r1 - iWrap
+          -- Check that the integer-AP @{b, b+s1, ..., b + r*s1}@ is wholly
+          -- inside @si2@'s residue set @{0, s2, ..., r2*s2}@.
+          checkSeg b r =
+            b `mod` s2 == 0
+            && (r == 0 || s1 `mod` s2 == 0)
+            && b + r * s1 <= r2 * s2
+      in checkSeg c preR
+         && (Prelude.not wraps || checkSeg postBase postR)
+
+-- | /O(w)/. Greatest lower bound: a strided
+-- interval that under-approximates the true intersection. Exact when
+-- one operand is a singleton or the bases match. Distinct from the
+-- lattice 'meet' (which is an over-approximation): 'glb' may /miss/
+-- witnesses that lie outside its strided shape but does not invent
+-- any. Use 'glb' for path-condition refinement; use 'meet' for lattice
+-- work.
+--
+-- @
+-- a:      [*.*.*.*.*.......]   base 0, range 4, stride 2: {0,2,4,6,8}
+-- b:      [*..*..*..*..*...]   base 0, range 4, stride 3: {0,3,6,9,12}
+-- 'glb':  [*.....*.........]   base 0, range 1, stride 6: {0,6}
+-- @
+--
+-- The cost is /O(log(min(stride si1, stride si2))) = O(log(2^w)) =
+-- O(w)/ for the extended-Euclidean Bezout step on the strides; the
+-- rest is /O(1)/.
+glb ::
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+glb si1 si2
+  | isBottom si1 || isBottom si2 = bottom (siMask si1)
+  | Just v <- asSingleton si1 =
+      if member si2 v then si1 else bottom (siMask si1)
+  | Just v <- asSingleton si2 =
+      if member si1 v then si2 else bottom (siMask si1)
+  | base si1 == base si2 = build (base si1)
+  -- Lower bound of the intersection: solve
+  --   base1 + n * stride1 = base2 + m * stride2
+  -- for the least non-negative n in [0, range si1] and m in [0, range si2].
+  | Just (n, _) <- solveLinearDiophantine
+                     (stride si1) (stride si2)
+                     (base si2 - base si1)
+                     (siRange si1) (siRange si2) =
+      build (base si1 + n * stride si1)
+  | otherwise = bottom (siMask si1)
+  where
+    -- @lo@ is a known common element. Cap the range so that
+    -- @(siRange + 1) * s <= 2^w@ - otherwise 'normalize' would widen to
+    -- 'top', which is /not/ a sound under-approximation of the
+    -- intersection. The cap-imposed range is a sound under-approximation
+    -- of the true intersection size.
+    build lo =
+      let !upper = min (base si1 + span si1)
+                       (base si2 + span si2)
+          !s = lcm (stride si1) (stride si2)
+          !m = siMask si1 + 1
+          !rFromUpper = (upper - lo) `div` s
+          !rFromCap   = (m `div` s) - 1
+          !r          = max 0 (min rFromUpper rFromCap)
+      in mkStridedInterval (siMask si1) False lo (lo + r * s) s
+
+-- ---------------------------------------------------------------------------
+-- Width manipulation
+
+-- | /O(w)/. Zero-extend a strided interval to a wider type. The set
+-- is unchanged; only the declared width changes. Wrapping intervals
+-- are handled by splitting into the union of two non-wrapping
+-- segments.
+--
+-- The cost is /O(log(2^w)) = O(w)/ for the gcd inside 'join' on the
+-- wrapping branch; /O(1)/ otherwise.
+zext ::
+  forall w u.
+  (1 <= w, w + 1 <= u) =>
+  StridedInterval w ->
+  NatRepr u ->
+  StridedInterval u
+zext si u =
+  case fProof of
+    LeqProof
+      | isBottom si -> bottom (maxUnsigned u)
+      | otherwise ->
+          let m_old = modulus si
+              endRes = (base si + span si) `mod` m_old
+          in if endRes >= base si
+               -- Non-wrapping: relabel.
+               then si { siMask = maxUnsigned u }
+               -- Wrapping: cover by the union of the two segments.
+               else join (range u (base si) (m_old - 1))
+                         (range u 0 endRes)
+  where
+    wProof :: LeqProof 1 w
+    wProof = LeqProof
+    uProof :: LeqProof (w + 1) u
+    uProof = LeqProof
+    fProof :: LeqProof 1 u
+    fProof = leqTrans (leqAdd wProof (knownNat :: NatRepr 1)) uProof
+
+-- | /O(w)/. Sign-extend an SI from width @w@ to a wider width @u@.
+-- Stride is always preserved: the SI is split at the sign boundary
+-- into a non-negative segment (relabeled at the new width) and a
+-- negative segment (shifted by the sign-extension amount), and their
+-- union is returned.
+--
+-- The cost is /O(log(2^w)) = O(w)/ for the gcd inside 'join' on the
+-- straddling/wrapping branch; /O(1)/ otherwise.
+sext ::
+  forall w u.
+  (1 <= w, w + 1 <= u) =>
+  NatRepr w ->
+  StridedInterval w ->
+  NatRepr u ->
+  StridedInterval u
+sext _ si u =
+  case fProof of
+    LeqProof
+      | isBottom si -> bottom (maxUnsigned u)
+      | otherwise ->
+          let !m_old   = modulus si
+              !half    = m_old `div` 2
+              !endRes  = (base si + span si) `mod` m_old
+              !signExt = (2 ^ natValue u) - m_old
+          in if endRes >= base si && endRes < half
+             -- Non-wrapping, all non-negative: relabel at the new width.
+             then si { siMask = maxUnsigned u }
+             else if endRes >= base si && base si >= half
+             -- Non-wrapping, all negative: shift the base into the
+             -- sign-extended range, preserving stride and range.
+             then (si { siMask = maxUnsigned u }) { base = base si + signExt }
+             else
+               -- Straddles the sign boundary and/or wraps. Split into
+               -- non-negative @[0, half-1]@ and negative @[half, m_old-1]@
+               -- sub-SIs (each with the same stride), then sign-extend
+               -- each separately and join.
+               let posPart = clipUnsigned si 0 (half - 1)
+                   negPart = case clipUnsigned si half (m_old - 1) of
+                               Nothing -> Nothing
+                               Just s  -> Just (s { base = base s + signExt })
+               in case (posPart, negPart) of
+                    (Just p, Just n)  -> join (p { siMask = maxUnsigned u }) (n { siMask = maxUnsigned u })
+                    (Just p, Nothing) -> p { siMask = maxUnsigned u }
+                    (Nothing, Just n) -> n { siMask = maxUnsigned u }
+                    (Nothing, Nothing) -> bottom (maxUnsigned u)
+  where
+    wProof :: LeqProof 1 w
+    wProof = LeqProof
+    uProof :: LeqProof (w + 1) u
+    uProof = LeqProof
+    fProof :: LeqProof 1 u
+    fProof = leqTrans (leqAdd wProof (knownNat :: NatRepr 1)) uProof
+
+-- | /O(w)/. Restrict an SI to the elements in the unsigned interval
+-- @[lo, hi]@, preserving stride. Returns 'Nothing' if no elements
+-- fall in the range. Internal helper for 'sext'; assumes
+-- @0 <= lo <= hi < 2^w@.
+--
+-- Indices @i ∈ [0, range]@ correspond to residues
+-- @(base + i*stride) mod m@. The residues march by @stride@ each step
+-- and may wrap around @m@ at most once (since @(range + 1) * stride <=
+-- m@). The pre-wrap and post-wrap segments are each handled as a
+-- contiguous integer range that we intersect with the (shifted) target
+-- range to find which @i@s qualify.
+--
+-- The cost is /O(log(2^w)) = O(w)/ for the gcd inside 'join';
+-- otherwise /O(1)/.
+clipUnsigned ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Integer ->
+  Integer ->
+  Maybe (StridedInterval w)
+clipUnsigned si lo hi
+  | isBottom si = Nothing
+  | otherwise =
+      let !s    = stride si
+          !m    = modulus si
+          !rng  = siRange si
+          !b    = base si
+          -- Index of first wrap-around: first @i@ such that
+          -- @b + i*s >= m@. If this is > rng, no wrap.
+          !iWrap = ceilDivPos' (m - b) s
+          residue i = (b + i * s) `mod` m
+          -- Pre-wrap: i in [0, min iWrap - 1, rng]; residues b, b+s, ..., b + i*s without wrap.
+          preEnd = min (iWrap - 1) rng
+          pre = clipSegment 0 preEnd b
+          -- Post-wrap: i in [iWrap, rng]; residues start at @b + iWrap*s - m@.
+          post
+            | iWrap > rng = Nothing
+            | otherwise =
+                let !pBase = b + iWrap * s - m
+                in clipSegment iWrap rng pBase
+          -- Clip a contiguous arithmetic-progression segment
+          -- (i in [iLo, iHi], residues startBase + (i - iLo)*s) to
+          -- the target range [lo, hi]. The set of qualifying @i@s
+          -- forms a contiguous integer range.
+          clipSegment iLo iHi startBase
+            | iLo > iHi = Nothing
+            | endRes < lo = Nothing      -- entirely below
+            | startBase > hi = Nothing   -- entirely above
+            | otherwise =
+                let -- @firstI@: smallest @i@ in @[iLo, iHi]@ with residue >= @lo@
+                    firstI = max iLo (iLo + ceilDivPos' (lo - startBase) s)
+                    -- @lastI@:  largest  @i@ in @[iLo, iHi]@ with residue <= @hi@
+                    lastI  = min iHi (iLo + (hi - startBase) `div` s)
+                in if firstI <= lastI
+                     then Just StridedInterval
+                       { siMask = siMask si
+                       , base = residue firstI
+                       , siRange = lastI - firstI
+                       , stride = s }
+                     else Nothing
+            where
+              endRes = startBase + (iHi - iLo) * s
+      in case (pre, post) of
+           (Just p, Just q) ->
+             -- Both segments contribute. They share stride; whether
+             -- they form a single SI or need a join depends on
+             -- alignment. Use 'join' for safety.
+             Just (join p q)
+           (Just p, Nothing) -> Just p
+           (Nothing, Just q) -> Just q
+           (Nothing, Nothing) -> Nothing
+  where
+    -- Ceiling division for positive divisor; returns 0 when @x <= 0@.
+    ceilDivPos' x y
+      | x <= 0 = 0
+      | otherwise = (x + y - 1) `div` y
+
+-- | /O(1)/. Concatenate. The result set is @{a * 2^v + b | a ∈ a_dom,
+-- b ∈ b_dom}@. When @b@ is a singleton, the high bits inherit @a@'s
+-- stride (scaled by @2^v@). When @a@ is a singleton, the high bits
+-- are constant and the low bits inherit @b@'s shape (with possible
+-- split if @b@ wraps). Otherwise the result mixes both strides — the
+-- gcd-of-stride structure may have gaps that don't fit a single
+-- strided shape, so we fall back
+-- to the contiguous cover.
+concat ::
+  NatRepr u ->
+  StridedInterval u ->
+  NatRepr v ->
+  StridedInterval v ->
+  StridedInterval (u + v)
+concat u a v b
+  | isBottom a || isBottom b = bottom resultMask
+  | Just bv <- asSingleton b =
+      -- @{a_i * 2^v + bv}@: stride scales by @2^v@, range preserved.
+      normalize StridedInterval { siMask = resultMask
+                                , base = base a * shift_v + bv
+                                , siRange = siRange a
+                                , stride = stride a * shift_v }
+  | Just av <- asSingleton a
+  , let !endRes_b = (base b + span b) `mod` shift_v
+  , endRes_b >= base b =
+      -- @{av * 2^v + b_j}@ with non-wrapping @b@: shift @b@'s shape
+      -- by @av * 2^v@ in the wider type. (The wrapping case would
+      -- require a join, so fall back to Arith below.)
+      normalize StridedInterval { siMask = resultMask
+                                , base = av * shift_v + base b
+                                , siRange = siRange b
+                                , stride = stride b }
+  | otherwise = fromArith resultMask (A.concat u (toArith a) v (toArith b))
+  where
+    resultMask = maxUnsigned (addNat u v)
+    !shift_v = 2 ^ natValue v
+
+-- | /O(w)/. Select a bit-slice. Mirrors 'What4.Domains.BV.Arith.select'.
+select ::
+  (1 <= n, i + n <= w) =>
+  NatRepr i ->
+  NatRepr n ->
+  StridedInterval w ->
+  StridedInterval n
+select i n a
+  | isBottom a = bottom (maxUnsigned n)
+  | otherwise = fromArith (maxUnsigned n) (A.select i n (toArith a))
+
+-- | /O(1)/. Truncate or relabel a strided interval at width @v@.
+trunc ::
+  NatRepr v ->
+  StridedInterval u ->
+  StridedInterval v
+trunc w si
+  | isBottom si = bottom mask
+  | isAny si   = top mask
+  -- Already fits at the new width: relabel.
+  | span si + stride si <= m =
+      normalize si { siMask = mask, base = base si `mod` m }
+  -- Stride divides modulus: every residue class is hit.
+  | m `mod` stride si == 0 =
+      let base_mod_w = base si `mod` m
+          base' = (base_mod_w
+                  + (stride si * ((m - base_mod_w) `ceilDiv` stride si)))
+                  `mod` m
+      in normalize StridedInterval { siMask = mask, base = base'
+                                   , siRange = (m `ceilDiv` stride si) - 1
+                                   , stride = stride si }
+  | otherwise = top mask
+  where
+    mask = maxUnsigned w
+    m = mask + 1
+    ceilDiv x y = assert (y /= 0) $ (x + y - 1) `div` y
+
+-- ---------------------------------------------------------------------------
+-- Arithmetic
+
+-- | /O(w)/. Bitvector addition modulo @2^w@. Mirrors
+-- 'What4.Domains.BV.Arith.add' on stride-1 inputs. On strided inputs,
+-- preserves the gcd-of-strides structure of the result, which can be
+-- strictly tighter than the contiguous Arith cover.
+--
+-- @
+-- a:      [*.*.*...........]   base 0, range 2, stride 2: {0,2,4}
+-- b:      [*...*...........]   base 0, range 1, stride 4: {0,4}
+-- 'add':  [*.*.*.*.*.......]   base 0, range 4, stride 2: {0,2,4,6,8}
+-- @
+--
+-- Anchors at @base si1 + base si2@ and uses @gcd(stride si1, stride
+-- si2)@ as the new stride. Letting @s = gcd(s1, s2)@, the cover has
+-- @r1*(s1\/s) + r2*(s2\/s) + 1@ elements spanning @r1*s1 + r2*s2@
+-- integers - the same total span as the Arith cover @[lo, lo+r1*s1 +
+-- r2*s2]@, but sparser by a factor of @s@. Hence this is always at
+-- least as precise as routing through 'A.add' on the contiguous
+-- covers, and strictly tighter when @s > 1@.
+--
+-- When the strided shape exceeds the size cap, 'normalize' drops to a
+-- stride-1 cover with the same span - which is exactly the Arith
+-- cover. So the SI ≤ A precision relation holds in every case.
+--
+-- The cost is /O(log(min(stride si1, stride si2))) = O(log(2^w)) =
+-- O(w)/ for the gcd of strides; otherwise /O(1)/.
+add ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+add si1 si2
+  | isBottom si1 || isBottom si2 = bottom (siMask si1)
+  | Just v <- asSingleton si1 =
+      normalize si2 { base = base si2 + v }
+  | Just v <- asSingleton si2 =
+      normalize si1 { base = base si1 + v }
+  | otherwise =
+      let !s = gcd (stride si1) (stride si2)
+          !r = (siRange si1 * (stride si1 `div` s))
+             + (siRange si2 * (stride si2 `div` s))
+      in normalize StridedInterval { siMask = siMask si1
+                                   , base = base si1 + base si2
+                                   , siRange = r
+                                   , stride = s
+                                   }
+
+
+-- | /O(w)/. Bitvector add-with-carry. @'Nothing'@ widens the range
+-- by one to account for an unknown carry-in.
+--
+-- The cost is /O(w)/ via 'add' and (in the @'Nothing'@ case) 'join'.
+adc ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Maybe Bool ->
+  StridedInterval w
+adc si1 si2 _ | isBottom si1 || isBottom si2 = bottom (siMask si1)
+adc si1 si2 (Just b) = add si1 (add si2 (singleton (siMask si1) (if b then 1 else 0)))
+adc si1 si2 Nothing =
+  -- Unknown carry-in: join of (a+b) and (a+b+1).
+  join (adc si1 si2 (Just False)) (adc si1 si2 (Just True))
+
+-- | /O(w)/. Bitvector multiplication modulo @2^w@. Bounds the result
+-- by taking corner products of the operands' /signed/ representatives
+-- (lifting bases that straddle the signed midpoint by @-2^w@), then
+-- takes the gcd of the cross-term step strides. On stride-1 inputs
+-- this matches 'A.mul' exactly; on strided inputs it can be more
+-- precise (the gcd-stride is preserved).
+--
+-- @
+-- a:      [*.*.............]   base 0, range 1, stride 2: {0,2}
+-- b:      [...*...*........]   base 3, range 1, stride 4: {3,7}
+-- 'mul':  [*.*.*.*.*.*.*.*.]   base 0, range 7, stride 2: {0,2,4,6,8,10,12,14}
+-- @
+--
+-- The product set is @{0,6,14}@ (true product), but a single SI must
+-- contain those three points; the gcd-2 cover above is the tightest
+-- such SI - any stride > 2 misses one of the three.
+--
+-- The cost is /O(log(stride si1 * stride si2)) = O(log(2^(2w))) =
+-- O(w)/ for the gcd of cross-term step strides; otherwise /O(1)/.
+mul ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+mul si1 si2
+  | isBottom si1 || isBottom si2 = bottom (siMask si1)
+  | otherwise =
+      let !m    = modulus si1
+          !mask = siMask si1
+          -- Signed-shift each operand if its unsigned span straddles the
+          -- signed midpoint (matches Arith.zbounds).
+          lift si =
+            if 2 * base si + span si > mask
+              then base si - m else base si
+          !lo1 = lift si1
+          !lo2 = lift si2
+          !hi1 = lo1 + span si1
+          !hi2 = lo2 + span si2
+          -- The product (b1 + i*s1)(b2 + j*s2) is bilinear in (i, j) over the
+          -- rectangle [0, r1] x [0, r2], so its extrema lie at the corners.
+          !ll = lo1 * lo2
+          !lh = lo1 * hi2
+          !hl = hi1 * lo2
+          !hh = hi1 * hi2
+          !cl = ll `min` lh `min` hl `min` hh
+          !ch = ll `max` lh `max` hl `max` hh
+          -- Stride: gcd of the three cross-term step strides
+          -- (s1*lo2, s2*lo1, s1*s2), suppressing terms where the
+          -- corresponding index is fixed (range = 0). 'abs' first because
+          -- lifted bases can be negative; @gcd 0 x = x@ handles the
+          -- suppressed terms.
+          !step1  = if siRange si1 == 0 then 0 else abs (stride si1 * lo2)
+          !step2  = if siRange si2 == 0 then 0 else abs (stride si2 * lo1)
+          !step12 = if siRange si1 == 0 || siRange si2 == 0 then 0
+                    else stride si1 * stride si2
+          !sRaw   = gcd (gcd step1 step2) step12
+          !s      = if sRaw == 0 then 1 else sRaw
+      in normalize StridedInterval { siMask = mask
+                                   , base = cl `mod` m
+                                   , siRange = (ch - cl) `div` s
+                                   , stride = s
+                                   }
+
+-- | /O(1)/. Negation modulo @2^w@. Mirrors 'What4.Domains.BV.Arith.negate'.
+negate ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w
+negate si
+  | isBottom si = si
+  | otherwise =
+      normalize si { base = Prelude.negate (base si + span si) }
+
+-- | /O(w)/. Subtraction modulo @2^w@. Mirrors
+-- 'What4.Domains.BV.Arith.add' composed with 'A.negate' on stride-1
+-- inputs; on strided inputs, preserves the gcd-of-strides structure.
+--
+-- @
+-- a:                [**..............]   base 0,  range 1, stride 1: {0,1}
+-- b:                [*.......*.......]   base 0,  range 1, stride 8: {0,8}
+-- 'sub' (native):   [********......**]   base 8,  range 9, stride 1: wraps to {0,1}
+-- @
+--
+-- Compare to @'add' a ('negate' b)@:
+--
+-- @
+-- 'negate' b:       [*.......*.......]   base 0,  range 1, stride 8: {0,8}  (set unchanged; dewrap rotated the AP)
+-- a + 'negate' b:   [**********......]   base 0,  range 9, stride 1: {0..9} (non-wrapping, looser)
+-- @
+--
+-- Anchors at @base si1 - base si2 - span si2@ (the
+-- smallest corner of the difference rectangle - the most negative
+-- @a_i - b_j@) and uses @gcd(stride si1, stride si2)@ as the new
+-- stride. Going native rather than @add a (negate b)@ matters because
+-- 'negate' canonicalizes via 'normalize''s @dewrap@ step, which
+-- dewraps @(range+1)*stride == 2^w@ shapes to a non-wrapping anchor;
+-- that loses the rotation that 'A.negate' picks for the contiguous
+-- cover.
+--
+-- The cost is /O(log(min(stride si1, stride si2))) = O(log(2^w)) =
+-- O(w)/ for the gcd of strides; otherwise /O(1)/.
+sub ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+sub si1 si2
+  | isBottom si1 || isBottom si2 = bottom (siMask si1)
+  | Just v <- asSingleton si2 =
+      normalize si1 { base = base si1 - v }
+  | otherwise =
+      let !s = gcd (stride si1) (stride si2)
+          !r = (siRange si1 * (stride si1 `div` s))
+             + (siRange si2 * (stride si2 `div` s))
+      in normalize StridedInterval
+           { siMask = siMask si1
+           , base = base si1 - base si2 - span si2
+           , siRange = r
+           , stride = s
+           }
+
+-- | /O(1)/. Multiply every element of @si@ by a scalar @k@, modulo
+-- @2^w@. Mirrors 'What4.Domains.BV.Arith.scale'. The scalar is
+-- interpreted as a /signed/ integer at width @w@ (matching Arith).
+scale ::
+  (1 <= w) =>
+  Integer ->
+  StridedInterval w ->
+  StridedInterval w
+scale _ si | isBottom si = si
+scale k si
+  | k' == 0 = singleton (siMask si) 0
+  | k' >= 0 =
+      normalize si { base = base si * k', stride = stride si * k' }
+  | otherwise =
+      -- Negate first (preserves stride), then scale by |k|.
+      let neg = negate si
+      in normalize neg { base = base neg * abs k', stride = stride neg * abs k' }
+  where
+    k' = maskSigned (siMask si) k
+
+-- | /O(1)/. Bitwise complement modulo @2^w@. Mirrors 'What4.Domains.BV.Arith.not'.
+not ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w
+not si
+  | isBottom si = si
+  | otherwise =
+      normalize si { base = siMask si
+                          - (base si + span si) }
+
+-- | /O(w)/. Bitwise AND. Converts both operands to the
+-- 'What4.Domains.BV.Bitwise' domain, applies 'B.and', and converts
+-- back to a stride-1 interval.
+and ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+and a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | otherwise = fromBitwise (siMask a) (B.and (toBitwise a) (toBitwise b))
+{-# INLINE and #-}
+
+-- | /O(w)/. Bitwise OR. Converts both operands to the
+-- 'What4.Domains.BV.Bitwise' domain, applies 'B.or', and converts
+-- back to a stride-1 interval.
+or ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+or a b
+  | isBottom a || isBottom b = if isBottom a then b else a
+  | otherwise = fromBitwise (siMask a) (B.or (toBitwise a) (toBitwise b))
+{-# INLINE or #-}
+
+-- | /O(w)/. Bitwise XOR. Converts both operands to the
+-- 'What4.Domains.BV.Bitwise' domain, applies 'B.xor', and converts
+-- back to a stride-1 interval.
+xor ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+xor a b
+  | isBottom a || isBottom b = if isBottom a then b else a
+  | otherwise = fromBitwise (siMask a) (B.xor (toBitwise a) (toBitwise b))
+{-# INLINE xor #-}
+
+-- | Convert an SI to a Bitwise domain via its bitwise bounds.
+toBitwise :: (1 <= w) => StridedInterval w -> B.Domain w
+toBitwise si = B.interval (siMask si) lo hi
+  where (lo, hi) = bitbounds si
+{-# INLINE toBitwise #-}
+
+-- | Convert a Bitwise domain back to a stride-1 SI.
+fromBitwise :: Integer -> B.Domain w -> StridedInterval w
+fromBitwise mask bw = assert (validMask mask) $
+  let (lo, hi) = B.ubounds bw
+  in if hi - lo >= mask then top mask
+     else StridedInterval { siMask = mask, base = lo, siRange = hi - lo, stride = 1 }
+{-# INLINE fromBitwise #-}
+
+-- | /O(w)/. Left shift. When the shift amount is a singleton @k@,
+-- scales by @2^k@ (preserving stride structure) or returns 0 if
+-- @k >= w@. Otherwise routes through 'A.shl' on the contiguous cover.
+--
+-- The cost is /O(w)/ for the @A.shl@ cover fallback; /O(1)/ on the
+-- singleton-shift path.
+shl ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+shl w a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | Just k <- asSingleton b =
+      if k >= intValue w
+        then singleton (siMask a) 0
+        else scale (2 ^ k) a
+  | otherwise =
+      -- Non-singleton shift amount: route through 'A.shl' on the cover,
+      -- which uses Arith's @mulRange@-of-@zbounds@ trick to produce a
+      -- tighter cover than enumerating shifts and joining would.
+      fromArith (siMask a) (A.shl w (toArith a) (toArith b))
+
+-- | /O(w)/. Logical right shift. When the shift amount is a singleton
+-- @k@, divides every element by @2^k@ (preserving the strided shape
+-- when the operand's stride is divisible by @2^k@); otherwise routes
+-- through 'A.lshr' on the unsigned cover.
+lshr ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+lshr w a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | Just k <- asSingleton b =
+      if k >= intValue w
+        then singleton (siMask a) 0
+        else lshrConst w a k
+  | otherwise = fromArith (siMask a) (A.lshr w (toArith a) (toArith b))
+
+-- | /O(1)/. Internal: @lshrConst a k@ shifts every element of @a@
+-- right by @k >= 0@ bits, preserving stride when possible.
+--
+-- If @a@ is non-wrapping and its stride is divisible by @2^k@, the
+-- result is @a@ with each element divided by @2^k@: same range, new
+-- stride @stride a / 2^k@, new base @base a `shiftR` k@. Otherwise we
+-- route through the contiguous Arith cover.
+lshrConst ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  Integer ->
+  StridedInterval w
+lshrConst w a k
+  | k == 0 = a
+  | otherwise =
+      let !m = modulus a
+          !endRes = (base a + span a) `mod` m
+          !wraps = endRes < base a
+          !shift_k = 2 ^ k
+          arithFallback =
+            fromArith (siMask a) (A.lshr w (toArith a)
+                                (toArith (singleton (siMask a) k)))
+      in if wraps then arithFallback
+         else if stride a `mod` shift_k == 0
+         then normalize StridedInterval { siMask = siMask a
+                                        , base = base a `Bits.shiftR` fromInteger k
+                                        , siRange = siRange a
+                                        , stride = stride a `div` shift_k }
+         else arithFallback
+
+-- | /O(w)/. Arithmetic right shift. Routes through 'A.ashr' on the
+-- unsigned cover.
+ashr ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+ashr w a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | otherwise = fromArith (siMask a) (A.ashr w (toArith a) (toArith b))
+
+-- | /O(w²)/. Rotate left. Converts to the 'What4.Domains.BV.Bitwise'
+-- domain, applies 'B.rolAbstract', and converts back to a stride-1 SI.
+rol ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+rol w a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | otherwise = fromBitwise (siMask a) (B.rolAbstract w (toBitwise a) (toBitwise b))
+{-# INLINE rol #-}
+
+-- | /O(w²)/. Rotate right. Converts to the 'What4.Domains.BV.Bitwise'
+-- domain, applies 'B.rorAbstract', and converts back to a stride-1 SI.
+ror ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+ror w a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | otherwise = fromBitwise (siMask a) (B.rorAbstract w (toBitwise a) (toBitwise b))
+{-# INLINE ror #-}
+
+-- | /O(w)/. Unsigned division. Routes through 'A.udiv' on the unsigned cover.
+udiv ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+udiv a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | otherwise = fromArith (siMask a) (A.udiv (toArith a) (toArith b))
+
+-- | /O(w)/. Unsigned remainder. Routes through 'A.urem' on the unsigned cover.
+urem ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+urem a b
+  | isBottom a || isBottom b = bottom (siMask a)
+  | otherwise = fromArith (siMask a) (A.urem (toArith a) (toArith b))
+
+-- | /O(w)/. Signed division. Routes through 'A.sdiv' on the unsigned cover.
+sdiv ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+sdiv w a b
+  | isBottom a || isBottom b = bottom (maxUnsigned w)
+  | otherwise = fromArith (maxUnsigned w) (A.sdiv w (toArith a) (toArith b))
+
+-- | /O(w)/. Signed remainder. Routes through 'A.srem' on the unsigned cover.
+srem ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  StridedInterval w
+srem w a b
+  | isBottom a || isBottom b = bottom (maxUnsigned w)
+  | otherwise = fromArith (maxUnsigned w) (A.srem w (toArith a) (toArith b))
+
+-- ---------------------------------------------------------------------------
+-- Destructors
+
+-- | /O(siRange) = O(2^w)/. Enumerate all elements of the SI.
+toList :: StridedInterval w -> [Integer]
+toList si
+  | isBottom si = []
+  | otherwise  =
+      let m = modulus si
+      in [ (base si + stride si * i) `mod` m | i <- [0 .. siRange si] ]
+
+-- | /O(1)/. Inclusive @(lo, hi)@ unsigned bounds. For wrapping or
+-- 'any' SIs, returns @(0, maxUnsigned w)@. Empty is treated like
+-- 'any' (callers should check 'isEmpty' first if they care).
+ubounds :: StridedInterval w -> (Integer, Integer)
+ubounds si
+  | isBottom si = (0, siMask si)
+  | isAny si   = (0, siMask si)
+  | otherwise  =
+      let !m = modulus si
+          !endRes = (base si + span si) `mod` m
+      in if endRes >= base si
+           then (base si, endRes)
+           else (0, siMask si)
+
+-- | /O(w)/. Inclusive @(lo, hi)@ signed bounds. Mirrors
+-- 'What4.Domains.BV.Arith.sbounds'.
+sbounds :: (1 <= w) => NatRepr w -> StridedInterval w -> (Integer, Integer)
+sbounds w si
+  | isBottom si = (Prelude.negate halfRange, halfRange - 1)
+  | otherwise = A.sbounds w (toArith si)
+  where
+    halfRange = 2 ^ (natValue w - 1)
+
+-- | /O(1)/. Bitwise bounds for the domain: @(bitwise-AND of all
+-- elements, bitwise-OR of all elements)@. Refined using 'unknowns'
+-- (which masks out the low bits fixed by the stride).
+bitbounds :: (1 <= w) => StridedInterval w -> (Integer, Integer)
+bitbounds si
+  | isBottom si = (0, 0)
+  | otherwise =
+      let !u  = unknowns si
+          !b  = base si
+          !hi = b Bits..|. u
+          !lo = hi `Bits.xor` u
+      in (lo, hi)
+
+-- | /O(1)/. Bitmask of bit positions whose values are not constant
+-- across the elements of the domain.
+unknowns :: (1 <= w) => StridedInterval w -> Integer
+unknowns si
+  | isBottom si = 0
+  | otherwise =
+      let !aUnknowns = A.unknowns (toArith si)
+          -- The largest power of two dividing @stride@. The low bits
+          -- below it equal the corresponding bits of @base@ across
+          -- every element of the SI, hence they don't vary.
+          !lowFixed = (stride si Bits..&. Prelude.negate (stride si)) - 1
+      in aUnknowns Bits..&. Bits.complement lowFixed
+
+-- | /O(w)/. Equality test. Mirrors 'What4.Domains.BV.Arith.eq'. Returns
+-- @Just True@ when both operands are the same singleton, @Just False@
+-- when the domains are provably disjoint, @Nothing@ otherwise.
+eq :: StridedInterval w -> StridedInterval w -> Maybe Bool
+eq a b
+  | Just x <- asSingleton a, Just y <- asSingleton b = Just (x == y)
+  | Prelude.not (domainsOverlap a b) = Just False
+  | otherwise = Nothing
+
+-- | /O(1)/. Unsigned less-than test. Mirrors 'What4.Domains.BV.Arith.ult'.
+ult :: (1 <= w) => StridedInterval w -> StridedInterval w -> Maybe Bool
+ult a b
+  | a_max < b_min = Just True
+  | a_min >= b_max = Just False
+  | otherwise = Nothing
+  where
+    (a_min, a_max) = ubounds a
+    (b_min, b_max) = ubounds b
+
+-- | /O(w)/. Signed less-than test. Mirrors 'What4.Domains.BV.Arith.slt'.
+slt :: (1 <= w) => NatRepr w -> StridedInterval w -> StridedInterval w -> Maybe Bool
+slt w a b
+  | a_max < b_min = Just True
+  | a_min >= b_max = Just False
+  | otherwise = Nothing
+  where
+    (a_min, a_max) = sbounds w a
+    (b_min, b_max) = sbounds w b
+
+-- ---------------------------------------------------------------------------
+-- Correctness properties
+
+-- ---------------------------------------------------------------------------
+-- Generators
+
+-- | Random generator for proper strided-interval domain values.
+-- Produces a mix of empty, singleton, non-wrapping strided, and wrapping
+-- strided intervals.
+genDomain :: NatRepr w -> Gen (StridedInterval w)
+genDomain w =
+  do let mask = maxUnsigned w
+         m = mask + 1
+     sz <- getSize
+     shape <- chooseInt (0, 11 :: Int)
+     case shape of
+       0 -> pure (bottom mask)
+       1 -> singleton mask <$> chooseInteger (0, mask)
+       _ ->
+         -- Pick r >= 1 first, then pick s so that (r + 1) * s <= m. This
+         -- automatically excludes the uncanonical "stride > 1, range 0"
+         -- shape (which is just a singleton with the wrong stride).
+         do b <- chooseInteger (0, mask)
+            let rCap = max 1 (min (toInteger sz) (mask))
+            r <- chooseInteger (1, rCap)
+            let strideCap = max 1 (min (toInteger sz) (m `div` (r + 1)))
+            s <- chooseInteger (1, strideCap)
+            -- Avoid the uncanonical "full set" shape (covered by 'top').
+            let !full = r == mask && s == 1 && b /= 0
+            pure StridedInterval { siMask = mask
+                                 , base = if full then 0 else b
+                                 , siRange = r
+                                 , stride = s
+                                 }
+
+-- | Generate an element of a non-empty strided interval. If the input is
+-- empty, generates 0; properties using the result must guard with
+-- @member a x ==> ...@.
+genElement :: StridedInterval w -> Gen Integer
+genElement si
+  | isBottom si = pure 0
+  | otherwise =
+      do i <- chooseInteger (0, siRange si)
+         pure ((base si + stride si * i) `mod` modulus si)
+
+-- | Generate a domain paired with one of its elements.
+genPair :: NatRepr w -> Gen (StridedInterval w, Integer)
+genPair w =
+  do a <- genDomain w
+     x <- genElement a
+     pure (a, x)
+
+-- ---------------------------------------------------------------------------
+-- Invariant postconditions
+
+correct_proper_bottom :: NatRepr w -> Property
+correct_proper_bottom w = property (proper (bottom (maxUnsigned w)))
+
+correct_proper_top :: NatRepr w -> Property
+correct_proper_top w = property (proper (top (maxUnsigned w)))
+
+correct_proper_singleton :: NatRepr w -> Integer -> Property
+correct_proper_singleton w v = property (proper (singleton (maxUnsigned w) v))
+
+correct_proper_mkStridedInterval ::
+  NatRepr w ->
+  Bool ->
+  Integer ->
+  Integer ->
+  Integer ->
+  Property
+correct_proper_mkStridedInterval w roundUp lo hi s =
+  property (proper (mkStridedInterval (maxUnsigned w) roundUp lo hi s))
+
+correct_proper_range ::
+  NatRepr w ->
+  Integer ->
+  Integer ->
+  Property
+correct_proper_range w lo hi = property (proper (range w lo hi))
+
+correct_proper_fromAscEltList :: NatRepr w -> [Integer] -> Property
+correct_proper_fromAscEltList w vs = property (proper (fromAscEltList w vs))
+
+correct_proper_join ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_join a b = property (proper (join a b))
+
+correct_proper_unionSingleton ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_proper_unionSingleton si v = property (proper (unionSingleton v si))
+
+correct_proper_glb ::
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_glb a b = property (proper (glb a b))
+
+correct_proper_add ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_add a b = property (proper (add a b))
+
+correct_proper_adc ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Maybe Bool ->
+  Property
+correct_proper_adc a b c = property (proper (adc a b c))
+
+correct_proper_mul ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_mul a b = property (proper (mul a b))
+
+correct_proper_sub ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_sub a b = property (proper (sub a b))
+
+correct_proper_negate ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Property
+correct_proper_negate si = property (proper (negate si))
+
+correct_proper_scale ::
+  (1 <= w) =>
+  Integer ->
+  StridedInterval w ->
+  Property
+correct_proper_scale k si = property (proper (scale k si))
+
+correct_proper_not ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Property
+correct_proper_not si = property (proper (not si))
+
+correct_proper_and ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_and a b = property (proper (and a b))
+
+correct_proper_or ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_or a b = property (proper (or a b))
+
+correct_proper_xor ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_xor a b = property (proper (xor a b))
+
+correct_proper_shl ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_shl w a b = property (proper (shl w a b))
+
+correct_proper_lshr ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_lshr w a b = property (proper (lshr w a b))
+
+correct_proper_ashr ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_ashr w a b = property (proper (ashr w a b))
+
+correct_proper_rol ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_rol w a b = property (proper (rol w a b))
+
+correct_proper_ror ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_ror w a b = property (proper (ror w a b))
+
+correct_proper_udiv ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_udiv a b = property (proper (udiv a b))
+
+correct_proper_urem ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_urem a b = property (proper (urem a b))
+
+correct_proper_sdiv ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_sdiv w a b = property (proper (sdiv w a b))
+
+correct_proper_srem ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+correct_proper_srem w a b = property (proper (srem w a b))
+
+correct_proper_concat ::
+  NatRepr u ->
+  StridedInterval u ->
+  NatRepr v ->
+  StridedInterval v ->
+  Property
+correct_proper_concat u a v b = property (proper (concat u a v b))
+
+correct_proper_select ::
+  (1 <= n, i + n <= w) =>
+  NatRepr i ->
+  NatRepr n ->
+  StridedInterval w ->
+  Property
+correct_proper_select i n a = property (proper (select i n a))
+
+correct_proper_trunc :: NatRepr v -> StridedInterval w -> Property
+correct_proper_trunc v si = property (proper (trunc v si))
+
+correct_proper_zext ::
+  forall w u.
+  (1 <= w, w + 1 <= u) =>
+  StridedInterval w ->
+  NatRepr u ->
+  Property
+correct_proper_zext si u = property (proper (zext si u))
+
+correct_proper_sext ::
+  forall w u.
+  (1 <= w, w + 1 <= u) =>
+  NatRepr w ->
+  StridedInterval w ->
+  NatRepr u ->
+  Property
+correct_proper_sext w si u = property (proper (sext w si u))
+
+-- ---------------------------------------------------------------------------
+-- Predicates
+
+correct_toList_member :: StridedInterval w -> Property
+correct_toList_member si =
+  property (Prelude.all (member si) (toList si))
+
+correct_member_toList ::
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_member_toList si x =
+  member si x ==> elem (x `mod` modulus si) (toList si)
+
+correct_asSingleton :: StridedInterval w -> Property
+correct_asSingleton si =
+  case asSingleton si of
+    Just v  -> property (toList si == [v])
+    Nothing -> property True
+
+correct_domainsOverlap ::
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_domainsOverlap a b x =
+  member a x ==> member b x ==> domainsOverlap a b
+
+correct_domainsOverlap_bottom :: StridedInterval w -> Property
+correct_domainsOverlap_bottom si =
+  property (Prelude.not (domainsOverlap (bottom (siMask si)) si))
+
+-- ---------------------------------------------------------------------------
+-- Lattice operations
+
+-- | 'join' is sound: if @x@ is in either @a@ or @b@, then @x@ is in
+-- @join a b@.
+correct_join ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_join a b x =
+  (member a x || member b x) ==> member (join a b) x
+
+-- | 'meet' is a sound /over/-approximation of intersection: if @x@ is in
+-- both @a@ and @b@, then @x@ is in @meet a b@.
+correct_meet ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_meet a b x =
+  (member a x && member b x) ==> member (meet a b) x
+
+-- | 'leq' is a sound under-approximation of the subset relation: if
+-- @leq a b@ holds and @x@ is in @a@, then @x@ is in @b@.
+correct_leq ::
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_leq a b x =
+  (leq a b && member a x) ==> member b x
+
+correct_unionSingleton ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_unionSingleton si v =
+  property (member (unionSingleton v si) v)
+
+correct_glb ::
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_glb a b x =
+  member (glb a b) x ==> member a x && member b x
+
+correct_glb_singleton_left ::
+  NatRepr w ->
+  Integer ->
+  StridedInterval w ->
+  Property
+correct_glb_singleton_left w v si =
+  let s = singleton (maxUnsigned w) v
+  in member si v ==> member (glb s si) v
+
+correct_glb_singleton_right ::
+  NatRepr w ->
+  Integer ->
+  StridedInterval w ->
+  Property
+correct_glb_singleton_right w v si =
+  let s = singleton (maxUnsigned w) v
+  in member si v ==> member (glb si s) v
+
+-- ---------------------------------------------------------------------------
+-- Lattice laws (semantic, i.e. same set of members)
+
+join_commutative ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+join_commutative a b x =
+  property (member (join a b) x == member (join b a) x)
+
+join_idempotent ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Integer ->
+  Property
+join_idempotent a x =
+  property (member (join a a) x == member a x)
+
+meet_commutative ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+meet_commutative a b x =
+  property (member (meet a b) x == member (meet b a) x)
+
+meet_idempotent ::
+  (1 <= w) =>
+  StridedInterval w ->
+  Integer ->
+  Property
+meet_idempotent a x =
+  property (member (meet a a) x == member a x)
+
+join_top ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+join_top w a x =
+  property (member (join a (top (maxUnsigned w))) x)
+
+join_bottom ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+join_bottom w a x =
+  property (member (join a (bottom (maxUnsigned w))) x == member a x)
+
+meet_top ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+meet_top w a x =
+  property (member (meet a (top (maxUnsigned w))) x == member a x)
+
+meet_bottom ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  Integer ->
+  Property
+meet_bottom w a x =
+  property (Prelude.not (member (meet a (bottom (maxUnsigned w))) x))
+
+leq_reflexive :: StridedInterval w -> Property
+leq_reflexive a = property (leq a a)
+
+join_upper_bound ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+join_upper_bound a b = property (leq a (join a b))
+
+join_proper ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+join_proper a b = property (proper (join a b))
+
+meet_proper ::
+  (1 <= w) =>
+  StridedInterval w ->
+  StridedInterval w ->
+  Property
+meet_proper a b = property (proper c)
+  where c = meet a b
+
+-- ---------------------------------------------------------------------------
+-- Width manipulation
+
+correct_concat ::
+  NatRepr u ->
+  (StridedInterval u, Integer) ->
+  NatRepr v ->
+  (StridedInterval v, Integer) ->
+  Property
+correct_concat u (a, x) v (b, y) =
+  member a x ==> member b y ==>
+    member (concat u a v b)
+           (toUnsigned u x * 2 ^ natValue v + toUnsigned v y)
+
+correct_select ::
+  (1 <= n, i + n <= w) =>
+  NatRepr i ->
+  NatRepr n ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_select i n (a, x) =
+  member a x ==>
+    let !shifted = (x `mod` modulus a) `div` (2 ^ natValue i)
+    in member (select i n a) (toUnsigned n shifted)
+
+correct_trunc ::
+  NatRepr v ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_trunc v (si, x) =
+  member si x ==> member (trunc v si) (toUnsigned v x)
+
+correct_zext ::
+  forall w u.
+  (1 <= w, w + 1 <= u) =>
+  StridedInterval w ->
+  NatRepr u ->
+  Integer ->
+  Property
+correct_zext si u x =
+  member si x ==>
+    member (zext si u) (x `mod` modulus si)
+
+correct_sext ::
+  forall w u.
+  (1 <= w, w + 1 <= u) =>
+  NatRepr w ->
+  StridedInterval w ->
+  NatRepr u ->
+  Integer ->
+  Property
+correct_sext w si u x =
+  member si x ==>
+    member (sext w si u) (toSigned w x)
+
+-- ---------------------------------------------------------------------------
+-- Arithmetic
+
+correct_add ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_add w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    member (add a b) ((x + y) `mod` modulusN w)
+
+correct_adc ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Bool ->
+  Property
+correct_adc w (a, x) (b, y) c =
+  member a x ==> member b y ==>
+    member (adc a b (Just c))
+           ((x + y + (if c then 1 else 0)) `mod` modulusN w)
+
+correct_sub ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_sub w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    member (sub a b) ((x - y) `mod` modulusN w)
+
+correct_negate ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_negate w (a, x) =
+  member a x ==>
+    member (negate a) ((Prelude.negate x) `mod` modulusN w)
+
+correct_scale ::
+  (1 <= w) =>
+  NatRepr w ->
+  Integer ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_scale w k (a, x) =
+  member a x ==>
+    member (scale k a) ((toSigned w k * x) `mod` modulusN w)
+
+correct_mul ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_mul w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    member (mul a b) ((x * y) `mod` modulusN w)
+
+correct_udiv ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_udiv _ (a, x) (b, y) =
+  member a x ==> member b y ==> y' /= 0 ==>
+    member (udiv a b) (x' `quot` y')
+  where
+    x' = maskUnsigned (siMask a) x
+    y' = maskUnsigned (siMask b) y
+
+correct_urem ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_urem _ (a, x) (b, y) =
+  member a x ==> member b y ==> y' /= 0 ==>
+    member (urem a b) (x' `rem` y')
+  where
+    x' = maskUnsigned (siMask a) x
+    y' = maskUnsigned (siMask b) y
+
+correct_sdiv ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_sdiv w (a, x) (b, y) =
+  member a x ==> member b y ==> y' /= 0 ==>
+    member (sdiv w a b) (x' `quot` y')
+  where
+    x' = toSigned w x
+    y' = toSigned w y
+
+correct_srem ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_srem w (a, x) (b, y) =
+  member a x ==> member b y ==> y' /= 0 ==>
+    member (srem w a b) (x' `rem` y')
+  where
+    x' = toSigned w x
+    y' = toSigned w y
+
+correct_not ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_not w (a, x) =
+  member a x ==>
+    member (not a) (Bits.complement x Bits..&. maxUnsigned w)
+
+correct_and ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_and _w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    member (and a b) (x Bits..&. y)
+
+correct_or ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_or _w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    member (or a b) (x Bits..|. y)
+
+correct_xor ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_xor _w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    member (xor a b) (x `Bits.xor` y)
+
+correct_shl ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_shl w (a, x) (b, k) =
+  member a x ==> member b k ==>
+    let expected
+          | k >= toInteger (natValue w) = 0
+          | otherwise = (x * (2 ^ k)) `mod` modulusN w
+    in member (shl w a b) expected
+
+correct_lshr ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_lshr w (a, x) (b, k) =
+  member a x ==> member b k ==>
+    let z = toUnsigned w x `Bits.shiftR` fromInteger (min (intValue w) k)
+    in member (lshr w a b) z
+
+correct_ashr ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_ashr w (a, x) (b, k) =
+  member a x ==> member b k ==>
+    let z = toSigned w x `Bits.shiftR` fromInteger (min (intValue w) k)
+    in member (ashr w a b) z
+
+correct_rol ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_rol w (a, x) (b, k) =
+  member a x ==> member b k ==>
+    member (rol w a b) (Arith.rotateLeft w x k)
+
+correct_ror ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_ror w (a, x) (b, k) =
+  member a x ==> member b k ==>
+    member (ror w a b) (Arith.rotateRight w x k)
+
+-- ---------------------------------------------------------------------------
+-- Destructors
+
+correct_size :: (StridedInterval w, Integer) -> Property
+correct_size (si, _) =
+  property (size si == toInteger (length (toList si)))
+
+correct_ubounds ::
+  StridedInterval w ->
+  Integer ->
+  Property
+correct_ubounds si x =
+  member si x ==>
+    let (lo, hi) = ubounds si
+        x'      = x `mod` modulus si
+    in lo <= x' && x' <= hi
+
+correct_ubounds_bottom :: NatRepr w -> Property
+correct_ubounds_bottom w = property (isBottom (bottom (maxUnsigned w)))
+
+correct_sbounds ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_sbounds w (a, x) =
+  member a x ==>
+    let (lo, hi) = sbounds w a
+        x'      = toSigned w x
+    in lo <= x' && x' <= hi
+
+correct_bitbounds ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_bitbounds _ (a, x) =
+  member a x ==>
+    let (lo, hi) = bitbounds a
+        x'      = x `mod` modulus a
+    in (x' Bits..|. lo) == x' && (x' Bits..|. hi) == hi
+
+correct_unknowns ::
+  (1 <= w) =>
+  NatRepr w ->
+  StridedInterval w ->
+  Integer ->
+  Integer ->
+  Property
+correct_unknowns _ a x y =
+  member a x ==> member a y ==>
+    let u = unknowns a
+    in (x Bits..|. u) == (y Bits..|. u)
+
+correct_eq ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_eq w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    case eq a b of
+      Just True  -> toUnsigned w x == toUnsigned w y
+      Just False -> toUnsigned w x /= toUnsigned w y
+      Nothing    -> True
+
+correct_ult ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_ult w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    case ult a b of
+      Just True  -> toUnsigned w x < toUnsigned w y
+      Just False -> toUnsigned w x >= toUnsigned w y
+      Nothing    -> True
+
+correct_slt ::
+  (1 <= w) =>
+  NatRepr w ->
+  (StridedInterval w, Integer) ->
+  (StridedInterval w, Integer) ->
+  Property
+correct_slt w (a, x) (b, y) =
+  member a x ==> member b y ==>
+    case slt w a b of
+      Just True  -> toSigned w x < toSigned w y
+      Just False -> toSigned w x >= toSigned w y
+      Nothing    -> True
+
+-- ---------------------------------------------------------------------------
+-- Bottom edge cases
+
+correct_glb_bottom_left :: StridedInterval w -> Property
+correct_glb_bottom_left a = property (isBottom (glb (bottom (siMask a)) a))
+
+correct_glb_bottom_right :: StridedInterval w -> Property
+correct_glb_bottom_right a = property (isBottom (glb a (bottom (siMask a))))
+
+correct_add_bottom_left ::
+  (1 <= w) =>
+  NatRepr w -> StridedInterval w -> Property
+correct_add_bottom_left w a = property (isBottom (add (bottom (maxUnsigned w)) a))
+
+correct_add_bottom_right ::
+  (1 <= w) =>
+  NatRepr w -> StridedInterval w -> Property
+correct_add_bottom_right w a = property (isBottom (add a (bottom (maxUnsigned w))))
+
+correct_mul_bottom_left ::
+  (1 <= w) =>
+  NatRepr w -> StridedInterval w -> Property
+correct_mul_bottom_left w a = property (isBottom (mul (bottom (maxUnsigned w)) a))
+
+correct_mul_bottom_right ::
+  (1 <= w) =>
+  NatRepr w -> StridedInterval w -> Property
+correct_mul_bottom_right w a = property (isBottom (mul a (bottom (maxUnsigned w))))
+
+-- Helper.
+modulusN :: NatRepr w -> Integer
+modulusN w = 2 ^ natValue w

--- a/what4-domains/src/What4/Domains/BV/StridedInterval/Internal.hs
+++ b/what4-domains/src/What4/Domains/BV/StridedInterval/Internal.hs
@@ -1,0 +1,190 @@
+{-|
+Module      : What4.Domains.BV.StridedInterval.Internal
+Copyright   : (c) Galois, Inc 2015-2026
+License     : BSD3
+Maintainer  : langston@galois.com
+
+Internal helpers for "What4.Domains.BV.StridedInterval".  Exposed so the
+test suite can exercise them directly; not part of the public API.
+-}
+
+module What4.Domains.BV.StridedInterval.Internal
+  ( solveLinearDiophantine
+  , eGCD
+  , ceilDivPos
+  , floorDivPos
+  ) where
+
+import           Control.Exception (assert)
+
+-- | /O(log(min(a, b)))/. @solveLinearDiophantine a b c a_max b_max@
+-- finds nonnegative integers @x, y@ with @0 <= x <= a_max@,
+-- @0 <= y <= b_max@ such that
+--
+-- > a * x - b * y = c
+--
+-- Assumes @a > 0@, @b > 0@, and @c /= 0@.  Returns 'Nothing' when no
+-- such pair exists; when one does, returns the lex-least solution.
+--
+-- The cost is dominated by the 'eGCD' call. When called from
+-- 'What4.Domains.BV.StridedInterval.glb' on width-@w@ inputs, both
+-- @a@ and @b@ are bounded by @2^w@, giving /O(log(2^w)) = O(w)/.
+--
+-- == Proof of correctness
+--
+-- We must show two things: (1) the function returns 'Nothing' exactly when no
+-- solution in the 2D box @0 <= x <= a_max@, @0 <= y <= b_max@ exists, and (2)
+-- when a solution in the box exists, the returned pair is the lex-least one.
+-- We prove both by reducing the search over the two-dimensional set
+--
+-- > S = { (x, y) ∈ Z^2 : a*x - b*y = c, 0 <= x <= a_max, 0 <= y <= b_max }
+--
+-- to a search over a one-dimensional integer interval @[t_lower, t_upper]@, via
+-- a bijection @t \<-\> (x(t), y(t))@ that is increasing in both coordinates.
+-- Three lemmas do the work; the function then simply checks whether the
+-- @t@-interval is nonempty and, if so, evaluates @(x, y)@ at its left endpoint.
+--
+-- The construction follows the standard Bézout / extended-Euclidean recipe for
+-- linear Diophantine equations, restricted to the box.
+--
+-- === Setup
+--
+-- Let @g = gcd(a, b)@; since @a, b > 0@, @g > 0@.  'eGCD', called with @-b@,
+-- returns @(g, n, m)@ satisfying
+--
+-- > n * a - m * b = g                                                (*)
+--
+-- Define @aq = a \/ g@ and @bq = b \/ g@; both are positive integers.  By the
+-- general identity @gcd(k*x, k*y) = k * gcd(x, y)@ for @k > 0@, applied to
+-- @a = g*aq@ and @b = g*bq@, we get @g = gcd(a, b) = g * gcd(aq, bq)@, hence
+--
+-- > gcd(aq, bq) = 1                                                  (coprime)
+--
+-- === Lemma 1 (Divisibility is necessary)
+--
+-- If @a*x - b*y = c@ has any integer solution, then @g | c@.  Proof: the left
+-- side is an integer combination of @a@ and @b@, hence a multiple of @g@.  So
+-- if @g@ does not divide @c@, even the unbounded equation has no solutions and
+-- @S@ is empty.  The code checks this as @c \`rem\` g /= 0@.
+--
+-- === Lemma 2 (Bézout parameterization)
+--
+-- Assume @g | c@ and let @cq = c \/ g@.  Then the set of /all/ integer
+-- solutions to @a*x - b*y = c@ is exactly
+--
+-- > P = { (n*cq + bq*t, m*cq + aq*t) : t ∈ Z }                       (**)
+--
+-- We need both inclusions.
+--
+-- /(P ⊆ solutions.)/  For any @t ∈ Z@, direct substitution gives
+--
+-- > a*(n*cq + bq*t) - b*(m*cq + aq*t)
+-- >   = (n*a - m*b)*cq + (a*bq - b*aq)*t      { distribute, regroup by cq and t }
+-- >   = g*cq + (a*bq - b*aq)*t                { by (*) }
+-- >   = g*cq + (a*(b\/g) - b*(a\/g))*t        { unfold aq = a\/g, bq = b\/g }
+-- >   = g*cq + 0                              { a*b\/g - b*a\/g = 0 }
+-- >   = g*(c\/g)                              { unfold cq = c\/g }
+-- >   = c                                     { simplify }
+--
+-- /(solutions ⊆ P.)/  This direction is what justifies enumerating by @t@ at
+-- all: it ensures we are not missing solutions outside @P@.  Let @(x, y)@ be
+-- any solution.  Then
+--
+-- > a*(x - n*cq) - b*(y - m*cq)
+-- >   = (a*x - b*y) - (a*(n*cq) - b*(m*cq))   { distribute }
+-- >   = c - (n*a - m*b)*cq                    { (x,y) solves the equation; regroup }
+-- >   = c - g*cq                              { by (*) }
+-- >   = c - g*(c\/g)                          { unfold cq = c\/g }
+-- >   = 0                                     { g | c, so g*(c\/g) = c }
+--
+-- so @a*(x - n*cq) = b*(y - m*cq)@; dividing by @g > 0@,
+--
+-- > aq*(x - n*cq) = bq*(y - m*cq)
+--
+-- This shows @bq | aq*(x - n*cq)@.  By Euclid's lemma — if @gcd(p, q) = 1@ and
+-- @p | q*r@, then @p | r@ — together with (coprime), we conclude @bq | (x -
+-- n*cq)@.  Let @t = (x - n*cq) \/ bq@; then @x = n*cq + bq*t@, and substituting
+-- into the displayed equation gives @aq*bq*t = bq*(y - m*cq)@, so @y = m*cq
+-- + aq*t@ (since @bq > 0@). Hence @(x, y) ∈ P@ with this @t@, which is unique
+-- because @aq, bq@ are nonzero.
+--
+-- === Lemma 3 (Box constraints reduce to a @t@-interval)
+--
+-- Under the bijection @t \<-\> (x(t), y(t))@ from (**), the four box
+-- constraints are equivalent to a single integer interval on @t@. Substituting
+-- into @0 <= x <= a_max@ and @0 <= y <= b_max@ gives
+--
+-- > -n*cq <= bq*t <= a_max - n*cq        -m*cq <= aq*t <= b_max - m*cq
+--
+-- Multiplying through by @g > 0@ and using @g*bq = b@, @g*cq = c@ (and
+-- analogously for @a@) preserves the inequalities and clears the divisions:
+--
+-- > -n*c <= b*t <= a_max*g - n*c          -m*c <= a*t <= b_max*g - m*c
+--
+-- Since @a, b > 0@, dividing by the coefficient of @t@ preserves the
+-- direction; rounding inward (because @t@ is an integer) is exact.  So the
+-- four constraints are equivalent to @t_lower <= t <= t_upper@ where
+--
+-- > t_lower = max (ceiling(-n*c \/ b)) (ceiling(-m*c \/ a))
+-- > t_upper = min (floor((a_max*g - n*c) \/ b)) (floor((b_max*g - m*c) \/ a))
+--
+-- === Putting it together
+--
+-- Combining Lemmas 1--3, @S@ is nonempty iff @g | c@ /and/ @t_lower <=
+-- t_upper@; and when it is, @S = { (x(t), y(t)) : t_lower <= t <= t_upper
+-- }@.  Since @aq, bq > 0@, both coordinates of (**) are strictly increasing
+-- in @t@, so @t = t_lower@ simultaneously minimizes @x@ and @y@ and yields the
+-- lex-least element of @S@.
+--
+-- The code mirrors this exactly: it returns 'Nothing' when @cr /= 0@ (Lemma
+-- 1) or @t_upper < t@ (Lemma 3), and otherwise @Just (x(t_lower), y(t_lower))@
+-- (Lemma 2).
+solveLinearDiophantine :: Integer -> Integer -> Integer
+                       -> Integer -> Integer
+                       -> Maybe (Integer, Integer)
+solveLinearDiophantine a b c a_max b_max
+  | cr /= 0      = Nothing  -- Lemma 1
+  | t_upper < t  = Nothing  -- Lemma 3
+  | otherwise    = Just (n * cq + bq * t, m * cq + aq * t)  -- Lemma 2
+  where
+    (g, n, m) = eGCD a (-b)
+    (cq, cr)  = c `quotRem` g
+    aq        = a `quot` g
+    bq        = b `quot` g
+    nc        = n * c
+    mc        = m * c
+    t         = max (ceilDivPos (-nc) b) (ceilDivPos (-mc) a)
+    t_upper   = min (floorDivPos (a_max * g - nc) b)
+                    (floorDivPos (b_max * g - mc) a)
+
+-- | /O(log(min(a, b)))/. Extended Euclidean algorithm. @eGCD a b@
+-- returns @(g, n, m)@ such that @n * a + m * b = g@ and @g >= 0@.
+-- When @a@ and @b@ are both nonzero, @g@ is @gcd a b@.
+--
+-- The Fibonacci bound on the Euclidean iteration count gives
+-- /O(log(min(a, b)))/. For width-@w@ inputs both bounded by @2^w@,
+-- this is /O(log(2^w)) = O(w)/.
+--
+-- Adapted from the Wikibooks reference implementation:
+-- <http://en.wikibooks.org/wiki/Algorithm_Implementation/Mathematics/Extended_Euclidean_algorithm>
+eGCD :: Integer -> Integer -> (Integer, Integer, Integer)
+eGCD a0 b0 =
+  case go a0 b0 of
+    (g, n, m)
+      | g < 0     -> (-g, -n, -m)
+      | otherwise -> (g, n, m)
+  where
+    go a 0 = (a, 1, 0)
+    go a b =
+      case go b (rem a b) of
+        (g, x, y) -> (g, y, x - (a `quot` b) * y)
+
+-- | /O(1)/. @ceilDivPos x y@ is @ceiling(x \/ y)@ as integers. Requires @y > 0@.
+ceilDivPos :: Integer -> Integer -> Integer
+ceilDivPos x y = assert (y > 0) (negate (negate x `div` y))
+{-# INLINE ceilDivPos #-}
+
+-- | /O(1)/. @floorDivPos x y@ is @floor(x \/ y)@ as integers. Requires @y > 0@.
+floorDivPos :: Integer -> Integer -> Integer
+floorDivPos x y = assert (y > 0) (x `div` y)
+{-# INLINE floorDivPos #-}

--- a/what4-domains/test/BVDomTests.hs
+++ b/what4-domains/test/BVDomTests.hs
@@ -36,6 +36,8 @@ import           Data.Parameterized.Some
 import qualified What4.Domains.BV as O
 import qualified What4.Domains.BV.Arith as A
 import qualified What4.Domains.BV.Bitwise as B
+import qualified What4.Domains.BV.StridedInterval as SI
+import qualified What4.Domains.BV.StridedInterval.Internal as SI.I
 import qualified What4.Domains.BV.XOR as X
 import           What4.Domains.Internal (assertionsEnabled)
 import qualified What4.Domains.Arithmetic.Internal as ArithOpt
@@ -54,6 +56,9 @@ main = defaultMain $
     , arithmeticOptimiztionTests
     , arithDomainTests
     , bitwiseDomainTests
+    , stridedIntervalDomainTests
+    , stridedIntervalVsArithTests
+    , stridedIntervalInternalTests
     , xorDomainTests
     , overallDomainTests
     , transferTests
@@ -220,12 +225,24 @@ arithDomainTests = testGroup "Arith Domain"
   , genTest "correct_add" $
       do SW n <- genWidth
          A.correct_add n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_sub" $
+      do SW n <- genWidth
+         A.correct_sub n <$> A.genPair n <*> A.genPair n
   , genTest "correct_neg" $
       do SW n <- genWidth
          A.correct_neg n <$> A.genPair n
   , genTest "correct_not" $
       do SW n <- genWidth
          A.correct_not n <$> A.genPair n
+  , genTest "correct_and" $
+      do SW n <- genWidth
+         A.correct_and n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_or" $
+      do SW n <- genWidth
+         A.correct_or n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_xor" $
+      do SW n <- genWidth
+         A.correct_xor n <$> A.genPair n <*> A.genPair n
   , genTest "correct_mul" $
       do SW n <- genWidth
          A.correct_mul n <$> A.genPair n <*> A.genPair n
@@ -275,6 +292,12 @@ arithDomainTests = testGroup "Arith Domain"
   , genTest "correct_ashr" $
       do SW n <- genWidth
          A.correct_ashr n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_rol" $
+      do SW n <- genWidth
+         A.correct_rol n <$> A.genPair n <*> A.genPair n
+  , genTest "correct_ror" $
+      do SW n <- genWidth
+         A.correct_ror n <$> A.genPair n <*> A.genPair n
   , genTest "correct_eq" $
       do SW n <- genWidth
          A.correct_eq n <$> A.genPair n <*> A.genPair n
@@ -296,6 +319,752 @@ arithDomainTests = testGroup "Arith Domain"
   , genTest "correct_bitbounds" $
       do SW n <- genWidth
          A.correct_bitbounds n <$> A.genPair n
+  , genTest "correct_toBitwise" $
+      do SW n <- genWidth
+         A.correct_toBitwise n <$> A.genPair n
+  , genTest "correct_fromBitwise" $
+      do SW n <- genWidth
+         A.correct_fromBitwise n <$> B.genPair n
+  ]
+
+stridedIntervalDomainTests :: TestTree
+stridedIntervalDomainTests =
+  testGroup "Strided Interval Domain"
+  -- Invariant postconditions: every operation preserves 'proper'.
+  [ genTest "correct_proper_bottom" $
+      do SW n <- genWidth
+         pure (SI.correct_proper_bottom n)
+  , genTest "correct_proper_top" $
+      do SW n <- genWidth
+         pure (SI.correct_proper_top n)
+  , genTest "correct_proper_singleton" $
+      do SW n <- genWidth
+         SI.correct_proper_singleton n <$> genBV n
+  , genTest "correct_proper_mkStridedInterval" $
+      do SW n <- genWidth
+         SI.correct_proper_mkStridedInterval n
+           <$> chooseBool <*> genBV n <*> genBV n <*> genBV n
+  , genTest "correct_proper_range" $
+      do SW n <- genWidth
+         SI.correct_proper_range n <$> genBV n <*> genBV n
+  , genTest "correct_proper_fromAscEltList" $
+      do SW n <- genWidth
+         do k <- chooseInt (0, 8)
+            xs <- traverse (const (genBV n)) [1..k]
+            pure (SI.correct_proper_fromAscEltList n xs)
+  , genTest "correct_proper_join" $
+      do SW n <- genWidth
+         SI.correct_proper_join <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_unionSingleton" $
+      do SW n <- genWidth
+         SI.correct_proper_unionSingleton <$> SI.genDomain n <*> genBV n
+  , genTest "correct_proper_glb" $
+      do SW n <- genWidth
+         SI.correct_proper_glb <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_add" $
+      do SW n <- genWidth
+         SI.correct_proper_add <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_adc" $
+      do SW n <- genWidth
+         carry <- chooseInt (0, 2)
+         let c = case carry of 0 -> Nothing; 1 -> Just False; _ -> Just True
+         SI.correct_proper_adc <$> SI.genDomain n <*> SI.genDomain n <*> pure c
+  , genTest "correct_proper_mul" $
+      do SW n <- genWidth
+         SI.correct_proper_mul <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_sub" $
+      do SW n <- genWidth
+         SI.correct_proper_sub <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_negate" $
+      do SW n <- genWidth
+         SI.correct_proper_negate <$> SI.genDomain n
+  , genTest "correct_proper_scale" $
+      do SW n <- genWidth
+         SI.correct_proper_scale <$> genBV n <*> SI.genDomain n
+  , genTest "correct_proper_not" $
+      do SW n <- genWidth
+         SI.correct_proper_not <$> SI.genDomain n
+  , genTest "correct_proper_and" $
+      do SW n <- genWidth
+         SI.correct_proper_and <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_or" $
+      do SW n <- genWidth
+         SI.correct_proper_or <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_xor" $
+      do SW n <- genWidth
+         SI.correct_proper_xor <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_shl" $
+      do SW n <- genWidth
+         SI.correct_proper_shl n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_lshr" $
+      do SW n <- genWidth
+         SI.correct_proper_lshr n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_ashr" $
+      do SW n <- genWidth
+         SI.correct_proper_ashr n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_rol" $
+      do SW n <- genWidth
+         SI.correct_proper_rol n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_ror" $
+      do SW n <- genWidth
+         SI.correct_proper_ror n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_udiv" $
+      do SW n <- genWidth
+         SI.correct_proper_udiv <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_urem" $
+      do SW n <- genWidth
+         SI.correct_proper_urem <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_sdiv" $
+      do SW n <- genWidth
+         SI.correct_proper_sdiv n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_srem" $
+      do SW n <- genWidth
+         SI.correct_proper_srem n <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "correct_proper_concat" $
+      do SW m <- genWidth
+         SW n <- genWidth
+         SI.correct_proper_concat m <$> SI.genDomain m <*> pure n <*> SI.genDomain n
+  , genTest "correct_proper_select" $
+      do SW n <- genWidth
+         SW i <- genWidth
+         SW z <- genWidth
+         let i_n = addNat i n
+         let w = addNat i_n z
+         LeqProof <- pure $ addIsLeq i_n z
+         SI.correct_proper_select i n <$> SI.genDomain w
+  , genTest "correct_proper_trunc" $
+      do SW n <- genWidth
+         SW m <- genWidth
+         let w = addNat n m
+         LeqProof <- pure $ addIsLeq n m
+         SI.correct_proper_trunc n <$> SI.genDomain w
+  , genTest "correct_proper_zext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- SI.genDomain w
+                pure (SI.correct_proper_zext a u)
+  , genTest "correct_proper_sext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- SI.genDomain w
+                pure (SI.correct_proper_sext w a u)
+
+  -- Predicates.
+  , genTest "correct_toList_member" $
+      do SW n <- genWidth
+         SI.correct_toList_member <$> SI.genDomain n
+  , genTest "correct_member_toList" $
+      do SW n <- genWidth
+         SI.correct_member_toList <$> SI.genDomain n <*> genBV n
+  , genTest "correct_asSingleton" $
+      do SW n <- genWidth
+         SI.correct_asSingleton <$> SI.genDomain n
+  , genTest "correct_domainsOverlap" $
+      do SW n <- genWidth
+         SI.correct_domainsOverlap <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "correct_domainsOverlap_bottom" $
+      do SW n <- genWidth
+         SI.correct_domainsOverlap_bottom <$> SI.genDomain n
+
+  -- Lattice operations.
+  , genTest "correct_join" $
+      do SW n <- genWidth
+         SI.correct_join <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "correct_meet" $
+      do SW n <- genWidth
+         SI.correct_meet <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "correct_leq" $
+      do SW n <- genWidth
+         SI.correct_leq <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "correct_unionSingleton" $
+      do SW n <- genWidth
+         SI.correct_unionSingleton <$> SI.genDomain n <*> genBV n
+  , genTest "correct_glb" $
+      do SW n <- genWidth
+         SI.correct_glb <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "correct_glb_singleton_left" $
+      do SW n <- genWidth
+         SI.correct_glb_singleton_left n <$> genBV n <*> SI.genDomain n
+  , genTest "correct_glb_singleton_right" $
+      do SW n <- genWidth
+         SI.correct_glb_singleton_right n <$> genBV n <*> SI.genDomain n
+
+  -- Lattice laws.
+  , genTest "join_commutative" $
+      do SW n <- genWidth
+         SI.join_commutative <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "join_idempotent" $
+      do SW n <- genWidth
+         SI.join_idempotent <$> SI.genDomain n <*> genBV n
+  , genTest "meet_commutative" $
+      do SW n <- genWidth
+         SI.meet_commutative <$> SI.genDomain n <*> SI.genDomain n <*> genBV n
+  , genTest "meet_idempotent" $
+      do SW n <- genWidth
+         SI.meet_idempotent <$> SI.genDomain n <*> genBV n
+  , genTest "join_top" $
+      do SW n <- genWidth
+         SI.join_top n <$> SI.genDomain n <*> genBV n
+  , genTest "join_bottom" $
+      do SW n <- genWidth
+         SI.join_bottom n <$> SI.genDomain n <*> genBV n
+  , genTest "meet_top" $
+      do SW n <- genWidth
+         SI.meet_top n <$> SI.genDomain n <*> genBV n
+  , genTest "meet_bottom" $
+      do SW n <- genWidth
+         SI.meet_bottom n <$> SI.genDomain n <*> genBV n
+  , genTest "leq_reflexive" $
+      do SW n <- genWidth
+         SI.leq_reflexive <$> SI.genDomain n
+  , genTest "join_upper_bound" $
+      do SW n <- genWidth
+         SI.join_upper_bound <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "join_proper" $
+      do SW n <- genWidth
+         SI.join_proper <$> SI.genDomain n <*> SI.genDomain n
+  , genTest "meet_proper" $
+      do SW n <- genWidth
+         SI.meet_proper <$> SI.genDomain n <*> SI.genDomain n
+
+  -- Width manipulation.
+  , genTest "correct_concat" $
+      do SW m <- genWidth
+         SW n <- genWidth
+         SI.correct_concat m <$> SI.genPair m <*> pure n <*> SI.genPair n
+  , genTest "correct_select" $
+      do SW n <- genWidth
+         SW i <- genWidth
+         SW z <- genWidth
+         let i_n = addNat i n
+         let w = addNat i_n z
+         LeqProof <- pure $ addIsLeq i_n z
+         SI.correct_select i n <$> SI.genPair w
+  , genTest "correct_trunc" $
+      do SW n <- genWidth
+         SW m <- genWidth
+         let w = addNat n m
+         LeqProof <- pure $ addIsLeq n m
+         SI.correct_trunc n <$> SI.genPair w
+  , genTest "correct_zext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- SI.genDomain w
+                x <- SI.genElement a
+                pure (SI.correct_zext a u x)
+  , genTest "correct_sext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof ->
+             do a <- SI.genDomain w
+                x <- SI.genElement a
+                pure (SI.correct_sext w a u x)
+
+  -- Arithmetic.
+  , genTest "correct_add" $
+      do SW n <- genWidth
+         SI.correct_add n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_adc" $
+      do SW n <- genWidth
+         SI.correct_adc n <$> SI.genPair n <*> SI.genPair n <*> chooseBool
+  , genTest "correct_sub" $
+      do SW n <- genWidth
+         SI.correct_sub n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_negate" $
+      do SW n <- genWidth
+         SI.correct_negate n <$> SI.genPair n
+  , genTest "correct_scale" $
+      do SW n <- genWidth
+         SI.correct_scale n <$> genBV n <*> SI.genPair n
+  , genTest "correct_mul" $
+      do SW n <- genWidth
+         SI.correct_mul n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_udiv" $
+      do SW n <- genWidth
+         SI.correct_udiv n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_urem" $
+      do SW n <- genWidth
+         SI.correct_urem n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_sdiv" $
+      do SW n <- genWidth
+         SI.correct_sdiv n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_srem" $
+      do SW n <- genWidth
+         SI.correct_srem n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_not" $
+      do SW n <- genWidth
+         SI.correct_not n <$> SI.genPair n
+  , genTest "correct_and" $
+      do SW n <- genWidth
+         SI.correct_and n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_or" $
+      do SW n <- genWidth
+         SI.correct_or n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_xor" $
+      do SW n <- genWidth
+         SI.correct_xor n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_shl" $
+      do SW n <- genWidth
+         SI.correct_shl n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_lshr" $
+      do SW n <- genWidth
+         SI.correct_lshr n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_ashr" $
+      do SW n <- genWidth
+         SI.correct_ashr n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_rol" $
+      do SW n <- genWidth
+         SI.correct_rol n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_ror" $
+      do SW n <- genWidth
+         SI.correct_ror n <$> SI.genPair n <*> SI.genPair n
+
+  -- Destructors.
+  , genTest "correct_size" $
+      do SW n <- genWidth
+         SI.correct_size <$> SI.genPair n
+  , genTest "correct_ubounds" $
+      do SW n <- genWidth
+         SI.correct_ubounds <$> SI.genDomain n <*> genBV n
+  , genTest "correct_ubounds_bottom" $
+      do SW n <- genWidth
+         pure (SI.correct_ubounds_bottom n)
+  , genTest "correct_sbounds" $
+      do SW n <- genWidth
+         SI.correct_sbounds n <$> SI.genPair n
+  , genTest "correct_bitbounds" $
+      do SW n <- genWidth
+         SI.correct_bitbounds n <$> SI.genPair n
+  , genTest "correct_unknowns" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         x <- SI.genElement a
+         y <- SI.genElement a
+         pure (SI.correct_unknowns n a x y)
+  , genTest "correct_eq" $
+      do SW n <- genWidth
+         SI.correct_eq n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_ult" $
+      do SW n <- genWidth
+         SI.correct_ult n <$> SI.genPair n <*> SI.genPair n
+  , genTest "correct_slt" $
+      do SW n <- genWidth
+         SI.correct_slt n <$> SI.genPair n <*> SI.genPair n
+
+  -- Bottom edge cases.
+  , genTest "correct_glb_bottom_left" $
+      do SW n <- genWidth
+         SI.correct_glb_bottom_left <$> SI.genDomain n
+  , genTest "correct_glb_bottom_right" $
+      do SW n <- genWidth
+         SI.correct_glb_bottom_right <$> SI.genDomain n
+  , genTest "correct_add_bottom_left" $
+      do SW n <- genWidth
+         SI.correct_add_bottom_left n <$> SI.genDomain n
+  , genTest "correct_add_bottom_right" $
+      do SW n <- genWidth
+         SI.correct_add_bottom_right n <$> SI.genDomain n
+  , genTest "correct_mul_bottom_left" $
+      do SW n <- genWidth
+         SI.correct_mul_bottom_left n <$> SI.genDomain n
+  , genTest "correct_mul_bottom_right" $
+      do SW n <- genWidth
+         SI.correct_mul_bottom_right n <$> SI.genDomain n
+
+  -- Algebraic justifications of the size-cap invariant. The size cap
+  -- @(r + 1) * s <= m@ is a sufficient condition for the residues
+  -- @(b + i * s) mod m@ for @0 <= i <= r@ to be pairwise distinct, and
+  -- under that cap the simple `member` formula matches the defining set.
+  , genTest "correct_size_cap_sufficient" $
+      do b <- chooseInteger (-(2 ^ (12 :: Int)), 2 ^ (12 :: Int))
+         r <- chooseInteger (0, 64)
+         s <- chooseInteger (1, 64)
+         w <- chooseInteger (0, 12)
+         pure (sizeCapSufficient b r s w)
+  , genTest "correct_size_cap_simple_member" $
+      do b <- chooseInteger (-(2 ^ (8 :: Int)), 2 ^ (8 :: Int))
+         r <- chooseInteger (0, 64)
+         s <- chooseInteger (1, 64)
+         w <- chooseInteger (1, 8)
+         x <- chooseInteger (-(2 ^ (8 :: Int)), 2 ^ (8 :: Int))
+         pure (sizeCapSimpleMember b r s w x)
+  ]
+  where
+    sizeCapSufficient bRaw rRaw sRaw wRaw =
+      property $
+        let r = abs rRaw
+            s = max 1 (abs sRaw)
+            w_bits = abs wRaw `mod` 12
+            m = 2 ^ w_bits
+            b = bRaw `mod` max 1 m
+            residues = [ (b + i * s) `mod` m | i <- [0 .. r] ]
+        in (r + 1) * s > m
+           || length residues == length (uniq residues)
+      where
+        uniq []     = []
+        uniq (x:xs) = x : uniq [ y | y <- xs, y /= x ]
+    sizeCapSimpleMember bRaw rRaw sRaw wRaw xRaw =
+      property $
+        let r = abs rRaw
+            s = max 1 (abs sRaw)
+            w_bits = max 1 (abs wRaw `mod` 8)
+            m = 2 ^ w_bits
+            b = bRaw `mod` m
+            x = xRaw `mod` m
+            d = (x - b) `mod` m
+            viaFormula = d `mod` s == 0 && d `div` s <= r
+            viaSet     = elem x [ (b + i * s) `mod` m | i <- [0 .. r] ]
+        in (r + 1) * s > m || viaFormula == viaSet
+
+-- | Differential tests against 'A.Domain'. Inputs are sampled across
+-- /any-stride/ SIs ('SI.genDomain') so the general algorithms are
+-- actually exercised; 'SI.toArith' coarsens an SI to its contiguous
+-- unsigned cover, which is the natural common ground with 'A.Domain'.
+--
+-- Two flavors of comparison appear below:
+--
+--   * /Precision/: every concrete value @x@ accepted by 'SI.op' is
+--     also accepted by 'A.op' on the cover inputs. Pins down "SI is at
+--     least as precise as A on this op" while allowing strict
+--     refinement. Tested pointwise (via 'SI.member' ⇒ 'A.member')
+--     because 'SI.toArith' is lossy on stride > 1 outputs (it picks a
+--     contiguous cover that can be a strictly looser shape than what
+--     'A.op' produces, even though SI's actual set is tighter).
+--   * /Equality/: SI's result equals 'SI.fromArith' of Arith's result.
+--     Used for ops where SI's algorithm is just a re-routing through
+--     'A.op' on the cover (no refinement possible).
+--
+-- Ops that may produce a strided refinement go in the precision group;
+-- ops that route through 'A.op' verbatim go in the equality group.
+-- Soundness ('A.member x ⇒ SI.member x' under concrete operations) is
+-- not tested here; that's covered by 'correct_*' in
+-- 'stridedIntervalDomainTests'.
+stridedIntervalVsArithTests :: TestTree
+stridedIntervalVsArithTests =
+  testGroup "Strided Interval vs. Arith"
+  -- Round-trip: stride-1 SI ↔ Arith preserves membership.
+  [ genTest "arith->si->arith" $
+      do SW n <- genWidth
+         a <- A.genDomain n
+         x <- genBV n
+         pure $ property
+           (A.member a x == A.member (SI.toArith (SI.fromArith (maxUnsigned n) a)) x)
+
+  -- Bounds (definitionally cover bounds — exact equality).
+  , genTest "ubounds" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         pure $ nonBottom1 a $ SI.ubounds a == A.ubounds (SI.toArith a)
+  , genTest "sbounds" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         pure $ nonBottom1 a $ SI.sbounds n a == A.sbounds n (SI.toArith a)
+
+  -- Precision: every member of SI's result is a member of A's result
+  -- on the cover (pointwise SI.member ⇒ A.member).
+  , genTest "add" $ precisionBin SI.add A.add
+  , genTest "sub" $ precisionBin SI.sub (\x y -> A.add x (A.negate y))
+  , genTest "mul" $ precisionBin SI.mul A.mul
+  , genTest "scale" $
+      do SW n <- genWidth
+         k <- genBV n
+         a <- SI.genDomain n
+         x <- genBV n
+         pure $ Prelude.not (SI.isBottom a) ==>
+           SI.member (SI.scale k a) x ==>
+             A.member (A.scale (toSigned n k) (SI.toArith a)) x
+  , genTest "negate" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         x <- genBV n
+         pure $ Prelude.not (SI.isBottom a) ==>
+           SI.member (SI.negate a) x ==> A.member (A.negate (SI.toArith a)) x
+  , genTest "not" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         x <- genBV n
+         pure $ Prelude.not (SI.isBottom a) ==>
+           SI.member (SI.not a) x ==> A.member (A.not (SI.toArith a)) x
+  , genTest "shl" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         x <- genBV n
+         pure $ Prelude.not (SI.isBottom a || SI.isBottom b) ==>
+           SI.member (SI.shl n a b) x ==>
+             A.member (A.shl n (SI.toArith a) (SI.toArith b)) x
+
+  -- Equality: SI re-routes through A.op on the cover, so equality
+  -- after fromArith must hold. Bottom inputs are excluded — SI
+  -- propagates them explicitly while Arith doesn't, and we already
+  -- test bottom propagation in 'correct_*_bottom_*' soundness tests.
+  , genTest "lshr" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         x <- genBV n
+         -- SI.lshr can preserve stride when the shift is a singleton
+         -- and the operand's stride is divisible by 2^k; precision
+         -- check rather than equality.
+         pure $ Prelude.not (SI.isBottom a || SI.isBottom b) ==>
+           SI.member (SI.lshr n a b) x ==>
+             A.member (A.lshr n (SI.toArith a) (SI.toArith b)) x
+  , genTest "ashr" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ nonBottom2 a b $
+           SI.ashr n a b == SI.fromArith (maxUnsigned n) (A.ashr n (SI.toArith a) (SI.toArith b))
+  , genTest "udiv" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ nonBottom2 a b $
+           SI.udiv a b == SI.fromArith (maxUnsigned n) (A.udiv (SI.toArith a) (SI.toArith b))
+  , genTest "urem" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ nonBottom2 a b $
+           SI.urem a b == SI.fromArith (maxUnsigned n) (A.urem (SI.toArith a) (SI.toArith b))
+  , genTest "sdiv" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ nonBottom2 a b $
+           SI.sdiv n a b == SI.fromArith (maxUnsigned n) (A.sdiv n (SI.toArith a) (SI.toArith b))
+  , genTest "srem" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ nonBottom2 a b $
+           SI.srem n a b == SI.fromArith (maxUnsigned n) (A.srem n (SI.toArith a) (SI.toArith b))
+  , genTest "meet" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         x <- genBV n
+         -- 'meet' produces a sound /over/-approximation. SI's meet
+         -- can refine to a stride > 1 shape (e.g. when both inputs
+         -- have the same strided shape), so only the precision
+         -- direction is checked: every member of SI's meet is a
+         -- member of A's meet on the covers.
+         pure $ Prelude.not (SI.isBottom a || SI.isBottom b) ==>
+           SI.member (SI.meet a b) x ==>
+             A.member (A.meet (SI.toArith a) (SI.toArith b)) x
+  , genTest "sext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof -> do
+             (a, _) <- SI.genPair w
+             y <- SI.genElement (SI.sext w a u)
+             -- SI.sext preserves stride (e.g. {0, 4} sign-extended to
+             -- a wider width stays {0, 4} stride-4); the contiguous
+             -- Arith cover is strictly looser, so we test that every
+             -- member of SI's sext result lies in Arith's sext result.
+             pure $ Prelude.not (SI.isBottom a) ==>
+               A.member (A.sext w (SI.toArith a) u) y
+  , genTest "concat" $
+      do SW m <- genWidth
+         SW n <- genWidth
+         a <- SI.genDomain m
+         b <- SI.genDomain n
+         x <- chooseInteger (0, maxUnsigned (addNat m n))
+         -- SI.concat preserves stride when one operand is a singleton,
+         -- which gives a strictly more precise result than the cover.
+         pure $ Prelude.not (SI.isBottom a || SI.isBottom b) ==>
+           SI.member (SI.concat m a n b) x ==>
+             A.member (A.concat m (SI.toArith a) n (SI.toArith b)) x
+  , genTest "select" $
+      do SW n <- genWidth
+         SW i <- genWidth
+         SW z <- genWidth
+         let i_n = addNat i n
+         let w = addNat i_n z
+         LeqProof <- pure $ addIsLeq i_n z
+         a <- SI.genDomain w
+         pure $ nonBottom1 a $
+           SI.select i n a == SI.fromArith (maxUnsigned n) (A.select i n (SI.toArith a))
+  , genTest "zext" $
+      do SW w <- genWidth
+         SW n <- genWidth
+         let u = addNat w n
+         case testLeq (addNat w (knownNat @1)) u of
+           Nothing -> error "impossible!"
+           Just LeqProof -> do
+             a <- SI.genDomain w
+             y <- SI.genElement (SI.zext a u)
+             -- SI.zext preserves stride (e.g. {0, 2} zero-extended to
+             -- a wider width stays {0, 2} stride-2); precision check.
+             pure $ Prelude.not (SI.isBottom a) ==>
+               A.member (A.zext (SI.toArith a) u) y
+  , genTest "range" $
+      do SW n <- genWidth
+         lo <- genBV n
+         hi <- genBV n
+         pure $ property (SI.range n lo hi == SI.fromArith (maxUnsigned n) (A.range n lo hi))
+  , genTest "fromAscEltList" $
+      do SW n <- genWidth
+         lo <- chooseInteger (0, maxUnsigned n)
+         let maxK = max 0 (maxUnsigned n - lo)
+         k  <- chooseInteger (0, min maxK (intValue n))
+         let xs = [ lo + i | i <- [0 .. k] ]
+         pure $ property
+           (SI.fromAscEltList n xs == SI.fromArith (maxUnsigned n) (A.fromAscEltList n xs))
+
+  -- Predicate agreement on stride-1 inputs (where SI and A have
+  -- identical information). Uses 'SI.genDomain' (size-bounded) and
+  -- filters to stride 1 — 'A.genDomain' picks @siRange@ up to the full
+  -- @2^w - 1@, which makes 'leq's enumeration blow up at large widths.
+  , genTest "leq" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ (SI.stride a == 1 && SI.stride b == 1) ==>
+                  (SI.leq a b == A.leq (SI.toArith a) (SI.toArith b))
+  , genTest "domainsOverlap" $
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         pure $ (SI.stride a == 1 && SI.stride b == 1) ==>
+                  (SI.domainsOverlap a b == A.domainsOverlap (SI.toArith a) (SI.toArith b))
+  ]
+  where
+    precisionBin
+      :: (forall w. (1 <= w) => SI.StridedInterval w -> SI.StridedInterval w -> SI.StridedInterval w)
+      -> (forall w. (1 <= w) => A.Domain w -> A.Domain w -> A.Domain w)
+      -> Gen Property
+    precisionBin siOp aOp =
+      do SW n <- genWidth
+         a <- SI.genDomain n
+         b <- SI.genDomain n
+         x <- genBV n
+         pure $ Prelude.not (SI.isBottom a || SI.isBottom b) ==>
+           SI.member (siOp a b) x ==>
+             A.member (aOp (SI.toArith a) (SI.toArith b)) x
+
+    nonBottom1 :: SI.StridedInterval w -> Bool -> Property
+    nonBottom1 a = (Prelude.not (SI.isBottom a) ==>)
+
+    nonBottom2 :: SI.StridedInterval w -> SI.StridedInterval w' -> Bool -> Property
+    nonBottom2 a b = (Prelude.not (SI.isBottom a || SI.isBottom b) ==>)
+
+
+-- | Direct property tests for the internal helpers underlying
+-- 'SI.glb'\'s Diophantine path. These pin down the algebraic spec of
+-- 'eGCD', 'ceilDivPos'/'floorDivPos', and 'solveLinearDiophantine'
+-- itself, which 'correct_glb' cannot exercise directly because it only
+-- checks the @member x (glb a b) ⇒ member x a && member x b@ direction.
+stridedIntervalInternalTests :: TestTree
+stridedIntervalInternalTests =
+  testGroup "Strided Interval Internal"
+  [ testGroup "eGCD"
+    [ genTest "Bezout identity" $
+        do a <- chooseInteger (-256, 256)
+           b <- chooseInteger (-256, 256)
+           let (g, n, m) = SI.I.eGCD a b
+           pure (property (n * a + m * b == g))
+    , genTest "g is nonnegative" $
+        do a <- chooseInteger (-256, 256)
+           b <- chooseInteger (-256, 256)
+           let (g, _, _) = SI.I.eGCD a b
+           pure (property (g >= 0))
+    , genTest "g divides both inputs" $
+        do a <- chooseInteger (-256, 256)
+           b <- chooseInteger (-256, 256)
+           let (g, _, _) = SI.I.eGCD a b
+           pure $ property $
+             if g == 0
+               then a == 0 && b == 0
+               else a `mod` g == 0 && b `mod` g == 0
+    , genTest "matches Prelude.gcd" $
+        do a <- chooseInteger (-256, 256)
+           b <- chooseInteger (-256, 256)
+           let (g, _, _) = SI.I.eGCD a b
+           pure (property (g == gcd a b))
+    ]
+  , testGroup "ceilDivPos / floorDivPos"
+    [ genTest "ceilDivPos bounds" $
+        do x <- chooseInteger (-1024, 1024)
+           y <- chooseInteger (1, 2 ^ (32 :: Int))
+           let q = SI.I.ceilDivPos x y
+           -- q is the least integer with q * y >= x
+           pure (property (q * y >= x && (q - 1) * y < x))
+    , genTest "floorDivPos bounds" $
+        do x <- chooseInteger (-1024, 1024)
+           y <- chooseInteger (1, 2 ^ (32 :: Int))
+           let q = SI.I.floorDivPos x y
+           -- q is the greatest integer with q * y <= x
+           pure (property (q * y <= x && (q + 1) * y > x))
+    ]
+  , testGroup "solveLinearDiophantine"
+    -- Soundness: construct the input from a known solution, so the
+    -- solver must succeed; check the returned (x, y) satisfies the
+    -- equation and stays within bounds.
+    [ genTest "sound" $
+        do a    <- chooseInteger (1, 2 ^ (32 :: Int))
+           b    <- chooseInteger (1, 2 ^ (32 :: Int))
+           aMax <- chooseInteger (1, 2 ^ (32 :: Int))
+           bMax <- chooseInteger (1, 2 ^ (32 :: Int))
+           x0   <- chooseInteger (0, aMax)
+           y0   <- chooseInteger (0, bMax)
+           let c = a * x0 - b * y0
+           pure $ (c /= 0) ==>
+             case SI.I.solveLinearDiophantine a b c aMax bMax of
+               Nothing     -> property False
+               Just (x, y) ->
+                 property (0 <= x && x <= aMax
+                        && 0 <= y && y <= bMax
+                        && a * x - b * y == c)
+    -- Completeness on small inputs: brute-force over [0..aMax]×[0..bMax]
+    -- to see if a solution exists, then check that the solver's verdict
+    -- agrees.
+    , genTest "complete (brute-force)" $
+        do a    <- chooseInteger (1, 64)
+           b    <- chooseInteger (1, 64)
+           aMax <- chooseInteger (1, 64)
+           bMax <- chooseInteger (1, 64)
+           cAbs <- chooseInteger (1, 64)
+           sign <- chooseBool
+           let c = if sign then cAbs else -cAbs
+               exists = or [ a * x - b * y == c
+                           | x <- [0 .. aMax], y <- [0 .. bMax]
+                           ]
+           pure $ property $
+             case (exists, SI.I.solveLinearDiophantine a b c aMax bMax) of
+               (True,  Just _ ) -> True
+               (False, Nothing) -> True
+               _                -> False
+    -- Specific shape that must succeed: a*k - 1*0 = a*k.
+    , genTest "finds endpoint intersection" $
+        do a <- chooseInteger (1, 2 ^ (32 :: Int))
+           k <- chooseInteger (1, 2 ^ (32 :: Int))
+           let aMax = k
+               bMax = 1
+               c    = a * k
+           pure $ property $
+             case SI.I.solveLinearDiophantine a 1 c aMax bMax of
+               Just _  -> True
+               Nothing -> False
+    ]
   ]
 
 xorDomainTests :: TestTree

--- a/what4-domains/what4-domains.cabal
+++ b/what4-domains/what4-domains.cabal
@@ -17,6 +17,7 @@ Extra-doc-files:
   doc/bvdomain.cry
   doc/arithdomain.cry
   doc/bitsdomain.cry
+  doc/stridedinterval.cry
   doc/xordomain.cry
   doc/README.md
 
@@ -166,6 +167,8 @@ library
     What4.Domains.BV
     What4.Domains.BV.Arith
     What4.Domains.BV.Bitwise
+    What4.Domains.BV.StridedInterval
+    What4.Domains.BV.StridedInterval.Internal
     What4.Domains.BV.XOR
     What4.Domains.Internal
     What4.Domains.Verification


### PR DESCRIPTION
Fixes #374. Based on the implementation in Macaw, but with a few more operations.

Major differences from Macaw's strided interval:

- Handles wrapping
- Stores a mask, not a width

Needs:

- [ ] Table comparing operations to those in Macaw
- [ ] Bitwise operations via bitwise domain