### PR TITLE
`what4-domains`: Ensure all predicates have corresponding properties

### DIFF
--- a/what4-domains/doc/arithdomain.cry
+++ b/what4-domains/doc/arithdomain.cry
@@ -639,6 +639,8 @@ property a6 = correct_sdiv`{6}
 property a7 = correct_srem`{6}
 property a8 = correct_not`{16}
 property a9 = correct_sdivRange`{6}
+property a10 = correct_mulRange`{4}
+property a11 = correct_shrinkRange`{8}
 
 property s1 = correct_shl`{8}
 property s2 = correct_lshr`{8}
@@ -664,6 +666,8 @@ property lat11 = meet_bottom`{8}
 property lat12 = leq_reflexive`{8}
 property lat13 = join_upper_bound`{8}
 property lat14 = leq_transitive`{8}
+property lat15 = join_proper`{8}
+property lat16 = meet_proper`{8}
 
 ////////////////////////////////////////////////////////////
 // Operations preserve singletons
@@ -772,6 +776,7 @@ property i17 = singleton_slt`{16}
 property i18 = singleton_sle`{16}
 property i19 = singleton_ult`{16}
 property i20 = singleton_ule`{16}
+property i21 = singleton_mulRange`{4}
 
 ////////////////////////////////////////////////////////////
 // Associativity/commutativity properties

--- a/what4-domains/doc/bitsdomain.cry
+++ b/what4-domains/doc/bitsdomain.cry
@@ -947,6 +947,9 @@ property lat18 = join_associative`{8}
 property lat19 = meet_associative`{8}
 property lat20 = join_absorb`{8}
 property lat21 = meet_absorb`{8}
+property lat22 = precise_meet`{8}
+property lat23 = join_proper`{8}
+property lat24 = meet_proper`{8}
 
 
 ////////////////////////////////////////////////////////////

--- a/what4-domains/src/What4/Domains/BV/Arith.hs
+++ b/what4-domains/src/What4/Domains/BV/Arith.hs
@@ -317,7 +317,7 @@ ult a b
     (b_min, b_max) = ubounds b
 
 -- | Check if @(bvult (bvadd a c) (bvadd b c))@ is equivalent to @(bvult a b)@.
--- 
+--
 -- This is true if and only if for all natural values @i_a@, @i_b@, @i_c@ in
 -- @a@, @b@, @c@, either both @i_a + i_c@ and @i_b + i_c@ are less than @2^w@,
 -- or both are not. We prove this by contradiction. If @i_a = i_b@, then the

--- a/what4-domains/src/What4/Domains/BV/Arith.hs
+++ b/what4-domains/src/What4/Domains/BV/Arith.hs
@@ -119,6 +119,7 @@ module What4.Domains.BV.Arith
   , correct_udiv
   , correct_urem
   , correct_sdivRange
+  , correct_shrinkRange
   , correct_sdiv
   , correct_srem
   , correct_udivSmtlib
@@ -745,6 +746,11 @@ sdivRange (al, ah) (ReciprocalRange bl bh) = (ql, qh)
     ql = min ql1 ql2
     qh = max qh1 qh2
 
+shrinkRange :: (Integer, Integer) -> Integer -> (Integer, Integer)
+shrinkRange (lo, hi) k =
+  if k > 0 then (lo `quot` k, hi `quot` k) else
+  if k < 0 then (hi `quot` k, lo `quot` k) else (lo, hi)
+
 -- | @scaleDownRange (lo, hi) k@ returns an interval @(ql, qh)@ such that for any
 -- @x@ in @[lo..hi]@, @x `quot` k@ is in @[ql..qh]@.
 scaleDownRange :: (Integer, Integer) -> Integer -> (Integer, Integer)
@@ -1099,6 +1105,12 @@ correct_sdivRange a b x y =
    mem a x ==> mem b y ==> y /= 0 ==> mem (sdivRange a b') (x `quot` y)
  where
  b' = ReciprocalRange (snd b) (fst b)
+ mem (lo,hi) v = lo <= v && v <= hi
+
+correct_shrinkRange :: (Integer, Integer) -> Integer -> Integer -> Property
+correct_shrinkRange a x y =
+   mem a x ==> y /= 0 ==> mem (shrinkRange a y) (x `quot` y)
+ where
  mem (lo,hi) v = lo <= v && v <= hi
 
 correct_sdiv :: (1 <= n) => NatRepr n -> (Domain n, Integer) -> (Domain n, Integer) -> Property

--- a/what4-domains/test/BVDomTests.hs
+++ b/what4-domains/test/BVDomTests.hs
@@ -127,6 +127,12 @@ arithDomainTests = testGroup "Arith Domain"
          x <- genBV n
          y <- genBV n
          pure $ A.correct_mulRange a b x y
+  , genTest "correct_shrinkRange" $
+      do SW n <- genWidth
+         a <- (,) <$> genBV n <*> genBV n
+         x <- genBV n
+         y <- genBV n
+         pure $ A.correct_shrinkRange a x y
   , genTest "correct_union" $
       do SW n <- genWidth
          A.correct_union n <$> A.genDomain n <*> A.genDomain n <*> genBV n


### PR DESCRIPTION
In `{arith,bits}domain.cry`, ensure that all Cryptol predicates have corresponding properties. This revealed that `arithdomain`'s `shrinkRange` and `correct_shrinkRange` lacked Haskell counterparts, so define and test those as well.

Fixes https://github.com/GaloisInc/what4/issues/413.