### PR TITLE
Fix `floatToInteger`'s behavior when using `RNA`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -17,6 +17,8 @@
   Bitwuzla involving the `floatToReal` operation (which Bitwuzla does not
   support) instead of throwing a parse exception.
 * Replace `lens` with `microlens-{,-mtl,-th}`.
+* Fix a bug where `what4` could produce incorrect models involving the
+  `floatToBV` operation when using the `RNA` rounding mode.
 
 # 1.7.3 -- 2026-01-26
 

--- a/what4/src/What4/Utils/FloatHelpers.hs
+++ b/what4/src/What4/Utils/FloatHelpers.hs
@@ -14,6 +14,7 @@ import LibBF
 
 import What4.BaseTypes
 import What4.Panic (panic)
+import What4.Utils.Arithmetic (roundAway)
 
 -- | Rounding modes for IEEE-754 floating point operations.
 data RoundingMode
@@ -95,7 +96,7 @@ floatToInteger r fp =
   do rat <- floatToRational fp
      pure case r of
             RNE -> round rat
-            RNA -> if rat > 0 then ceiling rat else floor rat
+            RNA -> roundAway rat
             RTP -> ceiling rat
             RTN -> floor rat
             RTZ -> truncate rat

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -1161,6 +1161,48 @@ issue329Test sym solver = do
 
       _ -> fail "expected satisfible model"
 
+-- | A regression test for #377.
+issue377Test ::
+  OnlineSolver solver =>
+  SimpleExprBuilder t fs ->
+  SolverProcess t solver ->
+  IO ()
+issue377Test sym solver = do
+    -- Construct the following proposition (written in pseudo-Cryptol):
+    --
+    --   \(f : Float32) (bv3 : [32]) -> lit == f /\ bv2 == bv3
+    --     where
+    --       lit : Float32
+    --       lit = 0.25
+    --
+    --       bv1, bv2 : [32]
+    --       bv1 = fpFromBV rna lit
+    --       bv2 = fpFromBV rna f
+    let w :: NatRepr 32
+        w = knownNat
+    let fpp :: FloatPrecisionRepr Prec32
+        fpp = knownRepr
+    lit <- floatLit sym fpp (bfFromDouble 0.25)
+    f <- freshConstant sym (safeSymbol "f") (BaseFloatRepr fpp)
+    p1 <- floatEq sym lit f
+    bv1 <- floatToBV sym w RNA lit
+    bv2 <- floatToBV sym w RNA f
+    bv3 <- freshConstant sym (safeSymbol "bv") (BaseBVRepr w)
+    p2 <- bvEq sym bv2 bv3
+    p <- andPred sym p1 p2
+
+    -- Check that the proposition is satisfiaible and that the model that what4
+    -- computes evaluates all of the `bv*` values to `0`.
+    checkSatisfiableWithModel solver "test" p $ \case
+      Sat fn ->
+        do bv1Eval <- groundEval fn bv1
+           bv2Eval <- groundEval fn bv2
+           bv3Eval <- groundEval fn bv3
+           let expected = BV.mkBV w 0
+           (all (== expected) [bv1Eval, bv2Eval, bv3Eval]) @? "result other than 0"
+
+      _ -> fail "expected satisfible model"
+
 -- | These tests simply ensure that no exceptions are raised.
 testSolverInfo :: TestTree
 testSolverInfo = testGroup "solver info queries" $
@@ -1325,6 +1367,7 @@ main = do
         , testCase "Z3 #182 test case" $ withOnlineZ3 issue182Test
         , testCase "Z3 #315 test case" $ withOnlineZ3 issue315Test
         , testCase "Z3 #329 test case" $ withOnlineZ3 issue329Test
+        , testCase "Z3 #377 test case" $ withOnlineZ3 issue377Test
 
         , arrayCopyTest
         , arraySetTest
@@ -1377,6 +1420,7 @@ main = do
         , cvcTestCase "#182 test case" $ withCVC issue182Test
         , cvcTestCase "#315 test case" $ withCVC issue315Test
         , cvcTestCase "#329 test case" $ withCVC issue329Test
+        , cvcTestCase "#377 test case" $ withCVC issue377Test
         ]
   let cvc4Tests = cvcTests CVC4
   let cvc5Tests = cvcTests CVC5


### PR DESCRIPTION
This ports the fix from https://github.com/GaloisInc/cryptol/pull/2047 over to `what4`.

Fixes #377.