### PR TITLE
Add `strictSMTParseOpt` to `yicesOptions`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -31,6 +31,8 @@
   `fpToSBV` to `What4.SFloat`.
 * Fix a bug in which `fpToRational` could return an invalid rational number
   with a zero denominator.
+* Fix a bug in which calling `solver_adapter_write_smt2 yicesAdapter` would
+  always fail.
 
 # 1.7.3 -- 2026-01-26
 

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -1001,6 +1001,10 @@ yicesOptions =
       t = mkTmout yicesGoalTimeout
   in [ p, m, i, t
      , copyOpt (const $ configOptionText yicesStrictParsing) strictSMTParseOpt
+       -- Make sure to also include the original 'strictSMTParseOpt'. Since
+       -- Yices doesn't inherit the 'smtlib2Options' like other solvers do, we
+       -- have to include this option explicitly.
+     , strictSMTParseOpt
      , deprecatedOpt [p] $ mkPath yicesPathOLD
      , deprecatedOpt [m] $ mkMCSat yicesEnableMCSatOLD
      , deprecatedOpt [i] $ mkIntr yicesEnableInteractiveOLD


### PR DESCRIPTION
While `yicesOptions` included a Yices-specific strict parsing option, it did not include the original `solver.strict_parsing` option. This is bad because whenever What4 attempts to write an SMTLIB file, it defaults to looking up `solver.strict_parsing`'s setting if the Yices-specific option hasn't been set, and if `solver.strict_parsing` isn't included in the list of options, then this lookup will fail. (Other solvers did not suffer from this issue because they inherit a list of common SMTLIB-related options, but Yices is special and therefore did not inherit this list.)

Towards an eventual fix for https://github.com/GaloisInc/saw-script/issues/3304. Testing this fix using the What4 API proves somewhat tricky, so I'll add a test case on the SAW side instead.