### PR TITLE
feat(domains): Precise division, fast multipliction for bitwise domain

### DIFF
--- a/what4-domains/doc/bitsdomain.cry
+++ b/what4-domains/doc/bitsdomain.cry
@@ -170,18 +170,77 @@ bneg a = add (bnot a) (singleton 1)
 sub : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
 sub a b = add a (bneg b)
 
+// scale uses the precise (shift-and-add) multiplication so that
+// constant-by-domain products preserve bit-level structure.
 scale : {n} (fin n, n >= 1) => [n] -> Dom n -> Dom n
-scale k a = mul (singleton k) a
+scale k a = mulPrecise (singleton k) a
 
-// Multiply via shift-and-add over the bits of a.
+// Population count: number of 1 bits.
+popcount : {n} (fin n, n >= 1) => [n] -> [n]
+popcount x = sum [ zero # [b] | b <- x ]
+
+// Count trailing zeros, returning n for x == 0. Computed via the
+// bit-trick popcount ((x .&. -x) - 1): x .&. -x isolates the lowest
+// set bit, and the popcount of one less than that gives its position.
+ctz : {n} (fin n, n >= 1) => [n] -> [n]
+ctz x = if x == 0 then `n else popcount ((x && (- x)) - 1)
+
+// knownBitsOfInterval lo hi: given an arithmetic interval [lo, hi]
+// (with 0 <= lo <= hi), return (value, mask) in tnum form. Bits above
+// the highest disagreement between lo and hi are determined (recorded
+// in value); bits at-or-below it are unknown (set in mask).
+//
+// Subsumes leading-zero analysis (when lo = 0) and adds leading-1
+// (and arbitrary leading-prefix) analysis when lo > 0.
+knownBitsOfInterval : {n} (fin n, n >= 1) => [n] -> [n] -> ([n], [n])
+knownBitsOfInterval lo hi = (lo && (~ varying), varying)
+  where
+  varying = bitsBelow (lo ^ hi)
+
+// Fast multiply via interval and trailing-zero analysis.
+//
+// The result has at least ctzA + ctzB trailing zero bits, where ctzA
+// is ctz(av | am) and similarly for B. Above that, known leading bits
+// are derived from the arithmetic interval [aMin*bMin, aMax*bMax] when
+// that interval fits in n bits; otherwise the high bits wrap and are
+// unconstrained. This captures both leading 0s (small upper bound) and
+// leading 1s (large lower bound).
+mul : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+mul a b =
+  if a.lomask == a.himask /\ b.lomask == b.himask
+    then singleton (a.lomask * b.lomask)
+    else { lomask = highValue, himask = highValue || (highUnknown && (~ lowZeros)) }
+  where
+  (av, am) = toTnum a
+  (bv, bm) = toTnum b
+  tz = ctz (av || am) + ctz (bv || bm)
+  lowZeros = (1 << tz) - 1
+  // Compute aMin*bMin and aMax*bMax in 2n-bit width so we can tell when
+  // the product overflows n bits.
+  aMinExt = (zext av : [n + n])
+  bMinExt = (zext bv : [n + n])
+  aMaxExt = (zext (av || am) : [n + n])
+  bMaxExt = (zext (bv || bm) : [n + n])
+  prodMin = aMinExt * bMinExt
+  prodMax = aMaxExt * bMaxExt
+  // The product overflows iff the high half of aMax*bMax is non-zero.
+  overflows = take`{n} prodMax != 0
+  (highValue, highUnknown) =
+    if overflows
+      then (zero, ~ zero)
+      else knownBitsOfInterval (drop`{n} prodMin) (drop`{n} prodMax)
+
+// Precise multiply via shift-and-add over the bits of a (BPF tnum_mul).
 //
 // At bit position i, when av_i = 1 we add bm shifted to position i
 // (the bv contribution is already accounted for by the initial
 // av*bv product). When am_i = 1 (unknown bit), we add (bv|bm) shifted
 // to position i, since b might or might not contribute.
-mul : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
-mul a b = fromTnum resv resm
+mulPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+mulPrecise a b = intersection schoolbook fast
   where
+  fast = mul a b
+  schoolbook = fromTnum resv resm
   (av, am) = toTnum a
   (bv, bm) = toTnum b
   // Initial value-by-value product
@@ -218,22 +277,27 @@ bitsBelow x = ys ! 0
 
 // Unsigned division. When the divisor is a singleton power of
 // two 2^k, the result is exact (a logical shift right by k);
-// otherwise, the result is bounded above by aMax / bMin and we
-// keep only its leading-zero structure.
+// otherwise, the result is bounded by interval analysis on
+// [aMin/bMax, aMax/bMin], keeping every bit above the highest
+// disagreement between the bounds.
 udiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
 udiv a b =
   if (bm == 0) /\ (bv != 0) /\ ((bv && (bv - 1)) == 0)
     then { lomask = av / bv, himask = (av || am) / bv }
-    else { lomask = 0, himask = bitsBelow qMax }
+    else { lomask = highValue, himask = highValue || highUnknown }
   where
   (av, am) = toTnum a
   (bv, bm) = toTnum b
+  aMin = av
   aMax = av || am
-  // bv may be 0 if b.lomask = 0; we substitute 1 to avoid division
-  // by zero in this Cryptol expression. The result of the else
-  // branch is sound regardless: x/y <= x <= aMax for any y >= 1.
-  bSafe = if bv == 0 then 1 else bv
-  qMax = aMax / bSafe
+  // bv = 0 means b.lomask = 0, i.e. b's domain might contain zero. We use
+  // max 1 to avoid division by zero; the result is sound under our
+  // assumption that b is nonzero.
+  bMin = if bv == 0 then 1 else bv
+  bMax = if (bv || bm) == 0 then 1 else (bv || bm)
+  qMin = aMin / bMax
+  qMax = aMax / bMin
+  (highValue, highUnknown) = knownBitsOfInterval qMin qMax
 
 // Unsigned remainder. When the divisor is a singleton power of
 // two 2^k, the result is exact (the low k bits of the dividend);
@@ -250,12 +314,90 @@ urem a b =
   bMax = bv || bm
   rMax = if bMax == 0 then 0 else (if aMax < bMax - 1 then aMax else bMax - 1)
 
+// 3-valued unsigned-less-than on Doms: returns 0 (definitely false),
+// 1 (definitely true), or 2 (unknown). Used by long division.
+ultMaybe : {n} (fin n) => Dom n -> Dom n -> [2]
+ultMaybe a b =
+  if a.himask < b.lomask then 1
+  else if a.lomask >= b.himask then 0
+  else 2
+
+// Long division: walk the bits of a from high to low, maintaining a
+// running partial remainder r as a Dom. At each step, shift r left
+// and inject the corresponding bit of a; then compare to b. If r >= b
+// definitely, subtract and set the quotient bit. If r < b definitely,
+// leave the quotient bit clear. If undetermined, union both branches
+// into r and leave the quotient bit unknown.
+//
+// Returns (quotient, remainder) Doms.
+longDivision : {n} (fin n, n >= 1) => Dom n -> Dom n -> (Dom n, Dom n)
+longDivision a b = (states ! 0).0
+  where
+  // states !! i is (qDom, rDom) after processing the i-th iteration
+  // (from MSB down).
+  states : [n + 1]((Dom n, Dom n), [width n])
+  states = [((singleton 0, singleton 0), 0)]
+         # [ step s i | s <- states | i <- [0 .. n - 1] ]
+  step ((q, r), _) i =
+    ((q', r'), i + 1)
+    where
+    bitIdx = `n - 1 - i
+    aBit = testBitDom a bitIdx
+    rShifted = shl r 1
+    rPrime = bor rShifted aBit
+    rMinusB = sub rPrime b
+    cmp = ultMaybe rPrime b
+    (q', r') =
+      if cmp == 1                       // rPrime < b: quotient bit 0
+        then (q, rPrime)
+        else if cmp == 0                // rPrime >= b: quotient bit 1
+          then (setBitDom q bitIdx, rMinusB)
+          else (unknownBitDom q bitIdx, union rPrime rMinusB)
+
+// Get bit i of a Dom as a 1-bit-wide Dom (in width n: low bit only).
+testBitDom : {n} (fin n, n >= 1) => Dom n -> [width n] -> Dom n
+testBitDom a i =
+  if a.lomask @ idx
+    then singleton 1                    // bit known set
+    else if a.himask @ idx
+      then { lomask = 0, himask = 1 }   // bit unknown
+      else singleton 0                  // bit known clear
+  where
+  // Cryptol indexes from the MSB; convert from LSB index i.
+  idx : [width n]
+  idx = `n - 1 - i
+
+// Set bit i of a Dom (assumes it was previously known to be 0).
+setBitDom : {n} (fin n, n >= 1) => Dom n -> [width n] -> Dom n
+setBitDom a i = bor a (singleton (1 << i))
+
+// Mark bit i of a Dom as unknown (assumes it was previously known to be 0).
+unknownBitDom : {n} (fin n, n >= 1) => Dom n -> [width n] -> Dom n
+unknownBitDom a i =
+  { lomask = a.lomask, himask = a.himask || (1 << i) }
+
+// Unsigned division combining schoolbook long division with the
+// leading-zero analysis of udiv. Strictly at least as precise as udiv.
+udivPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+udivPrecise a b = intersection (longDivision a b).0 (udiv a b)
+
+// Unsigned remainder combining schoolbook long division with the
+// leading-zero analysis of urem. Strictly at least as precise as urem.
+uremPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
+uremPrecise a b = intersection (longDivision a b).1 (urem a b)
+
 // splitSign a returns (zero_circle, one_circle), where the first
 // is a's restriction to non-negative values (sign bit cleared)
 // and the second is its restriction to negative values (sign bit
-// set). Either circle may be empty (lomask not bitle himask),
-// which is fine: empty inputs make the soundness implication
-// vacuously true, and union accepts any well-formed pair.
+// set).
+//
+// One of the two circles may be empty in the sense that
+// (lomask || himask) != himask: if a's sign bit is already known,
+// clearing or setting it in only one of the masks produces a
+// pair that no concrete value can satisfy. That's fine here: any
+// x that satisfied the input ends up in the *other* circle, the
+// soundness implication is vacuously true on the empty side, and
+// union with an empty domain contributes nothing.
 splitSign : {n} (fin n, n >= 1) => Dom n -> (Dom n, Dom n)
 splitSign a = (zero_circle, one_circle)
   where
@@ -405,6 +547,10 @@ correct_mul : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
 correct_mul a b x y =
   mem a x ==> mem b y ==> mem (mul a b) (x * y)
 
+correct_mulPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_mulPrecise a b x y =
+  mem a x ==> mem b y ==> mem (mulPrecise a b) (x * y)
+
 correct_udiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
 correct_udiv a b x y =
   mem a x ==> mem b y ==> y != 0 ==> mem (udiv a b) (x / y)
@@ -412,6 +558,14 @@ correct_udiv a b x y =
 correct_urem : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
 correct_urem a b x y =
   mem a x ==> mem b y ==> y != 0 ==> mem (urem a b) (x % y)
+
+correct_udivPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_udivPrecise a b x y =
+  mem a x ==> mem b y ==> y != 0 ==> mem (udivPrecise a b) (x / y)
+
+correct_uremPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
+correct_uremPrecise a b x y =
+  mem a x ==> mem b y ==> y != 0 ==> mem (uremPrecise a b) (x % y)
 
 correct_sdiv : {n} (fin n, n >= 1) => Dom n -> Dom n -> [n] -> [n] -> Bit
 correct_sdiv a b x y =
@@ -466,6 +620,9 @@ property a10 = correct_udiv`{8}
 property a11 = correct_urem`{8}
 property a12 = correct_sdiv`{8}
 property a13 = correct_srem`{8}
+property a14 = correct_mulPrecise`{8}
+property a15 = correct_udivPrecise`{8}
+property a16 = correct_uremPrecise`{8}
 
 
 ////////////////////////////////////////////////////////////

--- a/what4-domains/doc/bitsdomain.cry
+++ b/what4-domains/doc/bitsdomain.cry
@@ -190,6 +190,10 @@ ctz x = if x == 0 then `n else popcount ((x && (- x)) - 1)
 // the highest disagreement between lo and hi are determined (recorded
 // in value); bits at-or-below it are unknown (set in mask).
 //
+// For example, if lo = 0b1100 and hi = 0b1110, every value in [lo, hi]
+// has bits 3 and 2 set; bits 1 and 0 vary. So value = 0b1100 and
+// mask = 0b0011.
+//
 // Subsumes leading-zero analysis (when lo = 0) and adds leading-1
 // (and arbitrary leading-prefix) analysis when lo > 0.
 knownBitsOfInterval : {n} (fin n, n >= 1) => [n] -> [n] -> ([n], [n])
@@ -197,14 +201,48 @@ knownBitsOfInterval lo hi = (lo && (~ varying), varying)
   where
   varying = bitsBelow (lo ^ hi)
 
+// Like knownBitsOfInterval but for the image of [lo, hi] under
+// reduction mod 2^n. Three cases:
+//
+//   * the interval is at least 2^n wide -- every residue is reached, so
+//     no bits are determined;
+//   * the interval fits in one modulus -- use knownBitsOfInterval on
+//     the wrapped bounds directly;
+//   * the interval crosses one modulus boundary -- analyze each half
+//     and join (a bit is known only when both halves agree on it).
+//
+// The inputs are 2n-bit so they can represent the unbounded product of
+// two n-bit values.
+wrappedKnownBitsOfInterval : {n} (fin n, n >= 1) => [n + n] -> [n + n] -> ([n], [n])
+wrappedKnownBitsOfInterval lo hi =
+  if take`{n} (hi - lo) != 0
+    then (zero, ~ zero)
+    else if wLo <= wHi
+      then knownBitsOfInterval wLo wHi
+      else
+        // wraps: [wLo, ~zero] U [0, wHi]
+        (vA && (~ mAB), mAB)
+        where
+        (vA, mA) = knownBitsOfInterval wLo (~ zero)
+        (vB, mB) = knownBitsOfInterval 0 wHi
+        mAB = mA || mB || (vA ^ vB)
+  where
+  wLo = drop`{n} lo
+  wHi = drop`{n} hi
+
 // Fast multiply via interval and trailing-zero analysis.
 //
-// The result has at least ctzA + ctzB trailing zero bits, where ctzA
-// is ctz(av | am) and similarly for B. Above that, known leading bits
-// are derived from the arithmetic interval [aMin*bMin, aMax*bMax] when
-// that interval fits in n bits; otherwise the high bits wrap and are
-// unconstrained. This captures both leading 0s (small upper bound) and
-// leading 1s (large lower bound).
+// The result has:
+//
+//   * at least ctzA + ctzB trailing zero bits, where ctzA is the
+//     longest prefix of low bits that are known-zero in a (i.e. both
+//     av and am have that bit clear), and similarly for ctzB; and
+//   * known bits derived from the arithmetic interval
+//     [aMin*bMin, aMax*bMax] reduced mod 2^n
+//     (see wrappedKnownBitsOfInterval).
+//
+// Special case: when both operands are concrete singletons (mask == 0),
+// the result is the exact concrete product.
 mul : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
 mul a b =
   if a.lomask == a.himask /\ b.lomask == b.himask
@@ -215,27 +253,26 @@ mul a b =
   (bv, bm) = toTnum b
   tz = ctz (av || am) + ctz (bv || bm)
   lowZeros = (1 << tz) - 1
-  // Compute aMin*bMin and aMax*bMax in 2n-bit width so we can tell when
-  // the product overflows n bits.
+  // Compute aMin*bMin and aMax*bMax in 2n-bit width so the product is
+  // exact (no overflow); wrappedKnownBitsOfInterval handles wrap-around.
   aMinExt = (zext av : [n + n])
   bMinExt = (zext bv : [n + n])
   aMaxExt = (zext (av || am) : [n + n])
   bMaxExt = (zext (bv || bm) : [n + n])
   prodMin = aMinExt * bMinExt
   prodMax = aMaxExt * bMaxExt
-  // The product overflows iff the high half of aMax*bMax is non-zero.
-  overflows = take`{n} prodMax != 0
-  (highValue, highUnknown) =
-    if overflows
-      then (zero, ~ zero)
-      else knownBitsOfInterval (drop`{n} prodMin) (drop`{n} prodMax)
+  (highValue, highUnknown) = wrappedKnownBitsOfInterval`{n} prodMin prodMax
 
 // Precise multiply via shift-and-add over the bits of a (BPF tnum_mul).
+// Strictly more precise than mul on its own, but quadratic in n.
+// Captures bit-level structure of the product that trailing-zero
+// analysis can't see.
 //
-// At bit position i, when av_i = 1 we add bm shifted to position i
-// (the bv contribution is already accounted for by the initial
-// av*bv product). When am_i = 1 (unknown bit), we add (bv|bm) shifted
-// to position i, since b might or might not contribute.
+// Accumulate contributions from each bit of a. A known-1 bit at
+// position i adds bm shifted to position i (b's value bits are already
+// included via the initial av*bv product). An unknown bit at position
+// i adds (bv|bm) shifted in, since the bit might or might not
+// contribute b.
 mulPrecise : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
 mulPrecise a b = intersection schoolbook fast
   where
@@ -301,7 +338,12 @@ udiv a b =
 
 // Unsigned remainder. When the divisor is a singleton power of
 // two 2^k, the result is exact (the low k bits of the dividend);
-// otherwise, the result is bounded above by min(aMax, bMax-1).
+// otherwise, the result is bounded above by min(aMax, bMax-1) and
+// every bit above that is known zero.
+//
+// (The remainder's lower bound is trivially 0, so the same
+// interval-agreement analysis used in udiv would not yield additional
+// leading bits here.)
 urem : {n} (fin n, n >= 1) => Dom n -> Dom n -> Dom n
 urem a b =
   if (bm == 0) /\ (bv != 0) /\ ((bv && (bv - 1)) == 0)
@@ -620,7 +662,7 @@ property a10 = correct_udiv`{8}
 property a11 = correct_urem`{8}
 property a12 = correct_sdiv`{8}
 property a13 = correct_srem`{8}
-property a14 = correct_mulPrecise`{8}
+property a14 = correct_mulPrecise`{8}  // NB: takes 60s
 property a15 = correct_udivPrecise`{8}
 property a16 = correct_uremPrecise`{8}
 

--- a/what4-domains/src/What4/Domains/Arithmetic.hs
+++ b/what4-domains/src/What4/Domains/Arithmetic.hs
@@ -27,7 +27,7 @@ import Data.Parameterized.NatRepr
 import qualified GHC.Num.Integer as Integer
 #endif
 
--- | Count trailing zeros
+-- | /O(w)/. Count trailing zeros, capped at the width.
 ctz :: NatRepr w -> Integer -> Integer
 ctz w x = go 0
  where
@@ -35,7 +35,7 @@ ctz w x = go 0
    | i < toInteger (natValue w) && testBit x (fromInteger i) == False = go (i + 1)
    | otherwise = i
 
--- | Count leading zeros
+-- | /O(w)/. Count leading zeros, capped at the width.
 clz :: NatRepr w -> Integer -> Integer
 clz w x = go 0
  where
@@ -43,9 +43,9 @@ clz w x = go 0
    | i < toInteger (natValue w) && testBit x (widthVal w - fromInteger i - 1) == False = go (i + 1)
    | otherwise = i
 
--- | @intLog2 n@ for @n >= 1@: floor of base-2 logarithm. Undefined for
--- @n <= 0@. On GHC 9.0+ this delegates to a fast primop in @ghc-bignum@;
--- on earlier GHCs it falls back to a shift loop.
+-- | /O(w)/. @intLog2 n@ for @n >= 1@: floor of base-2 logarithm. Undefined
+-- for @n <= 0@. On GHC 9.0+ this delegates to a primop in @ghc-bignum@
+-- (constant-time per limb); on earlier GHCs it uses a shift loop.
 intLog2 :: Integer -> Int
 #if MIN_VERSION_base(4,15,0)
 intLog2 n = fromIntegral (Integer.integerLog2 n)
@@ -58,15 +58,17 @@ intLog2 = go 0
 #endif
 {-# INLINE intLog2 #-}
 
--- | @bitsBelow n@ returns the smallest mask of the form @2^k - 1@ that is at
--- least @n@. That is, @2^(floor(log2 n) + 1) - 1@ for @n > 0@, or @0@ for
--- @n <= 0@. Every value in @[0..n]@ has all its set bits within this mask.
+-- | /O(w)/. @bitsBelow n@ returns the smallest mask of the form @2^k - 1@
+-- that is at least @n@. That is, @2^(floor(log2 n) + 1) - 1@ for @n > 0@,
+-- or @0@ for @n <= 0@. Every value in @[0..n]@ has all its set bits within
+-- this mask.
 bitsBelow :: Integer -> Integer
 bitsBelow n
   | n <= 0    = 0
   | otherwise = bit (intLog2 n + 1) - 1
 {-# INLINE bitsBelow #-}
 
+-- | /O(w)/. Rotate a @w@-bit value right by @n@ positions (mod @w@).
 rotateRight ::
   NatRepr w {- ^ width -} ->
   Integer {- ^ value to rotate -} ->
@@ -77,6 +79,7 @@ rotateRight w x n = xor (shiftR x' n') (toUnsigned w (shiftL x' (widthVal w - n'
  x' = toUnsigned w x
  n' = fromInteger (n `rem` intValue w)
 
+-- | /O(w)/. Rotate a @w@-bit value left by @n@ positions (mod @w@).
 rotateLeft ::
   NatRepr w {- ^ width -} ->
   Integer {- ^ value to rotate -} ->

--- a/what4-domains/src/What4/Domains/BV/Bitwise.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise.hs
@@ -54,10 +54,13 @@ module What4.Domains.BV.Bitwise
   , negate
   , scale
   , mul
+  , mulPrecise
   , udiv
   , urem
   , sdiv
   , srem
+  , udivPrecise
+  , uremPrecise
   -- ** arithmetic (SMT-LIB div-by-zero semantics)
   , udivSmtlib
   , uremSmtlib
@@ -99,10 +102,13 @@ module What4.Domains.BV.Bitwise
   , correct_neg
   , correct_scale
   , correct_mul
+  , correct_mulPrecise
   , correct_udiv
   , correct_urem
   , correct_sdiv
   , correct_srem
+  , correct_udivPrecise
+  , correct_uremPrecise
   , correct_udivSmtlib
   , correct_uremSmtlib
   , correct_sdivSmtlib
@@ -467,33 +473,122 @@ negate a = add (not a) (mkSingleton (bvdMask a) 1)
 sub :: Domain w -> Domain w -> Domain w
 sub a b = add a (negate b)
 
--- | /O(w²)/. Multiply by a constant.
+-- | /O(w²)/. Multiply by a constant. Uses 'mulPrecise' since the
+-- shift-and-add algorithm gives bit-level precision when one operand
+-- is concrete.
 scale :: Integer -> Domain w -> Domain w
-scale k a = mul (mkSingleton (bvdMask a) k) a
+scale k a = mulPrecise (mkSingleton (bvdMask a) k) a
 
--- | /O(w²)/. Multiply two bitwise domains via the shift-and-add
--- tristate-number algorithm (BPF @tnum_mul@).
+-- | /O(w)/. Multiply two bitwise domains via interval and trailing-zero
+-- analysis. Captures known leading bits (both 0s and 1s) derived from
+-- @[aMin*bMin, aMax*bMax]@, plus known trailing zeros from the operands.
+--
+-- See 'Tnum.mul' for the algorithm. 'mulPrecise' is strictly more
+-- precise; this is the cheaper alternative when middle-bit precision
+-- doesn't matter.
 mul :: Domain w -> Domain w -> Domain w
 mul a@(BVBitInterval mask _ _) b =
   fromTnum mask (Tnum.mul mask (toTnum a) (toTnum b))
 
--- | /O(w)/. Unsigned division. Assumes the divisor is nonzero.
+-- | /O(w²)/. Multiply two bitwise domains, combining the shift-and-add
+-- tristate-number algorithm (BPF @tnum_mul@) with the interval and
+-- trailing-zero analysis of 'mul'. Strictly at least as precise as 'mul'.
+mulPrecise :: Domain w -> Domain w -> Domain w
+mulPrecise a@(BVBitInterval mask _ _) b =
+  intersection
+    (fromTnum mask (Tnum.mulPrecise mask (toTnum a) (toTnum b)))
+    (mul a b)
+
+-- | /O(w)/. Unsigned division via interval analysis on the quotient bounds.
+-- Assumes the divisor is nonzero.
 --
--- Compared to the arithmetic-domain @udiv@, this can be more precise when the
--- divisor is a known power of two: the result is exact, and bit-level structure
--- of the dividend is preserved (e.g.\ @udiv (any w) (singleton w (2^k))@ has
--- its top @k@ bits known zero).
+-- Captures known leading bits (both 0s and 1s) derived from
+-- @[aMin \`quot\` bMax, aMax \`quot\` bMin]@. When the divisor is a known
+-- power of two, the result is exact (bit-level structure of the dividend
+-- is preserved, e.g.\ @udiv (any w) (singleton w (2^k))@ has its top @k@
+-- bits known zero). 'udivPrecise' is strictly more precise; this is the
+-- cheaper alternative when middle-bit precision doesn't matter.
 udiv :: Domain w -> Domain w -> Domain w
 udiv a@(BVBitInterval mask _ _) b =
   fromTnum mask (Tnum.udiv mask (toTnum a) (toTnum b))
 
--- | /O(w)/. Unsigned remainder. Assumes the divisor is nonzero.
+-- | /O(w)/. Unsigned remainder via leading-zero analysis. Assumes the divisor
+-- is nonzero.
 --
--- Like 'udiv', this is more precise when the divisor is a known power of two:
+-- The result is bounded above by @min(aMax, bMax - 1)@; bits above that are
+-- known zero. (The remainder's lower bound is trivially 0, so the same
+-- interval-agreement analysis used in 'udiv' would not yield additional
+-- leading bits here.) When the divisor is a known power of two,
 -- @urem a (singleton w (2^k))@ is exactly the low @k@ bits of @a@.
 urem :: Domain w -> Domain w -> Domain w
 urem a@(BVBitInterval mask _ _) b =
   fromTnum mask (Tnum.urem mask (toTnum a) (toTnum b))
+
+-- | /O(w²)/. Unsigned division combining abstract schoolbook long division
+-- with the interval analysis of 'udiv'. Assumes the divisor is nonzero.
+-- Strictly at least as precise as 'udiv'.
+--
+-- The result is the 'intersection' of 'udiv' (interval analysis on the
+-- quotient bounds, plus an exact path for power-of-two divisors) and the
+-- schoolbook result (which captures middle-bit structure that interval
+-- analysis can't see, but joins through any undetermined comparison and so
+-- loses on power-of-two divisors).
+udivPrecise :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+udivPrecise w a b = intersection (fst (longDivision w a b)) (udiv a b)
+
+-- | /O(w²)/. Unsigned remainder combining schoolbook long division with the
+-- leading-zero analysis of 'urem'. Assumes the divisor is nonzero. Strictly
+-- at least as precise as 'urem'.
+uremPrecise :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
+uremPrecise w a b = intersection (snd (longDivision w a b)) (urem a b)
+
+-- | Abstract schoolbook long division: simultaneously computes the
+-- quotient and remainder by walking the bits of the dividend from MSB to
+-- LSB, maintaining a running partial remainder @r@ as a 'Domain'.
+--
+-- At each step, @r@ is shifted left and the next bit of the dividend is
+-- shifted in. If @r >= b@ definitely, we subtract and set the corresponding
+-- bit of the quotient. If @r < b@ definitely, we leave it. If the
+-- comparison is undetermined, we union both possibilities into @r@ and
+-- leave the quotient bit unknown.
+longDivision :: forall w. (1 <= w) => NatRepr w -> Domain w -> Domain w -> (Domain w, Domain w)
+longDivision w a b = go (widthVal w - 1) (singleton w 0) (singleton w 0)
+  where
+  -- Loop from bit (w-1) down to 0. @q@ accumulates the quotient,
+  -- @r@ is the partial remainder.
+  go :: Int -> Domain w -> Domain w -> (Domain w, Domain w)
+  go i q r
+    | i < 0     = (q, r)
+    | otherwise =
+        let r'        = injectBit r (testBit a (fromIntegral i))
+            r'MinusB  = sub r' b
+            (q'', r'')= case ult r' b of
+              Just True  -> (q,                       r')
+              Just False -> (setBitDom q i,           r'MinusB)
+              Nothing    -> (unknownBitDom q i,       union r' r'MinusB)
+        in go (i - 1) q'' r''
+
+  -- Shift @r@ left by 1 and OR in a fresh low bit, whose value is
+  -- determined by the @testBit@ result on the dividend.
+  injectBit :: Domain w -> Maybe Bool -> Domain w
+  injectBit r mb =
+    let r1 = shl w r 1
+        bit_dom = case mb of
+          Just True  -> singleton w 1
+          Just False -> singleton w 0
+          Nothing    -> range w 0 1
+    in or r1 bit_dom
+
+  -- Set bit @i@ of a domain that is known to have bit @i@ = 0 going in
+  -- (q starts at 0 and we only ever set bits, so this is safe).
+  setBitDom :: Domain w -> Int -> Domain w
+  setBitDom (BVBitInterval mask lo hi) i =
+    BVBitInterval mask (Bits.setBit lo i) (Bits.setBit hi i)
+
+  -- Mark bit @i@ of a domain as unknown.
+  unknownBitDom :: Domain w -> Int -> Domain w
+  unknownBitDom (BVBitInterval mask lo hi) i =
+    BVBitInterval mask lo (Bits.setBit hi i)
 
 -- | /O(w)/. Signed division (rounds toward zero). Assumes the divisor is
 -- nonzero.
@@ -583,9 +678,9 @@ uremSmtlib a b
   | otherwise               = urem a b
 
 -- | /O(w)/. Like 'sdiv', but using the SMT-LIB QF_BV logic's div-by-zero
--- convention: @bvsdiv s 0@ is all-ones when @s@ is non-negative and @1@
--- when @s@ is negative. See @Note [SMT-LIB division]@ in "What4.Interface"
--- for the design rationale.
+-- convention: @bvsdiv s 0@ is all-ones when @s@ is non-negative and @1@ when
+-- @s@ is negative. See @Note [SMT-LIB division]@ in "What4.Interface" for the
+-- design rationale.
 sdivSmtlib :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
 sdivSmtlib w a b
   | Just 0 <- asSingleton b = sdivByZero w a
@@ -604,8 +699,8 @@ sdivByZero w a =
   mask = bvdMask a
 
 -- | /O(w)/. Like 'srem', but using the SMT-LIB QF_BV logic's div-by-zero
--- convention: @bvsrem s 0@ is the dividend itself (@s@). See @Note
--- [SMT-LIB division]@ in "What4.Interface" for the design rationale.
+-- convention: @bvsrem s 0@ is the dividend itself (@s@). See @Note [SMT-LIB
+-- division]@ in "What4.Interface" for the design rationale.
 sremSmtlib :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
 sremSmtlib w a b
   | Just 0 <- asSingleton b = a
@@ -769,6 +864,9 @@ correct_scale n k (a,x) = member a x ==> pmember n (scale k' a) (k' * x)
 correct_mul :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
 correct_mul n (a,x) (b,y) = member a x ==> member b y ==> pmember n (mul a b) (x * y)
 
+correct_mulPrecise :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_mulPrecise n (a,x) (b,y) = member a x ==> member b y ==> pmember n (mulPrecise a b) (x * y)
+
 correct_udiv :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
 correct_udiv n (a,x) (b,y) =
   member a x ==> member b y ==> y' /= 0 ==> pmember n (udiv a b) (x' `quot` y')
@@ -796,6 +894,22 @@ correct_srem n (a,x) (b,y) =
   where
   x' = toSigned n x
   y' = toSigned n y
+
+correct_udivPrecise :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_udivPrecise n (a,x) (b,y) =
+  member a x ==> member b y ==> y' /= 0 ==> pmember n (udivPrecise n a b) (x' `quot` y')
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+correct_uremPrecise :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property
+correct_uremPrecise n (a,x) (b,y) =
+  member a x ==> member b y ==> y' /= 0 ==> pmember n (uremPrecise n a b) (x' `rem` y')
+  where
+  x' = toUnsigned n x
+  y' = toUnsigned n y
+
+
 
 correct_udivSmtlib ::
   (1 <= n) =>

--- a/what4-domains/src/What4/Domains/BV/Bitwise.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise.hs
@@ -140,7 +140,7 @@ data Domain (w :: Nat) =
   --  @mask@ caches the value of @2^w - 1@
   deriving (Eq, Ord, Show)
 
--- | Test if the domain satisfies its invariants
+-- | /O(w)/. Test if the domain satisfies its invariants.
 proper :: NatRepr w -> Domain w -> Bool
 proper w (BVBitInterval mask lo hi) =
   mask == maxUnsigned w &&
@@ -148,12 +148,12 @@ proper w (BVBitInterval mask lo hi) =
   bitle hi mask &&
   bitle lo hi
 
--- | Test if the given integer value is a member of the abstract domain
+-- | /O(w)/. Test if the given integer value is a member of the abstract domain.
 member :: Domain w -> Integer -> Bool
 member (BVBitInterval mask lo hi) x = bitle lo x' && bitle x' hi
   where x' = x .&. mask
 
--- | Compute how many concrete elements are in the abstract domain
+-- | /O(w)/. Compute how many concrete elements are in the abstract domain.
 size :: Domain w -> Integer
 size (BVBitInterval _ lo hi)
   | bitle lo hi = Bits.bit p
@@ -165,7 +165,7 @@ size (BVBitInterval _ lo hi)
 bitle :: Integer -> Integer -> Bool
 bitle x y = (x .|. y) == y
 
--- | Return the bitvector mask value from this domain
+-- | /O(1)/. Return the bitvector mask value from this domain.
 bvdMask :: Domain w -> Integer
 bvdMask (BVBitInterval mask _ _) = mask
 
@@ -217,11 +217,11 @@ genPair w =
      x <- genElement a
      return (a,x)
 
--- | Unsafe constructor for internal use.
+-- | /O(1)/. Unsafe constructor for internal use.
 interval :: Integer -> Integer -> Integer -> Domain w
 interval mask lo hi = BVBitInterval mask lo hi
 
--- | Construct a domain from bitwise lower and upper bounds
+-- | /O(w)/. Construct a domain from bitwise lower and upper bounds.
 range :: NatRepr w -> Integer -> Integer -> Domain w
 range w lo hi = BVBitInterval (maxUnsigned w) lo' hi'
   where
@@ -229,36 +229,38 @@ range w lo hi = BVBitInterval (maxUnsigned w) lo' hi'
   hi'  = hi .&. mask
   mask = maxUnsigned w
 
--- | Bitwise lower and upper bounds
+-- | /O(1)/. Bitwise lower and upper bounds.
 bitbounds :: Domain w -> (Integer, Integer)
 bitbounds (BVBitInterval _ lo hi) = (lo, hi)
 
--- | Test if this domain contains a single value, and return it if so
+-- | /O(w)/. Test if this domain contains a single value, and return it if so.
 asSingleton :: Domain w -> Maybe Integer
 asSingleton (BVBitInterval _ lo hi) = if lo == hi then Just lo else Nothing
 
--- | Returns true iff there is at least on element
---   in this bitwise domain.
+-- | /O(w)/. Returns true iff there is at least one element
+-- in this bitwise domain.
 nonempty :: Domain w -> Bool
 nonempty (BVBitInterval _mask lo hi) = bitle lo hi
 
--- | Return a domain containing just the given value
+-- | /O(w)/. Return a domain containing just the given value.
 singleton :: NatRepr w -> Integer -> Domain w
 singleton w x = BVBitInterval mask x' x'
   where
   x' = x .&. mask
   mask = maxUnsigned w
 
--- | Bitwise domain containing every bitvector value
+-- | /O(w)/. Bitwise domain containing every bitvector value.
 any :: NatRepr w -> Domain w
 any w = BVBitInterval mask 0 mask
   where
   mask = maxUnsigned w
 
--- | Returns true iff the domains have some value in common
+-- | /O(w)/. Returns true iff the domains have some value in common.
 domainsOverlap :: Domain w -> Domain w -> Bool
 domainsOverlap a b = nonempty (intersection a b)
 
+-- | /O(w)/. Decide equality of two domains: 'Just True' if both are the same
+-- singleton, 'Just False' if they're disjoint, 'Nothing' otherwise.
 eq :: Domain w -> Domain w -> Maybe Bool
 eq a b
   | Just x <- asSingleton a
@@ -268,17 +270,19 @@ eq a b
   | Prelude.not (domainsOverlap a b) = Just False
   | otherwise = Nothing
 
+-- | /O(w)/. Greatest lower bound of two domains.
 intersection :: Domain w -> Domain w -> Domain w
 intersection (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
   BVBitInterval mask (alo .|. blo) (ahi .&. bhi)
 
+-- | /O(w)/. Least upper bound of two domains.
 union :: Domain w -> Domain w -> Domain w
 union (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
   BVBitInterval mask (alo .&. blo) (ahi .|. bhi)
 
--- | @concat a y@ returns domain where each element in @a@ has been
--- concatenated with an element in @y@.  The most-significant bits
--- are @a@, and the least significant bits are @y@.
+-- | /O(u + v)/. @concat a y@ returns a domain where each element in @a@ has
+-- been concatenated with an element in @y@. The most-significant bits are
+-- @a@, and the least significant bits are @y@.
 concat :: NatRepr u -> Domain u -> NatRepr v -> Domain v -> Domain (u + v)
 concat u (BVBitInterval _ alo ahi) v (BVBitInterval _ blo bhi) =
     BVBitInterval mask (cat alo blo) (cat ahi bhi)
@@ -286,7 +290,7 @@ concat u (BVBitInterval _ alo ahi) v (BVBitInterval _ blo bhi) =
     cat i j = (i `shiftL` widthVal v) + j
     mask = maxUnsigned (addNat u v)
 
--- | @shrink i a@ drops the @i@ least significant bits from @a@.
+-- | /O(w)/. @shrink i a@ drops the @i@ least significant bits from @a@.
 shrink ::
   NatRepr i ->
   Domain (i + n) -> Domain n
@@ -294,7 +298,7 @@ shrink i (BVBitInterval mask lo hi) = BVBitInterval (shr mask) (shr lo) (shr hi)
   where
   shr x = x `shiftR` widthVal i
 
--- | @trunc n d@ selects the @n@ least significant bits from @d@.
+-- | /O(w)/. @trunc n d@ selects the @n@ least significant bits from @d@.
 trunc ::
   (n <= w) =>
   NatRepr n ->
@@ -302,7 +306,7 @@ trunc ::
   Domain n
 trunc n (BVBitInterval _ lo hi) = range n lo hi
 
--- | @select i n a@ selects @n@ bits starting from index @i@ from @a@.
+-- | /O(w)/. @select i n a@ selects @n@ bits starting from index @i@ from @a@.
 select ::
   (1 <= n, i + n <= w) =>
   NatRepr i ->
@@ -310,15 +314,20 @@ select ::
   Domain w -> Domain n
 select i n a = shrink i (trunc (addNat i n) a)
 
+-- | /O(w)/. Zero-extend a domain to a larger width.
 zext :: (1 <= w, w + 1 <= u) => Domain w -> NatRepr u -> Domain u
 zext (BVBitInterval _ lo hi) u = range u lo hi
 
+-- | /O(w)/. Sign-extend a domain to a larger width.
 sext :: (1 <= w, w + 1 <= u) => NatRepr w -> Domain w -> NatRepr u -> Domain u
 sext w (BVBitInterval _ lo hi) u = range u lo' hi'
   where
   lo' = toSigned w lo
   hi' = toSigned w hi
 
+-- | /O(w)/. Test bit @i@ of every value in the domain: 'Just True' if it is
+-- set in every member, 'Just False' if clear in every member, 'Nothing' if
+-- it varies.
 testBit :: Domain w -> Natural -> Maybe Bool
 testBit (BVBitInterval _mask lo hi) i = if lob == hib then Just lob else Nothing
   where
@@ -326,44 +335,53 @@ testBit (BVBitInterval _mask lo hi) i = if lob == hib then Just lob else Nothing
   hib = Bits.testBit hi j
   j = fromIntegral i
 
+-- | /O(w)/. Shift left by a known amount.
 shl :: NatRepr w -> Domain w -> Integer -> Domain w
 shl w (BVBitInterval mask lo hi) y = BVBitInterval mask (shleft lo) (shleft hi)
   where
   y' = fromInteger (min y (intValue w))
   shleft x = (x `shiftL` y') .&. mask
 
+-- | /O(w)/. Rotate left by a known amount.
 rol :: NatRepr w -> Domain w -> Integer -> Domain w
 rol w (BVBitInterval mask lo hi) y =
   BVBitInterval mask (Arith.rotateLeft w lo y) (Arith.rotateLeft w hi y)
 
+-- | /O(w)/. Rotate right by a known amount.
 ror :: NatRepr w -> Domain w -> Integer -> Domain w
 ror w (BVBitInterval mask lo hi) y =
   BVBitInterval mask (Arith.rotateRight w lo y) (Arith.rotateRight w hi y)
 
+-- | /O(w)/. Logical (zero-fill) shift right by a known amount.
 lshr :: NatRepr w -> Domain w -> Integer -> Domain w
 lshr w (BVBitInterval mask lo hi) y = BVBitInterval mask (shr lo) (shr hi)
   where
   y' = fromInteger (min y (intValue w))
   shr x = x `shiftR` y'
 
+-- | /O(w)/. Arithmetic (sign-extending) shift right by a known amount.
 ashr :: (1 <= w) => NatRepr w -> Domain w -> Integer -> Domain w
 ashr w (BVBitInterval mask lo hi) y = BVBitInterval mask (shr lo) (shr hi)
   where
   y' = fromInteger (min y (intValue w))
   shr x = ((toSigned w x) `shiftR` y') .&. mask
 
+-- | /O(w)/. Bitwise complement.
 not :: Domain w -> Domain w
 not (BVBitInterval mask alo ahi) =
   BVBitInterval mask (ahi `Bits.xor` mask) (alo `Bits.xor` mask)
 
+-- | /O(w)/. Bitwise AND of two domains.
 and :: Domain w -> Domain w -> Domain w
 and (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
   BVBitInterval mask (alo .&. blo) (ahi .&. bhi)
 
+-- | /O(w)/. Bitwise OR of two domains.
 or :: Domain w -> Domain w -> Domain w
 or (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) =
   BVBitInterval mask (alo .|. blo) (ahi .|. bhi)
 
+-- | /O(w)/. Bitwise XOR of two domains.
 xor :: Domain w -> Domain w -> Domain w
 xor (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) = BVBitInterval mask clo chi
   where
@@ -378,13 +396,14 @@ xor (BVBitInterval mask alo ahi) (BVBitInterval _ blo bhi) = BVBitInterval mask 
 ---------------------------------------------------------------------------------------
 -- Bounds and comparisons
 
--- | Unsigned bounds for the domain. The low bit-pattern bound is also the
---   unsigned minimum, and the high bit-pattern bound is also the unsigned
---   maximum: setting unknown bits to 0 minimizes, setting them to 1 maximizes.
+-- | /O(1)/. Unsigned bounds for the domain. The low bit-pattern bound is
+-- also the unsigned minimum, and the high bit-pattern bound is also the
+-- unsigned maximum: setting unknown bits to 0 minimizes, setting them to
+-- 1 maximizes.
 ubounds :: Domain w -> (Integer, Integer)
 ubounds = bitbounds
 
--- | Signed bounds for the domain.
+-- | /O(w)/. Signed bounds for the domain.
 sbounds :: (1 <= w) => NatRepr w -> Domain w -> (Integer, Integer)
 sbounds w (BVBitInterval _ lo hi) = (toSigned w lo', toSigned w hi')
   where
@@ -397,8 +416,8 @@ sbounds w (BVBitInterval _ lo hi) = (toSigned w lo', toSigned w hi')
     | (lo .&. signbit) == (hi .&. signbit) = (lo, hi)
     | otherwise = (lo .|. signbit, hi .&. complement signbit)
 
--- | Check if all elements in one domain are unsigned-less-than all
---   elements in the other.
+-- | /O(w)/. Check if all elements in one domain are unsigned-less-than all
+-- elements in the other.
 ult :: Domain w -> Domain w -> Maybe Bool
 ult a b
   | ah < bl  = Just True
@@ -408,8 +427,8 @@ ult a b
   (al, ah) = ubounds a
   (bl, bh) = ubounds b
 
--- | Check if all elements in one domain are signed-less-than all
---   elements in the other.
+-- | /O(w)/. Check if all elements in one domain are signed-less-than all
+-- elements in the other.
 slt :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Maybe Bool
 slt w a b
   | ah < bl  = Just True
@@ -436,29 +455,29 @@ mkSingleton :: Integer -> Integer -> Domain w
 mkSingleton mask x = BVBitInterval mask x' x'
   where x' = x .&. mask
 
--- | Add two bitwise domains.
+-- | /O(w)/. Add two bitwise domains.
 add :: Domain w -> Domain w -> Domain w
 add a@(BVBitInterval mask _ _) b = fromTnum mask (Tnum.add mask (toTnum a) (toTnum b))
 
--- | Two's complement negation: @negate a = not a + 1@.
+-- | /O(w)/. Two's complement negation: @negate a = not a + 1@.
 negate :: Domain w -> Domain w
 negate a = add (not a) (mkSingleton (bvdMask a) 1)
 
--- | Subtract: @sub a b = add a (negate b)@.
+-- | /O(w)/. Subtract: @sub a b = add a (negate b)@.
 sub :: Domain w -> Domain w -> Domain w
 sub a b = add a (negate b)
 
--- | Multiply by a constant.
+-- | /O(w²)/. Multiply by a constant.
 scale :: Integer -> Domain w -> Domain w
 scale k a = mul (mkSingleton (bvdMask a) k) a
 
--- | Multiply two bitwise domains, using the shift-and-add tristate-number
---   algorithm (BPF @tnum_mul@).
+-- | /O(w²)/. Multiply two bitwise domains via the shift-and-add
+-- tristate-number algorithm (BPF @tnum_mul@).
 mul :: Domain w -> Domain w -> Domain w
 mul a@(BVBitInterval mask _ _) b =
   fromTnum mask (Tnum.mul mask (toTnum a) (toTnum b))
 
--- | Unsigned division, assumes the divisor is nonzero.
+-- | /O(w)/. Unsigned division. Assumes the divisor is nonzero.
 --
 -- Compared to the arithmetic-domain @udiv@, this can be more precise when the
 -- divisor is a known power of two: the result is exact, and bit-level structure
@@ -468,7 +487,7 @@ udiv :: Domain w -> Domain w -> Domain w
 udiv a@(BVBitInterval mask _ _) b =
   fromTnum mask (Tnum.udiv mask (toTnum a) (toTnum b))
 
--- | Unsigned remainder, assumes the divisor is nonzero.
+-- | /O(w)/. Unsigned remainder. Assumes the divisor is nonzero.
 --
 -- Like 'udiv', this is more precise when the divisor is a known power of two:
 -- @urem a (singleton w (2^k))@ is exactly the low @k@ bits of @a@.
@@ -476,7 +495,8 @@ urem :: Domain w -> Domain w -> Domain w
 urem a@(BVBitInterval mask _ _) b =
   fromTnum mask (Tnum.urem mask (toTnum a) (toTnum b))
 
--- | Signed division (rounds toward zero), assumes the divisor is nonzero.
+-- | /O(w)/. Signed division (rounds toward zero). Assumes the divisor is
+-- nonzero.
 --
 -- Implemented by splitting each operand on its sign bit into a non-negative
 -- \"zero circle\" and a negative \"one circle\", applying 'udiv' to the
@@ -487,7 +507,8 @@ sdiv w = signedOp w udiv flipDiff
   -- For sdiv, the result is negated iff the input signs differ.
   flipDiff sa sb d = if sa == sb then d else negate d
 
--- | Signed remainder (sign of dividend), assumes the divisor is nonzero.
+-- | /O(w)/. Signed remainder (sign of dividend). Assumes the divisor is
+-- nonzero.
 --
 -- Implemented like 'sdiv', except the result takes the sign of the dividend
 -- rather than the XOR of the input signs.
@@ -541,9 +562,9 @@ splitSign w d@(BVBitInterval mask lo hi) =
   where
   signbit = bit (widthVal w - 1)
 
--- | Like 'udiv', but using the SMT-LIB @FixedSizeBitVectors@ theory's
---   div-by-zero semantics: @bvudiv s 0@ is the all-ones bitvector. See @Note
---   [SMT-LIB division]@ in "What4.Interface" for the design rationale.
+-- | /O(w)/. Like 'udiv', but using the SMT-LIB @FixedSizeBitVectors@ theory's
+-- div-by-zero semantics: @bvudiv s 0@ is the all-ones bitvector. See @Note
+-- [SMT-LIB division]@ in "What4.Interface" for the design rationale.
 udivSmtlib :: (1 <= w) => Domain w -> Domain w -> Domain w
 udivSmtlib a b
   | Just 0 <- asSingleton b = mkSingleton mask mask
@@ -552,19 +573,19 @@ udivSmtlib a b
   where
   mask = bvdMask a
 
--- | Like 'urem', but using the SMT-LIB @FixedSizeBitVectors@ theory's
---   div-by-zero semantics: @bvurem s 0@ is the dividend itself (@s@). See @Note
---   [SMT-LIB division]@ in "What4.Interface" for the design rationale.
+-- | /O(w)/. Like 'urem', but using the SMT-LIB @FixedSizeBitVectors@ theory's
+-- div-by-zero semantics: @bvurem s 0@ is the dividend itself (@s@). See @Note
+-- [SMT-LIB division]@ in "What4.Interface" for the design rationale.
 uremSmtlib :: (1 <= w) => Domain w -> Domain w -> Domain w
 uremSmtlib a b
   | Just 0 <- asSingleton b = a
   | member b 0              = union (urem a b) a
   | otherwise               = urem a b
 
--- | Like 'sdiv', but using the SMT-LIB QF_BV logic's div-by-zero convention:
---   @bvsdiv s 0@ is all-ones when @s@ is non-negative and @1@ when @s@ is
---   negative. See @Note [SMT-LIB division]@ in "What4.Interface" for the design
---   rationale.
+-- | /O(w)/. Like 'sdiv', but using the SMT-LIB QF_BV logic's div-by-zero
+-- convention: @bvsdiv s 0@ is all-ones when @s@ is non-negative and @1@
+-- when @s@ is negative. See @Note [SMT-LIB division]@ in "What4.Interface"
+-- for the design rationale.
 sdivSmtlib :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
 sdivSmtlib w a b
   | Just 0 <- asSingleton b = sdivByZero w a
@@ -582,9 +603,9 @@ sdivByZero w a =
   where
   mask = bvdMask a
 
--- | Like 'srem', but using the SMT-LIB QF_BV logic's div-by-zero convention:
---   @bvsrem s 0@ is the dividend itself (@s@). See @Note [SMT-LIB division]@ in
---   "What4.Interface" for the design rationale.
+-- | /O(w)/. Like 'srem', but using the SMT-LIB QF_BV logic's div-by-zero
+-- convention: @bvsrem s 0@ is the dividend itself (@s@). See @Note
+-- [SMT-LIB division]@ in "What4.Interface" for the design rationale.
 sremSmtlib :: (1 <= w) => NatRepr w -> Domain w -> Domain w -> Domain w
 sremSmtlib w a b
   | Just 0 <- asSingleton b = a

--- a/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
@@ -34,6 +34,7 @@ module What4.Domains.BV.Bitwise.Tnum
   , mk
   , add
   , mul
+  , mulPrecise
   , udiv
   , urem
   ) where
@@ -76,14 +77,104 @@ add bvmask (Tnum av am) (Tnum bv bm) = mk resv resm
   resv  = (sv .&. complement resm) .&. bvmask
 {-# INLINE add #-}
 
--- | /O(w²)/. Tristate-number multiply via shift-and-add (BPF @tnum_mul@),
--- with the result truncated to @bvmask@.
+-- | /O(w)/. Tristate-number multiply via interval and trailing-zero analysis.
+--
+-- The result has:
+--
+--   * at least @ctzA + ctzB@ trailing zero bits, where @ctzA@ is the longest
+--     prefix of low bits that are known-zero in @a@ (i.e.\ both 'tnumValue' and
+--     'tnumMask' have that bit clear), and similarly for @ctzB@; and
+--   * known leading bits derived from the arithmetic interval
+--     @[aMin*bMin, aMax*bMax]@ when that interval fits in @bvmask@. This
+--     captures both leading zeros (when the upper bound is small) and
+--     leading ones (when the lower bound is large) — every bit above the
+--     highest disagreement between the bounds has the same value in every
+--     product.
+--
+-- Special case: when both operands are concrete singletons (mask == 0), the
+-- result is the exact concrete product.
 mul ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->
   Tnum {- ^ b -} ->
   Tnum
-mul bvmask (Tnum av0 am0) (Tnum bv0 bm0) = go av0 am0 bv0 bm0 acc0
+mul bvmask (Tnum av am) (Tnum bv bm)
+  | am == 0, bm == 0 = mk ((av * bv) .&. bvmask) 0
+  | otherwise = mk (highValue .&. bvmask) (highUnknown .&. complement lowZeros .&. bvmask)
+  where
+  -- Trailing-zero analysis: ctz(value | mask) is the lowest bit that is not
+  -- known-zero in each operand.
+  ctzA = countTrailingZerosOr0 (av .|. am)
+  ctzB = countTrailingZerosOr0 (bv .|. bm)
+  lowZeros = (bit (ctzA + ctzB) - 1) .&. bvmask
+  -- Interval analysis: the product lies in [aMin*bMin, aMax*bMax] (computed
+  -- in unbounded Integer). If the upper bound exceeds @bvmask@, the n-bit
+  -- result wraps and the high bits are unconstrained. Otherwise, bits above
+  -- the highest disagreement between the bounds are determined.
+  prodMin = av * bv
+  prodMax = (av .|. am) * (bv .|. bm)
+  overflows = prodMax > bvmask
+  (highValue, highUnknown)
+    | overflows = (0, bvmask)
+    | otherwise = knownBitsOfInterval prodMin prodMax
+{-# INLINE mul #-}
+
+-- | /O(w)/. @knownBitsOfInterval lo hi@ analyzes the arithmetic interval @[lo, hi]@
+-- (where @0 <= lo <= hi@) and returns @(value, mask)@ in tnum form: the bits
+-- on which all values in @[lo, hi]@ agree are known (recorded in @value@),
+-- and the bits below the highest disagreement are unknown (set in @mask@).
+--
+-- For example, if @lo = 0b1100@ and @hi = 0b1110@, every value in
+-- @[lo, hi]@ has bits 3 and 2 set; bits 1 and 0 vary. So @value = 0b1100@
+-- and @mask = 0b0011@.
+--
+-- This subsumes leading-zero analysis (when @lo = 0@) and adds leading-1
+-- (and arbitrary leading-prefix) analysis when @lo > 0@.
+knownBitsOfInterval :: Integer -> Integer -> (Integer, Integer)
+knownBitsOfInterval lo hi = (lo .&. complement varying, varying)
+  where
+  -- Bits at-or-below the highest position where lo and hi disagree.
+  varying = bitsBelow (lo `xor` hi)
+{-# INLINE knownBitsOfInterval #-}
+
+-- | Count trailing zeros of a non-negative 'Integer', returning @0@ for input
+-- @0@. ('Data.Bits.countTrailingZeros' requires 'FiniteBits', which 'Integer'
+-- doesn't have.)
+--
+-- Uses the bit-trick @popCount ((n .&. -n) - 1)@: @n .&. -n@ isolates the
+-- lowest set bit (always a single power-of-two bit, for any nonzero @n@), and
+-- @popCount@ of one less than that is the bit's position.
+countTrailingZerosOr0 :: Integer -> Int
+countTrailingZerosOr0 0 = 0
+countTrailingZerosOr0 n = popCount ((n .&. negate n) - 1)
+{-# INLINE countTrailingZerosOr0 #-}
+
+-- | @log2OfPowerOfTwo n@ returns @k@ such that @n == 2^k@. Asserts that @n@
+-- is a positive power of two, and that the fast computation
+-- @popCount (n - 1)@ agrees with the general 'countTrailingZerosOr0'.
+--
+-- Faster than 'countTrailingZerosOr0' for known powers of two: skips the
+-- @n .&. -n@ isolation step.
+log2OfPowerOfTwo :: Integer -> Int
+log2OfPowerOfTwo n =
+  X.assert (n > 0 && n .&. (n - 1) == 0) $
+  X.assert (k == countTrailingZerosOr0 n) $
+  k
+  where
+  k = popCount (n - 1)
+
+-- | /O(w²)/. Tristate-number multiply via shift-and-add (BPF
+-- @tnum_mul@). The result is truncated to @bvmask@.
+--
+-- Strictly more precise than 'mul' on its own, but quadratic in @w@.
+-- Captures bit-level structure of the product that trailing-zero
+-- analysis can't see.
+mulPrecise ::
+  Integer {- ^ bvmask -} ->
+  Tnum {- ^ a -} ->
+  Tnum {- ^ b -} ->
+  Tnum
+mulPrecise bvmask (Tnum av0 am0) (Tnum bv0 bm0) = go av0 am0 bv0 bm0 acc0
   where
   acc0 = mk ((av0 * bv0) .&. bvmask) 0
   -- Accumulate contributions from each bit of a. A known-1 bit at
@@ -101,11 +192,15 @@ mul bvmask (Tnum av0 am0) (Tnum bv0 bm0) = go av0 am0 bv0 bm0 acc0
         in go (av `shiftR` 1) (am `shiftR` 1)
               (bv `shiftL` 1) (bm `shiftL` 1)
               acc'
+{-# INLINE mulPrecise #-}
 
 -- | /O(w)/. Tristate-number unsigned division, with the result truncated to
--- @bvmask@. Assumes the divisor is nonzero. When the divisor is a known
--- power of two, the result is exact (a logical right shift); otherwise the
--- result is bounded by leading-zero analysis on @aMax `quot` bMin@.
+-- @bvmask@.
+--
+-- Assumes the divisor is nonzero. When the divisor is a known power of two,
+-- the result is exact (a logical right shift); otherwise the result is bounded
+-- by interval analysis: every bit above the highest disagreement between
+-- @aMin \`quot\` bMax@ and @aMax \`quot\` bMin@ is determined.
 udiv ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->
@@ -113,19 +208,27 @@ udiv ::
   Tnum
 udiv bvmask (Tnum av am) (Tnum bv bm)
   | bm == 0, bv > 0, bv .&. (bv - 1) == 0 =
-      -- bv is a power of two, so popCount (bv - 1) is its trailing-zero count.
-      let k = popCount (bv - 1)
+      let k = log2OfPowerOfTwo bv
       in mk ((av `shiftR` k) .&. bvmask) ((am `shiftR` k) .&. bvmask)
-  | otherwise = mk 0 (bitsBelow qMax .&. bvmask)
+  | otherwise = mk (highValue .&. bvmask) (highUnknown .&. bvmask)
   where
+  aMin = av .&. bvmask
   aMax = (av .|. am) .&. bvmask
-  qMax = aMax `quot` max 1 bv
+  bMin = max 1 bv
+  bMax = max 1 ((bv .|. bm) .&. bvmask)
+  -- a / b lies in [aMin/bMax, aMax/bMin]. Both quotients are non-negative
+  -- and within @bvmask@, so no overflow check is needed.
+  qMin = aMin `quot` bMax
+  qMax = aMax `quot` bMin
+  (highValue, highUnknown) = knownBitsOfInterval qMin qMax
 {-# INLINE udiv #-}
 
 -- | /O(w)/. Tristate-number unsigned remainder, with the result truncated to
--- @bvmask@. Assumes the divisor is nonzero. When the divisor is a known
--- power of two, the result is exact (a bitwise mask); otherwise the result
--- is bounded by leading-zero analysis on @min(aMax, bMax-1)@.
+-- @bvmask@.
+--
+-- When the divisor is a known power of two, the result is exact (a bitwise
+-- mask); otherwise the result is bounded by leading-zero analysis on @min(aMax,
+-- bMax-1)@.
 urem ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->

--- a/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
@@ -84,12 +84,12 @@ add bvmask (Tnum av am) (Tnum bv bm) = mk resv resm
 --   * at least @ctzA + ctzB@ trailing zero bits, where @ctzA@ is the longest
 --     prefix of low bits that are known-zero in @a@ (i.e.\ both 'tnumValue' and
 --     'tnumMask' have that bit clear), and similarly for @ctzB@; and
---   * known leading bits derived from the arithmetic interval
---     @[aMin*bMin, aMax*bMax]@ when that interval fits in @bvmask@. This
---     captures both leading zeros (when the upper bound is small) and
---     leading ones (when the lower bound is large) — every bit above the
---     highest disagreement between the bounds has the same value in every
---     product.
+--   * known bits derived from the arithmetic interval @[aMin*bMin, aMax*bMax]@
+--     reduced modulo @bvmask+1@ (see 'wrappedKnownBitsOfInterval'). When the
+--     interval fits within one modulus, bits above the highest disagreement
+--     between the wrapped bounds are determined; when it crosses a modulus
+--     boundary once, we recover bits the two halves agree on; if it spans a
+--     full modulus, no high bits are determined.
 --
 -- Special case: when both operands are concrete singletons (mask == 0), the
 -- result is the exact concrete product.
@@ -108,15 +108,12 @@ mul bvmask (Tnum av am) (Tnum bv bm)
   ctzB = countTrailingZerosOr0 (bv .|. bm)
   lowZeros = (bit (ctzA + ctzB) - 1) .&. bvmask
   -- Interval analysis: the product lies in [aMin*bMin, aMax*bMax] (computed
-  -- in unbounded Integer). If the upper bound exceeds @bvmask@, the n-bit
-  -- result wraps and the high bits are unconstrained. Otherwise, bits above
-  -- the highest disagreement between the bounds are determined.
+  -- in unbounded Integer). 'wrappedKnownBitsOfInterval' reduces this modulo
+  -- @bvmask+1@ and extracts known bits whether or not the interval crosses a
+  -- modulus boundary.
   prodMin = av * bv
   prodMax = (av .|. am) * (bv .|. bm)
-  overflows = prodMax > bvmask
-  (highValue, highUnknown)
-    | overflows = (0, bvmask)
-    | otherwise = knownBitsOfInterval prodMin prodMax
+  (highValue, highUnknown) = wrappedKnownBitsOfInterval bvmask prodMin prodMax
 {-# INLINE mul #-}
 
 -- | /O(w)/. @knownBitsOfInterval lo hi@ analyzes the arithmetic interval @[lo, hi]@
@@ -136,6 +133,38 @@ knownBitsOfInterval lo hi = (lo .&. complement varying, varying)
   -- Bits at-or-below the highest position where lo and hi disagree.
   varying = bitsBelow (lo `xor` hi)
 {-# INLINE knownBitsOfInterval #-}
+
+-- | /O(w)/. Like 'knownBitsOfInterval', but for the image of @[lo, hi]@ under
+-- reduction modulo @bvmask + 1@ (where @0 <= lo <= hi@ and @bvmask@ is of the
+-- form @2^w - 1@).
+--
+-- Three cases:
+--
+--   * @hi - lo + 1 >= bvmask + 1@: the image covers every residue, so no bits
+--     are determined (returns @(0, bvmask)@).
+--   * @lo \`quot\` (bvmask+1) == hi \`quot\` (bvmask+1)@: the interval fits
+--     entirely within one modulus, so the wrapped bounds @lo \`rem\` (bvmask+1)@
+--     and @hi \`rem\` (bvmask+1)@ are still ordered and we use
+--     'knownBitsOfInterval' on them.
+--   * Otherwise the interval crosses exactly one modulus boundary: the image is
+--     @[wLo, bvmask] \\cup [0, wHi]@ where @wLo = lo \`rem\` (bvmask+1)@ and
+--     @wHi = hi \`rem\` (bvmask+1)@. We analyze each half with
+--     'knownBitsOfInterval' and join: a bit is known only when both halves
+--     agree on it.
+wrappedKnownBitsOfInterval :: Integer -> Integer -> Integer -> (Integer, Integer)
+wrappedKnownBitsOfInterval bvmask lo hi
+  | hi - lo >= modulus = (0, bvmask)
+  | wLo <= wHi = knownBitsOfInterval wLo wHi
+  | otherwise =
+      let (vA, mA) = knownBitsOfInterval wLo bvmask
+          (vB, mB) = knownBitsOfInterval 0 wHi
+          mAB = mA .|. mB .|. (vA `xor` vB)
+      in (vA .&. complement mAB, mAB)
+  where
+  modulus = bvmask + 1
+  wLo = lo `rem` modulus
+  wHi = hi `rem` modulus
+{-# INLINE wrappedKnownBitsOfInterval #-}
 
 -- | Count trailing zeros of a non-negative 'Integer', returning @0@ for input
 -- @0@. ('Data.Bits.countTrailingZeros' requires 'FiniteBits', which 'Integer'

--- a/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
+++ b/what4-domains/src/What4/Domains/BV/Bitwise/Tnum.hs
@@ -54,12 +54,13 @@ data Tnum = Tnum
     -- ^ The unknown bits.
   }
 
--- | Smart constructor that asserts the disjointness invariant.
+-- | /O(w)/. Smart constructor that asserts the disjointness invariant
+-- (@v .&. m == 0@).
 mk :: Integer -> Integer -> Tnum
 mk v m = X.assert (v .&. m == 0) (Tnum v m)
 {-# INLINE mk #-}
 
--- | Tristate-number add, with the result truncated to @bvmask@.
+-- | /O(w)/. Tristate-number add, with the result truncated to @bvmask@.
 add ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->
@@ -75,7 +76,8 @@ add bvmask (Tnum av am) (Tnum bv bm) = mk resv resm
   resv  = (sv .&. complement resm) .&. bvmask
 {-# INLINE add #-}
 
--- | Tristate-number multiply, with the result truncated to @bvmask@.
+-- | /O(w²)/. Tristate-number multiply via shift-and-add (BPF @tnum_mul@),
+-- with the result truncated to @bvmask@.
 mul ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->
@@ -100,10 +102,10 @@ mul bvmask (Tnum av0 am0) (Tnum bv0 bm0) = go av0 am0 bv0 bm0 acc0
               (bv `shiftL` 1) (bm `shiftL` 1)
               acc'
 
--- | Tristate-number unsigned division, with the result truncated to @bvmask@.
--- Assumes the divisor is nonzero. When the divisor is a known power of two, the
--- result is exact (a logical right shift); otherwise the result is bounded by
--- leading-zero analysis on @aMax `quot` bMin@.
+-- | /O(w)/. Tristate-number unsigned division, with the result truncated to
+-- @bvmask@. Assumes the divisor is nonzero. When the divisor is a known
+-- power of two, the result is exact (a logical right shift); otherwise the
+-- result is bounded by leading-zero analysis on @aMax `quot` bMin@.
 udiv ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->
@@ -120,10 +122,10 @@ udiv bvmask (Tnum av am) (Tnum bv bm)
   qMax = aMax `quot` max 1 bv
 {-# INLINE udiv #-}
 
--- | Tristate-number unsigned remainder, with the result truncated to @bvmask@.
--- When the divisor is a known power of two, the result is exact (a bitwise
--- mask); otherwise the result is bounded by leading-zero analysis on @min(aMax,
--- bMax-1)@.
+-- | /O(w)/. Tristate-number unsigned remainder, with the result truncated to
+-- @bvmask@. Assumes the divisor is nonzero. When the divisor is a known
+-- power of two, the result is exact (a bitwise mask); otherwise the result
+-- is bounded by leading-zero analysis on @min(aMax, bMax-1)@.
 urem ::
   Integer {- ^ bvmask -} ->
   Tnum {- ^ a -} ->

--- a/what4-domains/test/BVDomTests.hs
+++ b/what4-domains/test/BVDomTests.hs
@@ -362,6 +362,9 @@ bitwiseDomainTests =
   , genTest "correct_mul" $
       do SW n <- genWidth
          B.correct_mul n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_mulPrecise" $
+      do SW n <- genWidth
+         B.correct_mulPrecise n <$> B.genPair n <*> B.genPair n
   , genTest "correct_udiv" $
       do SW n <- genWidth
          B.correct_udiv n <$> B.genPair n <*> B.genPair n
@@ -386,6 +389,12 @@ bitwiseDomainTests =
   , genTest "correct_sremSmtlib" $
       do SW n <- genWidth
          B.correct_sremSmtlib n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_udivPrecise" $
+      do SW n <- genWidth
+         B.correct_udivPrecise n <$> B.genPair n <*> B.genPair n
+  , genTest "correct_uremPrecise" $
+      do SW n <- genWidth
+         B.correct_uremPrecise n <$> B.genPair n <*> B.genPair n
   ]
 
 overallDomainTests :: TestTree


### PR DESCRIPTION
 Tnum multiplication is O(w^2), add a fast bounds-based O(w) verison. Conversely, tnum division as-implemented was a fast bounds-based O(w) version, add the precise "schoolbook" O(w^2) algorithm, just like for multiplication.