### PR TITLE
fix(ci): Unpin `nix_path`, `install_url` in `cachix/install-nix-action`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
-          install_url: https://releases.nixos.org/nix/nix-2.31.0/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
@@ -70,8 +68,6 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-21.11
-          install_url: https://releases.nixos.org/nix/nix-2.11.0/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Attempt to work around a strange CI failure:

    error: unsupported tarball input attribute 'lastModified'

       … while updating the lock file of flake
        'github:GaloisInc/flakes/1b46c6f3de751a4fab8f5b3e491289979969ebbe'
        ABC version

See discussion on #424.