### PR TITLE
`What4.Expr.Builder`: Use `real{Trunc,RoundEven}` to define `iFloatRound`

### DIFF
--- a/what4/CHANGES.md
+++ b/what4/CHANGES.md
@@ -35,6 +35,9 @@
   always fail.
 * Fix a bug in which `baseIsConcrete` would incorrectly claim that concrete
   `SymFloat`s are not concrete.
+* Calling `iFloatRound` with the `RNE` rounding mode when using the `FloatReal`
+  interpretation now dispatches to `realRoundEven` instead of throwing an
+  error.
 
 # 1.7.3 -- 2026-01-26
 

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -4131,9 +4131,7 @@ instance IsInterpretedFloatExprBuilder (ExprBuilder t st (Flags FloatReal)) wher
       RNA -> realRound sym x
       RTP -> realCeil sym x
       RTN -> realFloor sym x
-      RTZ -> do
-        is_pos <- realLt sym (realZero sym) x
-        iteM intIte sym is_pos (realFloor sym x) (realCeil sym x)
+      RTZ -> realTrunc sym x
       RNE -> fail "Unsupported rond to nearest even for real values."
   iFloatFromBinary sym _ x
     | Just (FnApp fn args) <- asNonceApp x

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -4132,7 +4132,7 @@ instance IsInterpretedFloatExprBuilder (ExprBuilder t st (Flags FloatReal)) wher
       RTP -> realCeil sym x
       RTN -> realFloor sym x
       RTZ -> realTrunc sym x
-      RNE -> fail "Unsupported rond to nearest even for real values."
+      RNE -> realRoundEven sym x
   iFloatFromBinary sym _ x
     | Just (FnApp fn args) <- asNonceApp x
     , "uninterpreted_real_to_float_binary" == solverSymbolAsText (symFnName fn)

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -358,6 +358,38 @@ testRealFloatBinarySimplification =
       e1 <- iFloatFromBinary sym SingleFloatRepr e0
       e1 @?= x
 
+testRealFloatRounding :: TestTree
+testRealFloatRounding =
+  testCase "real float rounding" $
+    withSym FloatRealRepr $ \sym -> do
+      x <- iFloatLitSingle sym 1.5
+      xUp <- iFloatLitSingle sym 2.0
+      xDown <- iFloatLitSingle sym 1.0
+      xRNA <- iFloatRound sym RNA x
+      xRTP <- iFloatRound sym RTP x
+      xRTN <- iFloatRound sym RTN x
+      xRTZ <- iFloatRound sym RTZ x
+      xRNE <- iFloatRound sym RNE x
+      xRNA @?= xUp
+      xRTP @?= xUp
+      xRTN @?= xDown
+      xRTZ @?= xDown
+      xRNE @?= xUp
+
+      y <- iFloatLitSingle sym (-1.5)
+      yUp <- iFloatLitSingle sym (-1.0)
+      yDown <- iFloatLitSingle sym (-2.0)
+      yRNA <- iFloatRound sym RNA y
+      yRTP <- iFloatRound sym RTP y
+      yRTN <- iFloatRound sym RTN y
+      yRTZ <- iFloatRound sym RTZ y
+      yRNE <- iFloatRound sym RNE y
+      yRNA @?= yDown
+      yRTP @?= yUp
+      yRTN @?= yDown
+      yRTZ @?= yUp
+      yRNE @?= yDown
+
 testFloatCastSimplification :: TestTree
 testFloatCastSimplification = testCase "float cast simplification" $
   withSym FloatIEEERepr $ \sym -> do
@@ -1492,6 +1524,7 @@ main = do
     , testInterpretedFloatIEEE
     , testFloatBinarySimplification
     , testRealFloatBinarySimplification
+    , testRealFloatRounding
     , testFloatCastSimplification
     , testFloatCastNoSimplification
     , testBVSelectShl


### PR DESCRIPTION
Fixes https://github.com/GaloisInc/what4/issues/434.