### PR TITLE
`baseIsConcrete`: Fix `BaseFloatRepr` case

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -33,6 +33,8 @@
   with a zero denominator.
 * Fix a bug in which calling `solver_adapter_write_smt2 yicesAdapter` would
   always fail.
+* Fix a bug in which `baseIsConcrete` would incorrectly claim that concrete
+  `SymFloat`s are not concrete.
 
 # 1.7.3 -- 2026-01-26
 

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -3136,7 +3136,7 @@ baseIsConcrete x =
     BaseIntegerRepr -> isJust $ asInteger x
     BaseBVRepr _    -> isJust $ asBV x
     BaseRealRepr    -> isJust $ asRational x
-    BaseFloatRepr _ -> False
+    BaseFloatRepr _ -> isJust $ asFloat x
     BaseStringRepr{} -> isJust $ asString x
     BaseComplexRepr -> isJust $ asComplex x
     BaseStructRepr _ -> case asStruct x of


### PR DESCRIPTION
The previous implementation was blatantly wrong.

Fixes #432.