### PR TITLE
feat(domains): Add tnum-style arithmetic operations to bitwise domain

### DIFF
--- a/what4-domains/doc/bitsdomain.cry
+++ b/what4-domains/doc/bitsdomain.cry
@@ -105,6 +105,104 @@ ror : {n} (fin n) => Dom n -> [n] -> Dom n
 ror a x = { lomask = a.lomask >>> x, himask = a.himask >>> x }
 
 ////////////////////////////////////////////////////////////
+// Bounds and comparisons
+
+// Unsigned bounds: the bit-pattern lo and hi are also the unsigned min/max.
+ubounds : {n} (fin n) => Dom n -> ([n], [n])
+ubounds a = (a.lomask, a.himask)
+
+// Signed bounds: if the sign bit is known (lomask and himask agree on
+// it), the bit-pattern bounds are also the signed bounds. If the sign
+// bit is unknown, the most-negative value sets the sign bit and clears
+// all other unknowns; the most-positive clears the sign bit and sets
+// all other unknowns.
+sbounds : {n} (fin n, n >= 1) => Dom n -> ([n], [n])
+sbounds a =
+  if (a.lomask && signbit) == (a.himask && signbit)
+    then (a.lomask, a.himask)
+    else (a.lomask || signbit, a.himask && (~ signbit))
+  where
+  signbit = 1 << (`n - 1 : [n]) : [n]
+
+ult : {n} (fin n) => Dom n -> Dom n -> Bit
+ult a b = (ubounds a).1 < (ubounds b).0
+
+slt : {n} (fin n, n >= 1) => Dom n -> Dom n -> Bit
+slt a b = (sbounds a).1 <$ (sbounds b).0
+
+////////////////////////////////////////////////////////////
+// Arithmetic operations (tristate-number algorithms)
+//
+// These follow the algorithms used by the Linux kernel BPF verifier
+// for "tnum" (tristate-number) propagation.
+
+// Internal: tristate-number add. Given (av, am) and (bv, bm) where
+// "value" is the known-1 bits and "mask" is the unknown bits, compute
+// the tnum representing the sum.
+addTnum : {n} (fin n) => [n] -> [n] -> [n] -> [n] -> ([n], [n])
+addTnum av am bv bm = (resv, resm)
+  where
+  sm    = am + bm
+  sv    = av + bv
+  sigma = sm + sv
+  chi   = sigma ^ sv
+  resm  = chi || am || bm
+  resv  = sv && (~ resm)
+
+// Convert a (value, mask) pair into a Dom.
+fromTnum : {n} (fin n) => [n] -> [n] -> Dom n
+fromTnum v m = { lomask = v, himask = v || m }
+
+// Convert a Dom to a (value, mask) pair.
+toTnum : {n} (fin n) => Dom n -> ([n], [n])
+toTnum a = (a.lomask, a.lomask ^ a.himask)
+
+add : {n} (fin n) => Dom n -> Dom n -> Dom n
+add a b = fromTnum resv resm
+  where
+  (av, am) = toTnum a
+  (bv, bm) = toTnum b
+  (resv, resm) = addTnum av am bv bm
+
+bneg : {n} (fin n, n >= 1) => Dom n -> Dom n
+bneg a = add (bnot a) (singleton 1)
+
+sub : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+sub a b = add a (bneg b)
+
+scale : {n} (fin n, n >= 1) => [n] -> Dom n -> Dom n
+scale k a = mul (singleton k) a
+
+// Multiply via shift-and-add over the bits of a.
+//
+// At bit position i, when av_i = 1 we add bm shifted to position i
+// (the bv contribution is already accounted for by the initial
+// av*bv product). When am_i = 1 (unknown bit), we add (bv|bm) shifted
+// to position i, since b might or might not contribute.
+mul : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+mul a b = fromTnum resv resm
+  where
+  (av, am) = toTnum a
+  (bv, bm) = toTnum b
+  // Initial value-by-value product
+  init = (av * bv, 0 : [n])
+  // Shift contributions for each bit position i in [0..n-1]
+  contribs = [ if av @ (`n - 1 - i)
+                 then (0, bm << i)
+                 else if am @ (`n - 1 - i)
+                        then (0, (bv || bm) << i)
+                        else (0, 0)
+             | i <- [0 .. n-1] ]
+  // Sum them all using addTnum
+  (resv, resm) = foldl step init contribs
+  step (v, m) (cv, cm) = addTnum v m cv cm
+
+foldl : {a, b, n} (fin n) => (a -> b -> a) -> a -> [n]b -> a
+foldl f z xs = (zs : [_]a) ! 0
+  where
+  zs = [z] # [ f y x | y <- zs | x <- xs ]
+
+////////////////////////////////////////////////////////////
 // Soundness properties
 
 correct_top : {n} (fin n) => [n] -> Bit
@@ -189,6 +287,46 @@ correct_ror : {n} (fin n) => Dom n -> [n] -> [n] -> Bit
 correct_ror a x y =
   mem a x ==> mem (ror a y) (x >>> y)
 
+correct_ubounds : {n} (fin n) => Dom n -> [n] -> Bit
+correct_ubounds a x =
+  mem a x ==> lo <= x /\ x <= hi
+  where
+  (lo, hi) = ubounds a
+
+correct_sbounds : {n} (fin n, n >= 1) => Dom n -> [n] -> Bit
+correct_sbounds a x =
+  mem a x ==> lo <=$ x /\ x <=$ hi
+  where
+  (lo, hi) = sbounds a
+
+correct_add : {n} (fin n) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_add a b x y =
+  mem a x ==> mem b y ==> mem (add a b) (x + y)
+
+correct_sub : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_sub a b x y =
+  mem a x ==> mem b y ==> mem (sub a b) (x - y)
+
+correct_neg : {n} (fin n, n >= 1) => Dom n -> [n] -> Bit
+correct_neg a x =
+  mem a x ==> mem (bneg a) (- x)
+
+correct_scale : {n} (fin n, n >= 1) => [n] -> Dom n -> [n] -> Bit
+correct_scale k a x =
+  mem a x ==> mem (scale k a) (k * x)
+
+correct_mul : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_mul a b x y =
+  mem a x ==> mem b y ==> mem (mul a b) (x * y)
+
+correct_ult : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_ult a b x y =
+  ult a b ==> mem a x ==> mem b y ==> x < y
+
+correct_slt : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_slt a b x y =
+  slt a b ==> mem a x ==> mem b y ==> x <$ y
+
 property b1 = correct_top`{16}
 property b2 = correct_singleton`{16}
 property b3 = correct_overlap`{16}
@@ -212,6 +350,16 @@ property s2 = correct_lshr`{16}
 property s3 = correct_ashr`{16}
 property s4 = correct_rol`{16}
 property s5 = correct_ror`{16}
+
+property a1 = correct_ubounds`{8}
+property a2 = correct_sbounds`{8}
+property a3 = correct_add`{8}
+property a4 = correct_sub`{8}
+property a5 = correct_neg`{8}
+property a6 = correct_mul`{8}
+property a7 = correct_scale`{8}
+property a8 = correct_ult`{8}
+property a9 = correct_slt`{8}
 
 
 ////////////////////////////////////////////////////////////

--- a/what4-domains/src/What4/Domains/BV/Bitwise.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise.hs
@@ -24,8 +24,12 @@ module What4.Domains.BV.Bitwise
   , asSingleton
   , nonempty
   , eq
+  , slt
+  , ult
   , domainsOverlap
   , bitbounds
+  , ubounds
+  , sbounds
   -- * Operations
   , any
   , singleton
@@ -44,6 +48,12 @@ module What4.Domains.BV.Bitwise
   , ashr
   , rol
   , ror
+  -- ** arithmetic
+  , add
+  , sub
+  , negate
+  , scale
+  , mul
   -- ** bitwise logical
   , and
   , or
@@ -71,6 +81,15 @@ module What4.Domains.BV.Bitwise
   , correct_rol
   , correct_ror
   , correct_eq
+  , correct_ult
+  , correct_slt
+  , correct_ubounds
+  , correct_sbounds
+  , correct_add
+  , correct_sub
+  , correct_neg
+  , correct_scale
+  , correct_mul
   , correct_and
   , correct_or
   , correct_not
@@ -83,6 +102,8 @@ import qualified Data.Bits as Bits
 import           Data.Parameterized.NatRepr
 import           Numeric.Natural
 import           GHC.TypeNats
+import           What4.Domains.BV.Bitwise.Tnum (Tnum)
+import qualified What4.Domains.BV.Bitwise.Tnum as Tnum
 import           What4.Domains.Verification (Property, property, (==>), Gen, chooseInteger)
 
 import qualified Prelude
@@ -338,6 +359,90 @@ xor (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) = BVBitInterval mask 
 
 
 ---------------------------------------------------------------------------------------
+-- Bounds and comparisons
+
+-- | Unsigned bounds for the domain. The low bit-pattern bound is also the
+--   unsigned minimum, and the high bit-pattern bound is also the unsigned
+--   maximum: setting unknown bits to 0 minimizes, setting them to 1 maximizes.
+ubounds :: Domain w -> (Integer, Integer)
+ubounds = bitbounds
+
+-- | Signed bounds for the domain.
+sbounds :: (1 <= w) => NatRepr w -> Domain w -> (Integer, Integer)
+sbounds w (BVBitInterval _ lo hi) = (toSigned w lo', toSigned w hi')
+  where
+  signbit = bit (widthVal w - 1)
+  -- If the sign bit is known (lo and hi agree on it), the bit-pattern
+  -- bounds are also the signed bounds. If the sign bit is unknown, the
+  -- most-negative value sets the sign bit and clears all other unknowns,
+  -- and the most-positive clears the sign bit and sets all other unknowns.
+  (lo', hi')
+    | (lo .&. signbit) == (hi .&. signbit) = (lo, hi)
+    | otherwise = (lo .|. signbit, hi .&. complement signbit)
+
+-- | Check if all elements in one domain are unsigned-less-than all
+--   elements in the other.
+ult :: Domain w -> Domain w -> Maybe Bool
+ult a b
+  | ah < bl  = Just True
+  | al >= bh = Just False
+  | otherwise = Nothing
+  where
+  (al, ah) = ubounds a
+  (bl, bh) = ubounds b
+
+-- | Check if all elements in one domain are signed-less-than all
+--   elements in the other.
+slt :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Maybe Bool
+slt w a b
+  | ah < bl  = Just True
+  | al >= bh = Just False
+  | otherwise = Nothing
+  where
+  (al, ah) = sbounds w a
+  (bl, bh) = sbounds w b
+
+---------------------------------------------------------------------------------------
+-- Arithmetic
+
+-- | Convert a domain into its tristate-number form.
+toTnum :: Domain w -> Tnum
+toTnum (BVBitInterval _ lo hi) = Tnum.mk lo (lo `Bits.xor` hi)
+
+-- | Convert a tristate-number back into a domain at the given @bvmask@.
+fromTnum :: Integer -> Tnum -> Domain w
+fromTnum mask t = BVBitInterval mask v (v .|. Tnum.tnumMask t)
+  where v = Tnum.tnumValue t
+
+-- | Internal helper: build a singleton domain when only the mask is known.
+mkSingleton :: Integer -> Integer -> Domain w
+mkSingleton mask x = BVBitInterval mask x' x'
+  where x' = x .&. mask
+
+-- | Add two bitwise domains.
+add :: Domain w -> Domain w -> Domain w
+add a@(BVBitInterval mask _ _) b = fromTnum mask (Tnum.add mask (toTnum a) (toTnum b))
+
+-- | Two's complement negation: @negate a = not a + 1@.
+negate :: Domain w -> Domain w
+negate a = add (not a) (mkSingleton (bvdMask a) 1)
+
+-- | Subtract: @sub a b = add a (negate b)@.
+sub :: Domain w -> Domain w -> Domain w
+sub a b = add a (negate b)
+
+-- | Multiply by a constant.
+scale :: Integer -> Domain w -> Domain w
+scale k a = mul (mkSingleton (bvdMask a) k) a
+
+-- | Multiply two bitwise domains, using the shift-and-add tristate-number
+--   algorithm (BPF @tnum_mul@).
+mul :: Domain w -> Domain w -> Domain w
+mul a@(BVBitInterval mask _ _) b =
+  fromTnum mask (Tnum.mul mask (toTnum a) (toTnum b))
+
+
+---------------------------------------------------------------------------------------
 -- Correctness properties
 
 -- | Check that a domain is proper, and that
@@ -447,3 +552,49 @@ correct_testBit n (a,x) i =
       Just True  -> Bits.testBit x (fromIntegral i)
       Just False -> Prelude.not (Bits.testBit x (fromIntegral i))
       Nothing    -> True
+
+correct_ubounds :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_ubounds n (a,x) = member a x' ==> lo <= x' && x' <= hi
+  where
+  x' = toUnsigned n x
+  (lo, hi) = ubounds a
+
+correct_sbounds :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_sbounds n (a,x) = member a x' ==> lo <= x' && x' <= hi
+  where
+  x' = toSigned n x
+  (lo, hi) = sbounds n a
+
+correct_ult :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_ult n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case ult a b of
+      Just True  -> toUnsigned n x < toUnsigned n y
+      Just False -> toUnsigned n x >= toUnsigned n y
+      Nothing    -> True
+
+correct_slt :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_slt n (a,x) (b,y) =
+  member a x ==> member b y ==>
+    case slt n a b of
+      Just True  -> toSigned n x < toSigned n y
+      Just False -> toSigned n x >= toSigned n y
+      Nothing    -> True
+
+correct_add :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_add n (a,x) (b,y) = member a x ==> member b y ==> pmember n (add a b) (x + y)
+
+correct_sub :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_sub n (a,x) (b,y) = member a x ==> member b y ==> pmember n (sub a b) (x - y)
+
+correct_neg :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> Property
+correct_neg n (a,x) = member a x ==> pmember n (negate a) (Prelude.negate x)
+
+correct_scale :: (1 <= n) => NatRepr n -> Integer -> (Domain n, Integer) -> Property
+correct_scale n k (a,x) = member a x ==> pmember n (scale k' a) (k' * x)
+  where
+  k' = toSigned n k
+
+correct_mul :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_mul n (a,x) (b,y) = member a x ==> member b y ==> pmember n (mul a b) (x * y)
+

--- a/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
@@ -1,0 +1,93 @@
+{-|
+Module      : What4.Domains.BV.Bitwise.Tnum
+Copyright   : (c) Galois Inc, 2026
+License     : BSD3
+Maintainer  : langston@galois.com
+
+Tristate-numbers as used in the eBPF verifier.
+
+Used by the bitwise abstract domain to implement arithmetic operations.
+
+A tristate number ('Tnum') is a pair of bitvectors @(v, m)@ where @v@ records
+the bits known to be 1 and @m@ records the bits whose value is unknown. The two
+are required to be disjoint. The set of concrete bitvectors represented by @(v,
+m)@ is @{ v .|. (x .&. m) | x <- all bitvectors }@ — equivalently, the bitwise
+abstract-domain element with bit-pattern bounds @(v, v .|. m)@.
+
+This module is for internal use by 'What4.Domains.BV.Bitwise' only and is not
+part of the public API.
+
+See "Sound, Precise, and Fast Abstract Interpretation with Tristate Numbers"
+https://arxiv.org/abs/2105.05398.
+-}
+
+{-# LANGUAGE BangPatterns #-}
+
+module What4.Domains.BV.Bitwise.Tnum
+  ( Tnum
+  , tnumValue
+  , tnumMask
+  , mk
+  , add
+  , mul
+  ) where
+
+import qualified Control.Exception as X
+import           Data.Bits
+
+-- | A tristate-number representation.
+--
+-- The two fields are required to be disjoint (@tnumValue .&. tnumMask == 0@);
+-- 'mk' enforces this with an 'X.assert'.
+data Tnum = Tnum
+  { tnumValue :: !Integer
+    -- ^ The known-1 bits.
+  , tnumMask  :: !Integer
+    -- ^ The unknown bits.
+  }
+
+-- | Smart constructor that asserts the disjointness invariant.
+mk :: Integer -> Integer -> Tnum
+mk v m = X.assert (v .&. m == 0) (Tnum v m)
+{-# INLINE mk #-}
+
+-- | Tristate-number add, with the result truncated to @bvmask@.
+add ::
+  Integer {- ^ bvmask -} ->
+  Tnum {- ^ a -} ->
+  Tnum {- ^ b -} ->
+  Tnum
+add bvmask (Tnum av am) (Tnum bv bm) = mk resv resm
+  where
+  sm    = am + bm
+  sv    = av + bv
+  sigma = sm + sv
+  chi   = sigma `xor` sv
+  resm  = (chi .|. am .|. bm) .&. bvmask
+  resv  = (sv .&. complement resm) .&. bvmask
+{-# INLINE add #-}
+
+-- | Tristate-number multiply, with the result truncated to @bvmask@.
+mul ::
+  Integer {- ^ bvmask -} ->
+  Tnum {- ^ a -} ->
+  Tnum {- ^ b -} ->
+  Tnum
+mul bvmask (Tnum av0 am0) (Tnum bv0 bm0) = go av0 am0 bv0 bm0 acc0
+  where
+  acc0 = mk ((av0 * bv0) .&. bvmask) 0
+  -- Accumulate contributions from each bit of a. A known-1 bit at
+  -- position i adds b's mask shifted into position i (b's value bits
+  -- are already included via the initial @av*bv@ product). An unknown
+  -- bit at position i adds (b.value | b.mask) shifted in, since the
+  -- bit might or might not contribute b.
+  go !av !am !bv !bm !acc
+    | av == 0 && am == 0 = acc
+    | otherwise =
+        let acc'
+              | testBit av 0 = add bvmask acc (Tnum 0 bm)
+              | testBit am 0 = add bvmask acc (Tnum 0 (bv .|. bm))
+              | otherwise    = acc
+        in go (av `shiftR` 1) (am `shiftR` 1)
+              (bv `shiftL` 1) (bm `shiftL` 1)
+              acc'

--- a/what4-domains/test/BVDomTests.hs
+++ b/what4-domains/test/BVDomTests.hs
@@ -323,6 +323,33 @@ bitwiseDomainTests =
       do SW n <- genWidth
          i <- fromInteger <$> chooseInteger (0, intValue n - 1)
          B.correct_testBit n <$> B.genPair n <*> pure i
+  , genTest "correct_ubounds" $
+      do SW n <- genWidth
+         B.correct_ubounds n <$> B.genPair n
+  , genTest "correct_sbounds" $
+      do SW n <- genWidth
+         B.correct_sbounds n <$> B.genPair n
+  , genTest "correct_ult" $
+      do SW n <- genWidth
+         B.correct_ult n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_slt" $
+      do SW n <- genWidth
+         B.correct_slt n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_add" $
+      do SW n <- genWidth
+         B.correct_add n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_sub" $
+      do SW n <- genWidth
+         B.correct_sub n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_neg" $
+      do SW n <- genWidth
+         B.correct_neg n <$> B.genPair n
+  , genTest "correct_scale" $
+      do SW n <- genWidth
+         B.correct_scale n <$> genBV n <*> B.genPair n
+  , genTest "correct_mul" $
+      do SW n <- genWidth
+         B.correct_mul n <$> B.genPair n <*> B.genPair n
   ]
 
 overallDomainTests :: TestTree

--- a/what4-domains/what4-domains.cabal
+++ b/what4-domains/what4-domains.cabal
@@ -167,6 +167,7 @@ library
 
   other-modules:
     What4.Domains.Arithmetic
+    What4.Domains.BV.Bitwise.Tnum
 
   default-extensions:
     NondecreasingIndentation


### PR DESCRIPTION
Fixes #352, though I only implemented the operations necessary for expanding the range of operations of the existing `Bitwise` domain. Probably not worth doing the full implementation, as it would be very similar to `Bitwise`. Should help the precision of #372.