### PR TITLE
`fpToRational`: Ensure that the denominator is non-zero

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -29,6 +29,8 @@
 * Add `fpNegZero`, `fpPosZero`, `fpRem`, `fpNe`, `fpNeIEEE`, `fpLeIEEE`,
   `fpGeIEEE`, `fpIsPos`, `fpCast`, `fpFromBV`, `fpFromSBV`, `fpToBV`, and
   `fpToSBV` to `What4.SFloat`.
+* Fix a bug in which `fpToRational` could return an invalid rational number
+  with a zero denominator.
 
 # 1.7.3 -- 2026-01-26
 

--- a/what4/src/What4/SFloat.hs
+++ b/what4/src/What4/SFloat.hs
@@ -514,11 +514,15 @@ fpToRational sym fp =
   do r    <- fpToReal sym fp
      x    <- freshConstant sym emptySymbol BaseIntegerRepr
      y    <- freshConstant sym emptySymbol BaseIntegerRepr
+     one  <- intLit sym 1
+     -- Avoid rationals with zero denominators, which are invalid.
+     yPos <- intLt sym one y
      num  <- integerToReal sym x
      den  <- integerToReal sym y
      res  <- realDiv sym num den
      same <- realEq sym r res
-     pure (same, x, y)
+     rel  <- andPred sym yPos same
+     pure (rel, x, y)
 
 -- | Change the precision of a floating point number (see 'floatCast').
 fpCast ::


### PR DESCRIPTION
Towards an eventual fix for https://github.com/GaloisInc/cryptol/issues/2021 on the Cryptol side (which is where a test case will eventually go).